### PR TITLE
Clarify room flags label

### DIFF
--- a/src/scripts/DD/UpdateFunctions/update_travel.lua
+++ b/src/scripts/DD/UpdateFunctions/update_travel.lua
@@ -135,7 +135,7 @@ function update_travel()
             )
 
             if (gmcp.Room.Info.flags ~= "") and not (string.find(gmcp.Room.Info.flags, "^no_mob$")) then
-                    EnemyInfoConsole:cecho("<white>Room features: ")
+                    EnemyInfoConsole:cecho("<white>Room flags: ")
 
                     local rflags = split_str(gmcp.Room.Info.flags)
                     local last_flag_index = #rflags


### PR DESCRIPTION
Renames the travel-panel label from Room features to Room flags so it matches the values displayed there. Validated with muddle.