### PR TITLE
Add equipment paper doll and fix inventory rendering

### DIFF
--- a/src/scripts/DD/UpdateFunctions/scripts.json
+++ b/src/scripts/DD/UpdateFunctions/scripts.json
@@ -21,7 +21,9 @@
         {
                 "name": "update_equipped",
                 "eventHandlerList": [
-                        "gmcp.Char.Worn"
+                        "gmcp.Char.Worn",
+                        "gmcp.Char.Base",
+                        "gmcp.Char.Vitals"
                 ]
         },
         {

--- a/src/scripts/DD/UpdateFunctions/update_equipped.lua
+++ b/src/scripts/DD/UpdateFunctions/update_equipped.lua
@@ -23,6 +23,222 @@ local equipped_slot_labels = {
   ranged_weapon = "Ranged",
 }
 
+-- This is the order used by DD4's equipment command.
+local paper_doll_slots = {
+  { key = "float", column = 17 },
+  { key = "head", column = 6 },
+  { key = "neck_1", column = 4 },
+  { key = "neck_2", column = 4 },
+  { key = "arms", column = 10 },
+  { key = "wrist_l", column = 14 },
+  { key = "wrist_r", column = 14 },
+  { key = "hands", column = 9 },
+  { key = "finger_l", column = 3 },
+  { key = "finger_r", column = 3 },
+  { key = "body", column = 5 },
+  { key = "about", column = 12 },
+  { key = "waist", column = 13 },
+  { key = "pouch", column = 18 },
+  { key = "legs", column = 7 },
+  { key = "feet", column = 8 },
+  { key = "light", column = 1 },
+  { key = "hold", column = 16 },
+  { key = "shield", column = 11 },
+  { key = "wield", column = 15 },
+  { key = "dual", column = 15 },
+  { key = "ranged_weapon", column = 19 },
+}
+
+local wear_loc_slots = {
+  [0] = "light",
+  [1] = "finger_l",
+  [2] = "finger_r",
+  [3] = "neck_1",
+  [4] = "neck_2",
+  [5] = "body",
+  [6] = "head",
+  [7] = "legs",
+  [8] = "feet",
+  [9] = "hands",
+  [10] = "arms",
+  [11] = "shield",
+  [12] = "about",
+  [13] = "waist",
+  [14] = "wrist_l",
+  [15] = "wrist_r",
+  [16] = "wield",
+  [17] = "hold",
+  [18] = "dual",
+  [19] = "float",
+  [20] = "pouch",
+  [21] = "ranged_weapon",
+}
+
+-- Columns match DD4's form_wear_table:
+-- light, take, finger, neck, body, head, legs, feet, hands, arms,
+-- shield, about, waist, wrist, wield, held, float, pouch, ranged.
+local form_wear_table = {
+  normal = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
+  chameleon = { 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0 },
+  hawk = { 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0 },
+  cat = { 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0 },
+  snake = { 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0 },
+  scorpion = { 1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0 },
+  spider = { 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0 },
+  bear = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
+  tiger = { 1, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 0 },
+  ghost = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0 },
+  hydra = { 1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 0 },
+  phoenix = { 1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1, 0 },
+  demon = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
+  dragon = { 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 0 },
+  direwolf = { 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0 },
+  vampire = { 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0 },
+  werehuman = { 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0 },
+  fly = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+  griffin = { 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0 },
+  wolf = { 1, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0 },
+  bat = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+}
+
+-- Only the non-default location restrictions are listed here. The source
+-- table uses the effective subclass row whenever a subclass is present.
+local class_slot_restrictions = {
+  mage = { hands = true, shield = true },
+  thief = { shield = true },
+  psionic = { head = true },
+  psionicist = { head = true },
+  brawler = { shield = true, wield = true, dual = true },
+}
+
+local subclass_slot_restrictions = {
+  necromancer = { shield = true },
+  ninja = { shield = true },
+  witch = { body = true },
+  vampire = { light = true },
+  monk = { shield = true, wield = true, dual = true },
+  martialartist = { shield = true, wield = true, dual = true },
+  martist = { shield = true, wield = true, dual = true },
+  bard = { shield = true },
+}
+
+-- The server exposes the equipment slot but not learned[] for the dual skill.
+-- These are the professions with a DD4 dual skill prerequisite.
+local dual_professions = {
+  thief = true,
+  warrior = true,
+  ranger = true,
+  bounty = true,
+  bountyhunter = true,
+  knight = true,
+  ninja = true,
+  templar = true,
+  warlock = true,
+  vampire = true,
+  werewolf = true,
+  barbarian = true,
+  bard = true,
+  bhunter = true,
+}
+
+local form_number_names = {
+  [0] = "normal",
+  [1] = "chameleon",
+  [2] = "hawk",
+  [3] = "cat",
+  [4] = "snake",
+  [5] = "scorpion",
+  [6] = "spider",
+  [7] = "bear",
+  [8] = "tiger",
+  [9] = "ghost",
+  [10] = "hydra",
+  [11] = "phoenix",
+  [12] = "demon",
+  [13] = "dragon",
+  [14] = "direwolf",
+  [15] = "none",
+  [16] = "werehuman",
+  [17] = "fly",
+  [18] = "griffin",
+  [19] = "wolf",
+  [20] = "bat",
+}
+
+local function normalize_key(value)
+  local key = string.lower(tostring(value or ""))
+  key = string.gsub(key, "[^%a%d]", "")
+  return key
+end
+
+local function character_wear_context()
+  local base = {}
+  local vitals = {}
+
+  if gmcp and gmcp.Char then
+    if type(gmcp.Char.Base) == "table" then
+      base = gmcp.Char.Base
+    end
+
+    if type(gmcp.Char.Vitals) == "table" then
+      vitals = gmcp.Char.Vitals
+    end
+  end
+
+  local subclass = normalize_key(base.subclass)
+  if subclass == "none" then
+    subclass = ""
+  end
+
+  local form_number = tonumber(vitals.form)
+  local form = form_number_names[form_number]
+  if not form then
+    form = normalize_key(vitals.form)
+  end
+
+  if form == "" or form == "none" then
+    form = "normal"
+  end
+
+  return {
+    class = normalize_key(base.class),
+    subclass = subclass,
+    form = form,
+  }
+end
+
+local function item_slot_key(item)
+  local raw_slot = item.slot
+  local numeric_slot = tonumber(raw_slot)
+
+  if numeric_slot ~= nil and wear_loc_slots[numeric_slot] then
+    return wear_loc_slots[numeric_slot]
+  end
+
+  if raw_slot == nil then
+    local wear_loc = tonumber(item.wear_loc)
+    if wear_loc ~= nil and wear_loc_slots[wear_loc] then
+      return wear_loc_slots[wear_loc]
+    end
+  end
+
+  local normalized = normalize_key(raw_slot)
+  local aliases = {
+    fingerl = "finger_l",
+    fingerr = "finger_r",
+    neck1 = "neck_1",
+    neck2 = "neck_2",
+    wristl = "wrist_l",
+    wristr = "wrist_r",
+    dualwield = "dual",
+    held = "hold",
+    ranged = "ranged_weapon",
+    rangedweapon = "ranged_weapon",
+  }
+
+  return aliases[normalized] or normalized
+end
+
 local function worn_entries()
   if not gmcp or not gmcp.Char or type(gmcp.Char.Worn) ~= "table" then
     return {}
