### PR TITLE
Fix inventory tab refresh

### DIFF
--- a/src/scripts/DD/DD_GUI.InventoryBox.lua
+++ b/src/scripts/DD/DD_GUI.InventoryBox.lua
@@ -109,6 +109,12 @@ function DD_GUI.Inventory:switch_tab(key)
         end
 
         self:style_tabs()
+
+        if key == "inventory" and type(update_inventory) == "function" then
+                update_inventory()
+        elseif key == "equipped" and type(update_equipped) == "function" then
+                update_equipped()
+        end
 end
 
 function dd_inventory_tab_click(key, event)

--- a/src/scripts/DD/UpdateFunctions/update_inventory.lua
+++ b/src/scripts/DD/UpdateFunctions/update_inventory.lua
@@ -7,7 +7,10 @@ local function inventory_entries()
 
   local items = gmcp.Char.Items
   local first = items[1]
-  if type(first) == "table" and first.quan == nil and first.short_desc == nil then
+  if type(first) == "table"
+      and first.quan == nil
+      and first.short_desc == nil
+      and first.name == nil then
     return first
   end
 
@@ -18,8 +21,9 @@ local function compact_inventory_name(value)
   local name = ansi2string(tostring(value or ""))
   name = string.gsub(name, "%b()", "")
   name = string.gsub(name, "^%s+", "")
-  name = string.gsub(name, "%[.+%]", "")
+  name = string.gsub(name, "%b[]", "")
   name = string.gsub(name, "^%s+", "")
+  name = string.gsub(name, "%s+$", "")
   return name
 end
 
@@ -39,7 +43,7 @@ function update_inventory()
   end
 
   local entries = {}
-  for _, item in pairs(inventory_entries()) do
+  for _, item in ipairs(inventory_entries()) do
     if type(item) == "table" and item.quan ~= nil then
       table.insert(entries, item)
     end


### PR DESCRIPTION
Parse the wrapped Char.Items GMCP payload, refresh inventory and equipped panes when tabs are selected, and strip ANSI visual markers cleanly. Lua syntax validation and git diff --check passed; DD_GUI package rebuilt and uploaded.