### PR TITLE
Remove redundant box titles and add affects tab

### DIFF
--- a/src/scripts/DD/AffectsConsole.lua
+++ b/src/scripts/DD/AffectsConsole.lua
@@ -1,9 +1,9 @@
 function build_affects_console()
     AffectsConsole = Geyser.MiniConsole:new({
       name="AffectsConsole",
-      x = "4%", y = "13%",
+      x = "4%", y = "14%",
       width="92%",
-      height="83%",
+      height="82%",
       autoWrap = false,
       color = "black",
       scrollBar = true,

--- a/src/scripts/DD/CharsheetConsole.lua
+++ b/src/scripts/DD/CharsheetConsole.lua
@@ -2,7 +2,7 @@ function build_charsheet_console()
 
     CharsheetConsole = Geyser.MiniConsole:new({
       name="CharsheetConsole",
-      x = "4%", y = "13%",
+      x = "4%", y = "0%",
       width="94%",
       height="100%",
       autoWrap = false,

--- a/src/scripts/DD/DD_GUI.AffectsBox.lua
+++ b/src/scripts/DD/DD_GUI.AffectsBox.lua
@@ -1,19 +1,53 @@
-function build_affects_box()
+DD_GUI = DD_GUI or {}
+DD_GUI.Affects = DD_GUI.Affects or {}
 
-        DD_GUI.AffectsTopRow = Geyser.HBox:new({ 
-          name = "DD_GUI.AffectsTopRow", 
-          x = "5%", y = "3%", 
-          width = "100%", height = "10%", 
-        },DD_GUI.AffectBox ) 
-        
-        AffectsTitleLabel = Geyser.Label:new({
-          name = "AffectsTitleLabel",
-          x = 0, y = "10%",
-          width = "50%", height = "70%",
-          message = [[You are affected by:]]
-        }, DD_GUI.AffectsTopRow )
-        AffectsTitleLabel:setColor(0,0,0,0)
-        AffectsTitleLabel:setFgColor("Cyan")
-        AffectsTitleLabel:setFontSize(10)
-        AffectsTitleLabel:setBold(1)
+function DD_GUI.Affects:tab_css()
+        return [[
+                background-color: rgba(0,120,135,190);
+                border-style: solid;
+                border-width: 1px;
+                border-color: cyan;
+                margin: 1px;
+        ]]
+end
+
+function DD_GUI.Affects:build_tabs()
+        if self.tab_rail and self.tab_rail.hide then
+                self.tab_rail:hide()
+        end
+
+        self.tab_rail = Geyser.Label:new({
+                name = "DD_GUI.Affects.TabRail",
+                x = "4%",
+                y = "3%",
+                width = "92%",
+                height = "10%",
+        }, DD_GUI.AffectBox)
+        self.tab_rail:setColor(0, 0, 0, 0)
+
+        self.tab_button = Geyser.Label:new({
+                name = "DD_GUI.Affects.Tab",
+                x = "0%",
+                y = "0%",
+                width = "100%",
+                height = "100%",
+        }, self.tab_rail)
+        self.tab_button:setFontSize(8)
+        self.tab_button:setBold(1)
+        self.tab_button:setStyleSheet(self:tab_css())
+        self.tab_button:echo("Affects", "white", "c")
+end
+
+function build_affects_box()
+        if DD_GUI.AffectsTopRow and DD_GUI.AffectsTopRow.hide then
+                DD_GUI.AffectsTopRow:hide()
+        end
+
+        if AffectsTitleLabel and AffectsTitleLabel.hide then
+                AffectsTitleLabel:hide()
+        end
+
+        DD_GUI.AffectsTopRow = nil
+        AffectsTitleLabel = nil
+        DD_GUI.Affects:build_tabs()
 end

--- a/src/scripts/DD/DD_GUI.CharsheetBox.lua
+++ b/src/scripts/DD/DD_GUI.CharsheetBox.lua
@@ -1,19 +1,12 @@
 function build_charsheet_box()
-        DD_GUI.CharsheetTopRow = Geyser.HBox:new({ 
-          name = "DD_GUI.CharsheetTopRow", 
-          x = "5%", y = "3%", 
-          width = "100%", height = "10%", 
-        },DD_GUI.CharsheetBox ) 
-        
-        CharsheetLabel = Geyser.Label:new({
-          name = "CharsheetLabel",
-          x = 0, y = "10%",
-          width = "50%", height = "70%",
-          message = [[Character Info]]
-        }, DD_GUI.CharsheetTopRow )
-        CharsheetLabel:setColor(0,0,0,0)
-        CharsheetLabel:setFgColor("Cyan")
-        CharsheetLabel:setFontSize(10)
-        CharsheetLabel:setBold(1)
+        if DD_GUI.CharsheetTopRow and DD_GUI.CharsheetTopRow.hide then
+          DD_GUI.CharsheetTopRow:hide()
+        end
+
+        if CharsheetLabel and CharsheetLabel.hide then
+          CharsheetLabel:hide()
+        end
+
+        DD_GUI.CharsheetTopRow = nil
+        CharsheetLabel = nil
 end
-      

--- a/src/scripts/DD/DD_GUI.EnemyBox.lua
+++ b/src/scripts/DD/DD_GUI.EnemyBox.lua
@@ -1,18 +1,12 @@
 function build_enemy_box()
-  DD_GUI.EnemyTopRow = Geyser.HBox:new({
-    name = "DD_GUI.EnemyTopRow",
-    x = "4%", y = "3%",
-    width = "92%", height = "10%",
-  },DD_GUI.EnemyBox )
+  if DD_GUI.EnemyTopRow and DD_GUI.EnemyTopRow.hide then
+    DD_GUI.EnemyTopRow:hide()
+  end
 
-  EnemyLabel = Geyser.Label:new({
-    name = "EnemyLabel",
-    x = 0, y = "5%",
-    width = "50%", height = "70%",
-    message = [[Enemy Info]]
-  }, DD_GUI.EnemyTopRow )
-  EnemyLabel:setColor(0,0,0,0)
-  EnemyLabel:setFgColor("Cyan")
-  EnemyLabel:setFontSize(10)
-  EnemyLabel:setBold(1)
+  if EnemyLabel and EnemyLabel.hide then
+    EnemyLabel:hide()
+  end
+
+  DD_GUI.EnemyTopRow = nil
+  EnemyLabel = nil
 end

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -2,9 +2,9 @@ function build_enemy_console()
 
     EnemyConsole = Geyser.MiniConsole:new({
       name="EnemyConsole",
-      x = "4%", y = "13%",
+      x = "4%", y = "0%",
       width="92%",
-      height="83%",
+      height="100%",
       autoWrap = false,
       color = "black",
       scrollBar = false,

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -6,7 +6,6 @@ function update_enemy()
                 EnemyConsoleHitpoints:show()
                 EnemyHitpointsLabel:show()
                 EnemyConsole:clear()
-                EnemyLabel:echo("Enemy Info")
                 EnemyInfoConsole:clear()
                 local enemy_image       = ms_path .. "/mobs/20412_the_destroyer.png"
                 local def_enemy_image   = ms_path .. "/mobs/0_default.png"

--- a/src/scripts/DD/UpdateFunctions/update_travel.lua
+++ b/src/scripts/DD/UpdateFunctions/update_travel.lua
@@ -8,8 +8,6 @@ function update_travel()
             EnemyConsoleHitpointsContainer:hide()
             EnemyConsoleHitpoints:hide()
             EnemyHitpointsLabel:hide()
-            EnemyLabel:echo("Travel Info")
-
             local room_image = ms_path .. "/avatars/default_char.png"
             local sector_name = "Unknown"
 


### PR DESCRIPTION
## Summary
- remove Travel Info, Enemy Info, and Character Info title rows
- expand travel/enemy and character consoles into the reclaimed space
- replace the affects heading with an Inventory-style Affects tab

## Verification
- rebuilt and uploaded DD_GUI.mpackage and DD_GUI.xml with scripts/build-and-upload.ps1
- git diff --check passes