### PR TITLE
Keep info box controls clickable

### DIFF
--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -5,6 +5,25 @@ local function transparent_surface_css(css)
         )
 end
 
+function DD_GUI.raise_info_box_contents()
+        local box_names = {
+                "EnemyBox",
+                "MapBox",
+                "CharsheetBox",
+                "ChannelBox",
+                "InventoryBox",
+                "AffectBox",
+                "GaugesBox",
+        }
+
+        for _, box_name in ipairs(box_names) do
+                local box = DD_GUI[box_name]
+                if box and box.Inside and box.Inside.raiseAll then
+                        box.Inside:raiseAll()
+                end
+        end
+end
+
 local function new_info_box(cons, parent)
         if Adjustable and Adjustable.Container then
                 cons.padding = 4

--- a/src/scripts/DD/ChannelConsole.lua
+++ b/src/scripts/DD/ChannelConsole.lua
@@ -244,12 +244,19 @@ function DD_GUI.Comms:ensure_channel_widget(key)
                 return
         end
 
+        local changed = false
         if not self.tab_buttons[key] then
                 self:create_tab_button(key)
+                changed = true
         end
 
         if not self.consoles[key] then
                 self:create_console(key)
+                changed = true
+        end
+
+        if changed and DD_GUI.raise_info_box_contents then
+                DD_GUI.raise_info_box_contents()
         end
 end
 
@@ -285,6 +292,10 @@ function DD_GUI.Comms:refresh_tabs()
                 self:switch_tab("all")
         else
                 self:style_tabs()
+        end
+
+        if DD_GUI.raise_info_box_contents then
+                DD_GUI.raise_info_box_contents()
         end
 end
 

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -20,4 +20,8 @@ function bootstrap()
         load_dd_mapper()
         get_custom_content()
         update_travel()
+
+        if DD_GUI.raise_info_box_contents then
+                DD_GUI.raise_info_box_contents()
+        end
 end

--- a/src/scripts/DD/UpdateFunctions/update_vitals.lua
+++ b/src/scripts/DD/UpdateFunctions/update_vitals.lua
@@ -23,6 +23,11 @@ function update_vitals()
         build_enemy_box()
         build_enemy_console()
         build_compass()
+
+        if DD_GUI.raise_info_box_contents then
+                DD_GUI.raise_info_box_contents()
+        end
+
         lost_focus = false
     end
   end


### PR DESCRIPTION
## Summary\n- raise each adjustable panel's inner descendants above the resize mouse-capture layer\n- keep static tabs clickable after startup and focus rebuilds\n- refresh z-order when dynamic comms tabs appear or change\n\n## Verification\n- ran .\\scripts\\build-and-upload.ps1\n- clicked Equipped and a comms tab in the Mudlet test profile\n- resized the Enemy panel from 386px to 476px and restored its layout