### PR TITLE
Persist mapper data outside package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 .output
 custom/
+/.dd-gui-ftp.netrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Build deployment
+
+Whenever Codex produces a new DD_GUI package build, run `./scripts/build-and-upload.ps1` instead of invoking `muddle` directly. The helper rebuilds the package and uploads `build/DD_GUI.mpackage` and `build/DD_GUI.xml` to the production GUI directory.
+
+The FTP credential is stored only in the ignored `.dd-gui-ftp.netrc` file. Never commit, print, or otherwise expose that file or its contents.

--- a/scripts/build-and-upload.ps1
+++ b/scripts/build-and-upload.ps1
@@ -1,0 +1,43 @@
+[CmdletBinding()]
+param(
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = "Stop"
+
+$projectRoot = Split-Path -Parent $PSScriptRoot
+$credentialFile = Join-Path $projectRoot ".dd-gui-ftp.netrc"
+$ftpHost = "nosferatu.smihilist.com"
+$remoteDirectory = "var/www/smihilist.com/dd4/web/main/gui"
+$packageFiles = @("DD_GUI.mpackage", "DD_GUI.xml")
+
+if (-not (Test-Path -LiteralPath $credentialFile -PathType Leaf)) {
+    throw "Missing local FTP credentials at $credentialFile."
+}
+
+if (-not $SkipBuild) {
+    Push-Location $projectRoot
+    try {
+        & muddle
+        if ($LASTEXITCODE -ne 0) {
+            throw "muddle failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+foreach ($packageFile in $packageFiles) {
+    $localFile = Join-Path $projectRoot "build/$packageFile"
+    if (-not (Test-Path -LiteralPath $localFile -PathType Leaf)) {
+        throw "Expected build artifact not found: $localFile"
+    }
+
+    # A double slash selects the server's absolute path rather than the FTP-root-relative path.
+    $remoteUrl = "ftp://$ftpHost//$remoteDirectory/$packageFile"
+    & curl.exe --fail --silent --show-error --netrc --netrc-file $credentialFile --ftp-create-dirs --upload-file $localFile $remoteUrl
+    if ($LASTEXITCODE -ne 0) {
+        throw "FTP upload failed for $packageFile with exit code $LASTEXITCODE."
+    }
+}

--- a/src/scripts/DD/GMCPMapper.lua
+++ b/src/scripts/DD/GMCPMapper.lua
@@ -148,12 +148,17 @@ function load_dd_mapper ()
             z = z + z1
             setRoomCoordinates(ID,x,y,z)
             updateMap()
+            if save_dd_mapper then
+                save_dd_mapper()
+            end
         end
 
         local function handle_move()
             local info = map.room_info
+            local map_changed = false
             if not getRoomName(info.vnum) then
                 make_room()
+                map_changed = true
             else
                 local stubs = getExitStubs1(info.vnum)
                         if stubs then
@@ -165,11 +170,13 @@ function load_dd_mapper ()
                       -- need to see how special exits are represented to handle those properly here
                       if id and getRoomName(id) then
                           setExit(info.vnum, id, dir)
+                          map_changed = true
                       end
                   end
                         end
             end
             centerview(map.room_info.vnum)
+            return map_changed
         end
 
         local function config()
@@ -319,7 +326,9 @@ function load_dd_mapper ()
                 for k,v in pairs(map.room_info.exits) do
                     map.room_info.exits[k] = tonumber(v)
                 end
-                handle_move()
+                if handle_move() and save_dd_mapper then
+                    save_dd_mapper()
+                end
             elseif event == "shiftRoom" then
                 local dir = exitmap[arg[1]] or arg[1]
                 if not table.contains(exits, dir) then

--- a/src/scripts/DD/InitialiseMapper.lua
+++ b/src/scripts/DD/InitialiseMapper.lua
@@ -1,4 +1,53 @@
+local function file_exists(path)
+        local file = io.open(path, "rb")
+        if not file then
+                return false
+        end
+
+        file:close()
+        return true
+end
+
+function dd_mapper_save_path()
+        -- Keep player map data outside the package resource folder so reinstalls preserve it.
+        return string.gsub(getMudletHomeDir() .. "/dragons_domain_mapper.dat", "\\", "/")
+end
+
+local function legacy_mapper_save_path()
+        return string.gsub(getMudletHomeDir() .. "/DD_GUI/maps/dragons_domain_mapper.dat", "\\", "/")
+end
+
+function save_dd_mapper()
+        local saved, error_message = saveMap(dd_mapper_save_path())
+        if not saved then
+                cecho(string.format("<red>Unable to save Dragons Domain map: %s<reset>\n", error_message or "unknown error"))
+        end
+
+        return saved
+end
+
 function initialise_mapper()
         expandAlias("ignores")
-        loadMap(getMudletHomeDir() .. "/DD_GUI/maps/mud_school.dat")
+
+        local bundled_map = string.gsub(getMudletHomeDir() .. "/DD_GUI/maps/mud_school.dat", "\\", "/")
+        local persistent_map = dd_mapper_save_path()
+        local legacy_map = legacy_mapper_save_path()
+        local map_to_load = bundled_map
+        local migrate_legacy_map = false
+
+        if file_exists(persistent_map) then
+                map_to_load = persistent_map
+        elseif file_exists(legacy_map) then
+                map_to_load = legacy_map
+                migrate_legacy_map = true
+        end
+
+        local loaded, error_message = loadMap(map_to_load)
+
+        if not loaded and map_to_load ~= bundled_map then
+                cecho(string.format("<yellow>Unable to load saved Dragons Domain map: %s. Loading the bundled map instead.<reset>\n", error_message or "unknown error"))
+                loadMap(bundled_map)
+        elseif migrate_legacy_map then
+                save_dd_mapper()
+        end
 end


### PR DESCRIPTION
Summary

Persist Dragons Domain mapper data outside the package resource folder so reinstalling the GUI does not overwrite player map progress.

Changes

- Load a persistent mapper save from the Mudlet home directory when present.
- Migrate the legacy packaged mapper save location to the new persistent path.
- Save mapper changes after new rooms, linked exits, and shifted room coordinates.
- Add the build/upload helper and ignore the local FTP credential file.

Validation

- Ran git diff --cached --check.
- Parsed scripts/build-and-upload.ps1 as a PowerShell scriptblock.

No package build was produced for this commit.