### PR TITLE
Keep enemy display inside combat border

### DIFF
--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -2,9 +2,9 @@ function build_enemy_console()
 
     EnemyConsole = Geyser.MiniConsole:new({
       name="EnemyConsole",
-      x = "4%", y = "0%",
+      x = "4%", y = "3%",
       width="92%",
-      height="100%",
+      height="94%",
       autoWrap = false,
       color = "black",
       scrollBar = false,


### PR DESCRIPTION
## Summary
- inset the enemy/travel console from the combat border
- keep the image, enemy information, and hitpoint gauge inside the red frame

## Verification
- rebuilt and uploaded DD_GUI.mpackage and DD_GUI.xml with scripts/build-and-upload.ps1
- git diff --check passes