@@ -30,18 +246,73 @@ local function worn_entries()
 
   local worn = gmcp.Char.Worn
   local first = worn[1]
-  if type(first) == "table" and first.slot == nil and first.name == nil then
+  if type(first) == "table" and first.slot == nil and first.wear_loc == nil then
     return first
   end
 
   return worn
 end
 
+local function worn_by_slot(entries)
+  local equipped = {}
+
+  for _, item in ipairs(entries) do
+    if type(item) == "table" then
+      local slot = item_slot_key(item)
+      if slot ~= "" then
+        equipped[slot] = item
+      end
+    end
+  end
+
+  return equipped
+end
+
+local function slot_is_allowed(slot, context)
+  if slot.key == "ranged_weapon" then
+    return context.subclass == "knight"
+        or (context.class == "ranger" and context.subclass == "")
+  end
+
+  local form_row = form_wear_table[context.form] or form_wear_table.normal
+  if form_row[slot.column] ~= 1 then
+    return false
+  end
+
+  local restrictions
+  if context.subclass ~= "" then
+    restrictions = subclass_slot_restrictions[context.subclass]
+  else
+    restrictions = class_slot_restrictions[context.class]
+  end
+
+  if restrictions and restrictions[slot.key] then
+    return false
+  end
+
+  if slot.key == "dual" then
+    local profession = context.subclass
+    if profession == "" then
+      profession = context.class
+    end
+
+    if not dual_professions[profession] then
+      return false
+    end
+  end
+
+  return true
+end
+
 local function compact_equipped_name(value)
-  local name = ansi2string(tostring(value or ""))
+  local name = tostring(value or "")
+  if type(ansi2string) == "function" then
+    name = ansi2string(name)
+  end
+
+  name = string.gsub(name, "\27%[[0-9;]*m", "")
   name = string.gsub(name, "%b()", "")
-  name = string.gsub(name, "^%s+", "")
-  name = string.gsub(name, "%[.+%]", "")
+  name = string.gsub(name, "%b[]", "")
   name = string.gsub(name, "^%s+", "")
   name = string.gsub(name, "%s+$", "")
   return name
@@ -49,50 +320,60 @@ end
 
 local function fit_equipped_name(name, width)
   if #name > width then
-    name = replace_char(width, name, ".")
-    name = replace_char(width - 1, name, ".")
-    return string.format("%." .. width .. "s", name)
+    return string.sub(name, 1, width - 2) .. ".."
   end
 
   return string.format("%-" .. width .. "s", name)
 end
 
