### PR TITLE
Make GUI info panels resizable

### DIFF
--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -1,3 +1,32 @@
+local function new_info_box(cons, parent)
+        if Adjustable and Adjustable.Container then
+                cons.padding = 4
+                cons.autoLoad = true
+                cons.autoSave = true
+                cons.defaultDir = ms_path .. "/layout/"
+                cons.raiseOnClick = false
+                cons.titleText = ""
+                cons.titleTxtColor = "black"
+                cons.adjLabelstyle = [[
+                  background-color: rgba(0,0,0,0%);
+                  border-style: solid;
+                  border-width: 0px;
+                  border-color: rgba(0,0,0,0%);
+                  margin: 0px;
+                ]]
+
+                local box = Adjustable.Container:new(cons, parent)
+                box.adjLabel:echo("")
+                box.exitLabel:hide()
+                box.minimizeLabel:hide()
+                box.setStyleSheet = function(self, css)
+                        self.adjLabel:setStyleSheet(css)
+                end
+                return box
+        end
+
+        return Geyser.Label:new(cons, parent)
+end
 function define_boxes()
 
         DD_GUI.BoxCSS = CSSMan.new([[
@@ -18,7 +47,7 @@ function define_boxes()
           margin: 0px;
         ]])
         
-        DD_GUI.EnemyBox = Geyser.Label:new({
+        DD_GUI.EnemyBox = new_info_box({
           name = "DD_GUI.EnemyBox",
           x = "4%", y = "17%",
           width = "23%",
@@ -27,7 +56,7 @@ function define_boxes()
         DD_GUI.EnemyBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.EnemyBox:echo("<center>GUI.EnemyBox")
         
-        DD_GUI.MapBox = Geyser.Label:new({
+        DD_GUI.MapBox = new_info_box({
           name = "DD_GUI.MapBox",
           x = "27%", y = "17%",
           width = "24%",
@@ -45,7 +74,7 @@ function define_boxes()
         }, DD_GUI.MapBox)
         
         
-        DD_GUI.CharsheetBox = Geyser.Label:new({
+        DD_GUI.CharsheetBox = new_info_box({
           name = "DD_GUI.CharsheetBox",
           x = "51%", y = "17%",
           width = "23%",
@@ -54,7 +83,7 @@ function define_boxes()
         DD_GUI.CharsheetBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.CharsheetBox:echo("<center>GUI.CharsheetBox")
         
-        DD_GUI.ChannelBox = Geyser.Label:new({
+        DD_GUI.ChannelBox = new_info_box({
           name = "DD_GUI.ChannelBox",
           x = "74%", y = "17%",
           width = "23%",
@@ -63,7 +92,7 @@ function define_boxes()
         DD_GUI.ChannelBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.ChannelBox:echo("<center>GUI.ChannelBox")
         
-        DD_GUI.InventoryBox = Geyser.Label:new({
+        DD_GUI.InventoryBox = new_info_box({
           name = "DD_GUI.InventoryBox",
           x = "0%", y = "36%",
           width = "89%",
@@ -72,7 +101,7 @@ function define_boxes()
         DD_GUI.InventoryBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.InventoryBox:echo("<center>GUI.InventoryBox")
         
-        DD_GUI.AffectBox = Geyser.Label:new({
+        DD_GUI.AffectBox = new_info_box({
           name = "DD_GUI.AffectBox",
           x = "0%", y = "70%",
           width = "89%",
@@ -81,7 +110,7 @@ function define_boxes()
         DD_GUI.AffectBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.AffectBox:echo("<center>GUI.AffectBox")
         
-        DD_GUI.GaugesBox = Geyser.Label:new({
+        DD_GUI.GaugesBox = new_info_box({
           name = "DD_GUI.GaugesBox",
           x = "5%", y = 0,
           width = "95%",
@@ -90,4 +119,3 @@ function define_boxes()
         DD_GUI.GaugesBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.GaugesBox:echo("<center>GUI.GaugesBox")
 end
-     

--- a/src/scripts/DD/CharsheetConsole.lua
+++ b/src/scripts/DD/CharsheetConsole.lua
@@ -39,11 +39,16 @@ function build_charsheet_console()
     -- be a 160 x 200 px .png in the ms_path + /avatars/ directory
     -- pfp_filename = mycustomavatar.png'
 
-    resetBackgroundImage("CharsheetPFPConsole")
-    CharsheetPFPConsole:setBackgroundImage( [[
-      background-image: url(]] .. ms_path .. '/avatars/' .. pfp_filename .. [[);
-      background-position: top left;
-      background-repeat: no-repeat;
-    ]],
-    "style")
+    local pfp_path = ms_path .. '/avatars/' .. pfp_filename
+    local default_path = ms_path .. '/avatars/default_char.png'
+    if not file_exists(pfp_path) then
+      pfp_path = default_path
+    end
+
+    DD_GUI.ImageFit:set(
+      CharsheetPFPConsole,
+      CharsheetConsole,
+      pfp_path,
+      { fallback = { width = 160, height = 200 } }
+    )
 end

--- a/src/scripts/DD/ImageFit.lua
+++ b/src/scripts/DD/ImageFit.lua
@@ -1,0 +1,108 @@
+DD_GUI = DD_GUI or {}
+
+DD_GUI.ImageFit = DD_GUI.ImageFit or {
+        widgets = {},
+}
+
+local function image_dimensions(path, fallback)
+        local fallback_width = (fallback and fallback.width) or 1
+        local fallback_height = (fallback and fallback.height) or 1
+
+        if type(getImageSize) == "function" then
+                local ok, width, height = pcall(getImageSize, path)
+                if ok and tonumber(width) and tonumber(height) and
+                   tonumber(width) > 0 and tonumber(height) > 0 then
+                        return tonumber(width), tonumber(height)
+                end
+        end
+
+        return fallback_width, fallback_height
+end
+
+function DD_GUI.ImageFit:refresh_widget(state)
+        local widget = state and state.widget
+        local parent = state and state.parent
+        if not widget or not parent or not widget.get_width or not parent.get_width then
+                return
+        end
+
+        local parent_width = math.max(1, parent:get_width())
+        local parent_height = math.max(1, parent:get_height())
+        local x = parent_width * state.x_ratio
+        local y = parent_height * state.y_ratio
+        local max_width = math.max(1, parent_width * state.width_ratio)
+        local max_height = math.max(1, parent_height * state.height_ratio)
+        local image_ratio = state.image_height / state.image_width
+
+        local width = math.min(max_width, max_height / image_ratio)
+        local height = width * image_ratio
+
+        width = math.min(width, parent_width - x)
+        height = width * image_ratio
+        height = math.min(height, parent_height - y)
+        width = height / image_ratio
+
+        x = math.max(0, x)
+        y = math.max(0, y)
+        width = math.max(1, width)
+        height = math.max(1, height)
+
+        widget:move(math.floor(x + 0.5), math.floor(y + 0.5))
+        widget:resize(math.floor(width + 0.5), math.floor(height + 0.5))
+end
+
+function DD_GUI.ImageFit:refresh_all()
+        for _, state in pairs(self.widgets) do
+                self:refresh_widget(state)
+        end
+end
+
+function DD_GUI.ImageFit:set(widget, parent, path, options)
+        if not widget or not parent or not path then
+                return
+        end
+
+        options = options or {}
+        local state = self.widgets[widget.name]
+
+        if not state or state.widget ~= widget then
+                local parent_width = math.max(1, parent:get_width())
+                local parent_height = math.max(1, parent:get_height())
+                local widget_x = widget.get_x and widget:get_x() or 0
+                local widget_y = widget.get_y and widget:get_y() or 0
+                local parent_x = parent.get_x and parent:get_x() or 0
+                local parent_y = parent.get_y and parent:get_y() or 0
+
+                state = {
+                        widget = widget,
+                        parent = parent,
+                        x_ratio = options.x_ratio or math.max(0, (widget_x - parent_x) / parent_width),
+                        y_ratio = options.y_ratio or math.max(0, (widget_y - parent_y) / parent_height),
+                        width_ratio = options.width_ratio or
+                                math.max(0.01, widget:get_width() / parent_width),
+                        height_ratio = options.height_ratio or
+                                math.max(0.01, widget:get_height() / parent_height),
+                }
+                self.widgets[widget.name] = state
+        end
+
+        state.parent = parent
+        state.path = path
+        state.image_width, state.image_height = image_dimensions(path, options.fallback)
+
+        if widget.setBackgroundImage then
+                widget:setBackgroundImage(path, "border")
+        end
+
+        self:refresh_widget(state)
+end
+
+if not DD_GUI.ImageFit.handlers_registered then
+        local refresh = function()
+                DD_GUI.ImageFit:refresh_all()
+        end
+
+        registerAnonymousEventHandler("sysWindowResizeEvent", refresh)
+        registerAnonymousEventHandler("AdjustableContainerReposition", refresh)
+        DD_GUI.ImageFit.handlers_registered = true
+end

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -26,9 +26,19 @@ function update_enemy()
                 EnemyTPConsoleTop:clear()
 
                 if (file_exists(enemy_image)) then
-                        EnemyTPConsoleTop:setBackgroundImage(enemy_image,"border")
+                        DD_GUI.ImageFit:set(
+                                EnemyTPConsoleTop,
+                                EnemyConsole,
+                                enemy_image,
+                                { fallback = { width = 560, height = 300 } }
+                        )
                 else
-                        EnemyTPConsoleTop:setBackgroundImage(def_enemy_image,"border")
+                        DD_GUI.ImageFit:set(
+                                EnemyTPConsoleTop,
+                                EnemyConsole,
+                                def_enemy_image,
+                                { fallback = { width = 560, height = 300 } }
+                        )
                 end
 
                 for i, count in ipairs(gmcp.Char.Enemies) do

--- a/src/scripts/DD/UpdateFunctions/update_travel.lua
+++ b/src/scripts/DD/UpdateFunctions/update_travel.lua
@@ -99,7 +99,12 @@ function update_travel()
             --background-repeat: no-repeat;]],
             --"style")
 
-            EnemyTPConsoleTop:setBackgroundImage(room_image,"border")
+            DD_GUI.ImageFit:set(
+                    EnemyTPConsoleTop,
+                    EnemyConsole,
+                    room_image,
+                    { fallback = { width = 560, height = 300 } }
+            )
 
             local stripped_room_name = string.gsub(gmcp.Room.Info.name, "\{[a-zA-Z]", "")
             stripped_room_name = string.gsub(stripped_room_name, "\<%d+\>", "")

--- a/src/scripts/DD/UpdateFunctions/update_vitals.lua
+++ b/src/scripts/DD/UpdateFunctions/update_vitals.lua
@@ -139,14 +139,23 @@ function update_vitals()
     pfp_filename = 'mist_form.png'
   end
 
-  resetBackgroundImage("CharsheetPFPConsole")
   local char_image = ms_path .. '/avatars/' .. pfp_filename
   local def_image = ms_path .. '/avatars/' .. 'default_char.png'
 
   if file_exists(char_image) then
-        CharsheetPFPConsole:setBackgroundImage(char_image,"border")
+        DD_GUI.ImageFit:set(
+          CharsheetPFPConsole,
+          CharsheetConsole,
+          char_image,
+          { fallback = { width = 160, height = 200 } }
+        )
   else
-        CharsheetPFPConsole:setBackgroundImage(def_image,"border")
+        DD_GUI.ImageFit:set(
+          CharsheetPFPConsole,
+          CharsheetConsole,
+          def_image,
+          { fallback = { width = 160, height = 200 } }
+        )
   end
 
   --CharsheetPFPConsole:setBackgroundImage( [[

--- a/src/scripts/DD/scripts.json
+++ b/src/scripts/DD/scripts.json
@@ -9,6 +9,9 @@
         "name": "BoxesDefinitions"
   },
   {
+        "name": "ImageFit"
+  },
+  {
         "name": "ChannelConsole"
   },
   {


### PR DESCRIPTION
## Summary\n- make the main GUI information panels movable and resizable with Mudlet's native Adjustable.Container support\n- persist per-profile panel layouts under DD_GUI/layout\n- preserve image proportions and refit character, enemy, and room images as panels resize\n\n## Verification\n- ran .\\scripts\\build-and-upload.ps1\n- validated the generated package contains ImageFit\n- live-tested resizing the Enemy panel and restored the test profile layout