### PR TITLE
Balance enemy frame spacing

### DIFF
--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -2,9 +2,9 @@ function build_enemy_console()
 
     EnemyConsole = Geyser.MiniConsole:new({
       name="EnemyConsole",
-      x = "4%", y = "3%",
+      x = "4%", y = "6%",
       width="92%",
-      height="94%",
+      height="91%",
       autoWrap = false,
       color = "black",
       scrollBar = false,


### PR DESCRIPTION
## Summary
- add matching top breathing room above the enemy image
- preserve the bottom inset below the hitpoint bar

## Verification
- rebuilt and uploaded DD_GUI.mpackage and DD_GUI.xml with scripts/build-and-upload.ps1
- git diff --check passes