### PR TITLE
Fix inventory console z-order

### DIFF
--- a/src/scripts/DD/DD_GUI.InventoryBox.lua
+++ b/src/scripts/DD/DD_GUI.InventoryBox.lua
@@ -103,6 +103,7 @@ function DD_GUI.Inventory:switch_tab(key)
         for tab_key, console in pairs(self.consoles or {}) do
                 if tab_key == key then
                         console:show()
+                        raiseWindow(console.name)
                 else
                         console:hide()
                 end


### PR DESCRIPTION
## Summary
- Raise the active Inventory/Equipped mini-console whenever its tab is selected.

## Root cause
Mudlet populated the Inventory mini-console correctly, but it remained behind another opaque Geyser widget. Equipment appeared because it was created later and inherited the higher z-order.

## Validation
- Instrumented the live Owltest profile: `gmcp.Char.Items` contained 13 items and the InventoryConsole buffer contained all 13 rendered lines with no Lua errors.
- Confirmed `scrollTo()` did not restore visibility.
- Confirmed `raiseWindow(InventoryConsole)` immediately displayed the buffered items.
- Ran `./scripts/build-and-upload.ps1`; the package built and both production artifacts uploaded successfully.
- Verified `build/DD_GUI.xml` contains the selected-console `raiseWindow` call.