### PR TITLE
Fix inventory tab rendering

### DIFF
--- a/src/scripts/DD/UpdateFunctions/update_inventory.lua
+++ b/src/scripts/DD/UpdateFunctions/update_inventory.lua
@@ -1,46 +1,68 @@
 debug.setmetatable(nil, { __index=function () end })
 
-function update_inventory()
-  local quantity_ordered = {}
+local function inventory_entries()
+  if not gmcp or not gmcp.Char or type(gmcp.Char.Items) ~= "table" then
+    return {}
+  end
 
-  for key, value in orderedPairs(gmcp.Char.Items[1]) do
-    if key ~= nil then
-        quantity_ordered[key] = value.quan
+  local items = gmcp.Char.Items
+  local first = items[1]
+  if type(first) == "table" and first.quan == nil and first.short_desc == nil then
+    return first
+  end
+
+  return items
+end
+
+local function compact_inventory_name(value)
+  local name = ansi2string(tostring(value or ""))
+  name = string.gsub(name, "%b()", "")
+  name = string.gsub(name, "^%s+", "")
+  name = string.gsub(name, "%[.+%]", "")
+  name = string.gsub(name, "^%s+", "")
+  return name
+end
+
+local function fit_inventory_name(name, width)
+  if #name > width then
+    name = replace_char(width, name, ".")
+    name = replace_char(width - 1, name, ".")
+    return string.format("%." .. width .. "s", name)
+  end
+
+  return string.format("%-" .. width .. "s", name)
+end
+
+function update_inventory()
+  if not InventoryConsole then
+    return
+  end
+
+  local entries = {}
+  for _, item in pairs(inventory_entries()) do
+    if type(item) == "table" and item.quan ~= nil then
+      table.insert(entries, item)
     end
   end
 
-  --display(dump(quantity_ordered))
-  local sorted_quan_keys = getKeysSortedByValue(quantity_ordered, function(a, b) return tonumber(a) > tonumber(b) end)
-  --display(dump(sorted_quan_keys))
+  table.sort(entries, function(a, b)
+    return (tonumber(a.quan) or 0) > (tonumber(b.quan) or 0)
+  end)
 
   InventoryConsole:clear()
-  InventoryConsole:resetAutoWrap ()
+  InventoryConsole:resetAutoWrap()
 
-  if next(sorted_quan_keys) == nil then
+  if #entries == 0 then
     InventoryConsole:cecho("Nothing.<reset>")
+    return
   end
 
-  for i, count in ipairs(sorted_quan_keys) do
-    --local has_mod = 0
-    if (gmcp.Char.Items[1][count].quan) ~= nil then
-      local desc_string = gmcp.Char.Items[1][count].short_desc
-      --display(desc_string)
-      local strip_string = ansi2string(desc_string)
-      desc_string = ansi2string(desc_string)
-      --display(desc_string)
-      desc_string = string.gsub(desc_string, "%b()", "")
-      desc_string = string.gsub(desc_string, "^%s+", "")
-      desc_string = string.gsub(desc_string, "%[.+%]", "")
-      desc_string = string.gsub(desc_string, "^%s+", "")
-      --display(desc_string)
-      InventoryConsole:cecho("<white>" ..string.format("(%3d)", gmcp.Char.Items[1][count].quan).. "<reset> ")
-      if (#strip_string) > 34 then
-        local tmp_string = replace_char(28, desc_string, '.')
-        local tmp_string = replace_char(27, tmp_string, '.')
-        InventoryConsole:decho(string.format("%.28s", tmp_string) .."\n")
-      else
-        InventoryConsole:decho(string.format("%-28s", desc_string).."\n")
-      end
-    end
+  for _, item in ipairs(entries) do
+    local quantity = tonumber(item.quan) or 0
+    local desc_string = compact_inventory_name(item.short_desc or item.name)
+
+    InventoryConsole:cecho(
+      "<white>" .. string.format("(%3d)", quantity) .. "<reset> ")
+    InventoryConsole:decho(fit_inventory_name(desc_string, 28) .. "\n")
   end
 end


### PR DESCRIPTION
Fix the inventory renderer to handle both wrapped and direct gmcp.Char.Items arrays, normalize DD4 quantity strings, and preserve compact sorted output. Validation: Lua parse, JSON parse, git diff check, package build/upload, and package XML inspection passed.