-local function equipped_slot_label(slot)
-  slot = string.lower(tostring(slot or ""))
-  if equipped_slot_labels[slot] then
-    return equipped_slot_labels[slot]
+local function equipped_signature(entries, context)
+  local parts = { context.class, context.subclass, context.form }
+
+  for _, item in ipairs(entries) do
+    if type(item) == "table" then
+      table.insert(parts, item_slot_key(item) .. "=" .. tostring(item.name or item.short_desc or ""))
+    end
   end
 
-  slot = string.gsub(slot, "_", " ")
-  if slot == "" then
-    return "Other"
-  end
-
-  return string.upper(string.sub(slot, 1, 1)) .. string.sub(slot, 2)
+  return table.concat(parts, "|")
 end
+
+local last_rendered_console
+local last_equipped_signature
 
 function update_equipped()
   if not EquippedConsole then
     return
   end
 
+  local entries = worn_entries()
+  local context = character_wear_context()
+  local signature = equipped_signature(entries, context)
+
+  if last_rendered_console == EquippedConsole
+      and last_equipped_signature == signature then
+    return
+  end
+
+  last_rendered_console = EquippedConsole
+  last_equipped_signature = signature
+
   EquippedConsole:clear()
   EquippedConsole:resetAutoWrap()
 
-  local found = false
-  for _, item in ipairs(worn_entries()) do
-    if type(item) == "table" then
-      local name = compact_equipped_name(item.name or item.short_desc)
-      if name ~= "" then
-        found = true
-        local slot = equipped_slot_label(item.slot)
-        EquippedConsole:cecho("<white>" .. string.format("%-10s", slot) .. "<reset>")
-        EquippedConsole:decho(fit_equipped_name(name, 24) .. "\n")
-      end
-    end
-  end
+  local equipped = worn_by_slot(entries)
+  for _, slot in ipairs(paper_doll_slots) do
+    local label = equipped_slot_labels[slot.key] or slot.key
+    EquippedConsole:cecho("<white>" .. string.format("%-15s", label) .. "<reset>")
 
-  if not found then
-    EquippedConsole:cecho("Nothing.<reset>")
+    local item = equipped[slot.key]
+    if item then
+      local name = compact_equipped_name(item.name or item.short_desc)
+      EquippedConsole:decho(fit_equipped_name(name, 27) .. "\n")
+    elseif slot_is_allowed(slot, context) then
+      EquippedConsole:cecho("<yellow>[empty]<reset>\n")
+    else
+      EquippedConsole:cecho("<red>[prohibited]<reset>\n")
+    end
   end
 end

--- a/src/scripts/DD/UpdateFunctions/update_inventory.lua
+++ b/src/scripts/DD/UpdateFunctions/update_inventory.lua
@@ -1,24 +1,41 @@
 debug.setmetatable(nil, { __index=function () end })
 
+local function is_inventory_entry(value)
+  return type(value) == "table"
+      and value.quan ~= nil
+      and (value.short_desc ~= nil or value.name ~= nil)
+end
+
+local function collect_inventory_entries(value, entries, visited)
+  if type(value) ~= "table" or visited[value] then
+    return
+  end
+
+  visited[value] = true
+
+  if is_inventory_entry(value) then
+    table.insert(entries, value)
+    return
+  end
+
+  for _, child in pairs(value) do
+    collect_inventory_entries(child, entries, visited)
+  end
+end
+
 local function inventory_entries()
   if not gmcp or not gmcp.Char or type(gmcp.Char.Items) ~= "table" then
     return {}
   end
 
-  local items = gmcp.Char.Items
-  local first = items[1]
-  if type(first) == "table"
-      and first.quan == nil
-      and first.short_desc == nil
-      and first.name == nil then
-    return first
-  end
-
-  return items
+  local entries = {}
+  collect_inventory_entries(gmcp.Char.Items, entries, {})
+  return entries
 end
 
 local function compact_inventory_name(value)
-  local name = ansi2string(tostring(value or ""))
+  local name = tostring(value or "")
+  name = string.gsub(name, "\27%[[0-9;]*m", "")
   name = string.gsub(name, "%b()", "")
   name = string.gsub(name, "^%s+", "")
   name = string.gsub(name, "%b[]", "")
@@ -29,9 +46,7 @@ end
 
 local function fit_inventory_name(name, width)
   if #name > width then
-    name = replace_char(width, name, ".")
-    name = replace_char(width - 1, name, ".")
-    return string.format("%." .. width .. "s", name)
+    return string.sub(name, 1, width - 2) .. ".."
   end
 
   return string.format("%-" .. width .. "s", name)


### PR DESCRIPTION
## Summary\n- fix nested Char.Items extraction for the Inventory tab\n- render all DD4 equipment slots with items, [empty], or [prohibited]\n- apply DD4 class, subclass, form, ranged, and dual-wield rules\n- refresh equipment when GMCP base, vitals, or worn data changes\n\n## Verification\n- luaparse validation passed for both changed Lua update functions\n- scripts.json parsed successfully\n- scripts/build-and-upload.ps1 completed successfully and uploaded the package artifacts