### PR TITLE
Hide equipped paperdoll horizontal scrollbar

### DIFF
--- a/src/scripts/DD/InventoryConsole.lua
+++ b/src/scripts/DD/InventoryConsole.lua
@@ -28,6 +28,7 @@ function build_inventory_console()
       autoWrap = true,
       color = "black",
       scrollBar = true,
+      horizontalScrollBar = false,
       fontSize = 10,
     }, DD_GUI.Inventory.content_stack)
 


### PR DESCRIPTION
## Summary
- Disable the horizontal scrollbar on the Equipped paperdoll mini-console.
- Keep the vertical scrollbar enabled for scrolling through all equipment slots.

## Validation
- Verified Mudlet 4.21 Geyser applies `horizontalScrollBar = false` by calling `disableHorizontalScrollBar()` during construction.
- Ran `./scripts/build-and-upload.ps1` successfully; both production package artifacts uploaded.
- Verified the generated `build/DD_GUI.xml` contains the setting on `EquippedConsole` only.