### PR TITLE
Make main console and compass adjustable

### DIFF
--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -6,6 +6,26 @@ local function transparent_surface_css(css)
 end
 
 function DD_GUI.raise_info_box_contents()
+        if ui and ui.mainconsole_container and ui.mainconsole_container.adjLabel and
+           ui.mainconsole_container.adjLabel.raise then
+                ui.mainconsole_container.adjLabel:raise()
+        end
+
+        if Adjustable and Adjustable.Container and Adjustable.Container.all then
+                for _, box in pairs(Adjustable.Container.all) do
+                        if box and box.adjLabel and box.adjLabel.raise then
+                                box.adjLabel:raise()
+                        end
+                end
+
+                for _, box in pairs(Adjustable.Container.all) do
+                        if box and box.Inside and box.Inside.raiseAll then
+                                box.Inside:raiseAll()
+                        end
+                end
+                return
+        end
+
         local box_names = {
                 "EnemyBox",
                 "MapBox",
@@ -24,8 +44,9 @@ function DD_GUI.raise_info_box_contents()
         end
 end
 
-local function new_info_box(cons, parent)
+function DD_GUI.new_adjustable_container(cons, parent)
         if Adjustable and Adjustable.Container then
+                cons = cons or {}
                 cons.padding = 4
                 cons.autoLoad = true
                 cons.autoSave = true
@@ -48,6 +69,16 @@ local function new_info_box(cons, parent)
                 box.setStyleSheet = function(self, css)
                         self.adjLabel:setStyleSheet(transparent_surface_css(css))
                 end
+                box._dd_gui_adjustable = true
+                return box
+        end
+
+        return nil
+end
+
+local function new_info_box(cons, parent)
+        local box = DD_GUI.new_adjustable_container(cons, parent)
+        if box then
                 return box
         end
 

--- a/src/scripts/DD/MainWindow.lua
+++ b/src/scripts/DD/MainWindow.lua
@@ -4,41 +4,70 @@ function ui_container()
         --------------------------------
         ui = ui or {} -- user interface related stuff goes into this table
 
-        -- Container used to get console position
-        ui.mainconsole_container = Geyser.Container:new({
-                name = "mainconsole_container",
-                x="4%", y="38%",
-                width="75%", height="56%",
-        })
+        -- Transparent adjustable overlay used to define the main MUD console area.
+        local mainconsole_constraints = {
+                name = "DD_GUI.MainConsole",
+                x = "4%", y = "38%",
+                width = "75%", height = "56%",
+        }
 
+        ui.mainconsole_container = DD_GUI.new_adjustable_container and
+                DD_GUI.new_adjustable_container(mainconsole_constraints) or
+                Geyser.Container:new(mainconsole_constraints)
 
-        -- function called by the temptimer to do the work
         function ui.updateBorderSizes()
-                local w,h = getMainWindowSize()
-                -- Only update if window size have changed!
-                if( w ~= ui.window_width or h ~= ui.window_height ) then
+                if not ui.mainconsole_container then
+                        return
+                end
+
+                local w, h = getMainWindowSize()
+                local cx = tonumber(ui.mainconsole_container:get_x()) or 0
+                local cy = tonumber(ui.mainconsole_container:get_y()) or 0
+                local cw = tonumber(ui.mainconsole_container:get_width()) or w
+                local ch = tonumber(ui.mainconsole_container:get_height()) or h
+
+                local left = math.max(0, cx)
+                local top = math.max(0, cy)
+                local right = math.max(0, w - cx - cw)
+                local bottom = math.max(0, h - cy - ch)
+
+                if w ~= ui.window_width or h ~= ui.window_height or
+                   left ~= ui.border_left or top ~= ui.border_top or
+                   right ~= ui.border_right or bottom ~= ui.border_bottom then
                         ui.window_width = w
                         ui.window_height = h
+                        ui.border_left = left
+                        ui.border_top = top
+                        ui.border_right = right
+                        ui.border_bottom = bottom
 
-                        local cx = ui.mainconsole_container:get_x()
-                        local cy = ui.mainconsole_container:get_y()
-                        local cw = ui.mainconsole_container:get_width()
-                        local ch = ui.mainconsole_container:get_height()
-
-                        setBorderLeft(tonumber(cx))
-                        setBorderTop(tonumber(cy))
-                        setBorderRight(tonumber(w-cx-cw))
-                        setBorderBottom(tonumber(h-cy-ch))
+                        setBorderLeft(left)
+                        setBorderTop(top)
+                        setBorderRight(right)
+                        setBorderBottom(bottom)
                 end
         end
 
-        -- sysWindowResizeEvent handler
-        function ui.updatecontent( event, x, y )
-                if( ui.eventtimer ) then killTimer( ui.eventtimer ) end
-                ui.eventtimer = tempTimer(0, [[killTimer( "ui.eventtimer" ) ui.updateBorderSizes()]])
+        -- Defer border changes until the adjustable container has finished updating.
+        function ui.updatecontent()
+                if ui.eventtimer then
+                        killTimer(ui.eventtimer)
+                end
+
+                ui.eventtimer = tempTimer(0, function()
+                        ui.eventtimer = nil
+                        ui.updateBorderSizes()
+                end)
         end
 
-        -- register our function as an event handler
-        registerAnonymousEventHandler("sysWindowResizeEvent", "ui.updatecontent")
+        if not ui.handlers_registered then
+                registerAnonymousEventHandler("sysWindowResizeEvent", ui.updatecontent)
+                registerAnonymousEventHandler("AdjustableContainerReposition", ui.updatecontent)
+                ui.handlers_registered = true
+        end
+
+        -- set_borders() establishes the legacy defaults before this container exists.
+        -- Force one calculation so a saved layout is applied immediately on login.
+        ui.window_width = nil
+        ui.updateBorderSizes()
 end
-            

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -1,34 +1,85 @@
-function build_compass() 
+local function compass_background_css(width)
+  local radius = math.max(0, (tonumber(width) or 0) / 2 - 36)
+
+  return [[
+    background-color: QRadialGradient(cx:.3,cy:1,radius:1,stop:0 rgb(28,0,0),stop:.5 rgb(100,0,0),stop:1 rgb(255,0,0));
+    border-radius: ]] .. tostring(radius) .. [[px;
+    margin: 12px;
+  ]]
+end
+
+function build_compass()
 
 local mw, mh = getMainWindowSize()
- 
+
+  local previous_geometry
+  if compass and compass.back and compass.back._dd_gui_adjustable then
+    previous_geometry = {
+      x = compass.back.x,
+      y = compass.back.y,
+      width = compass.back.width,
+      height = compass.back.height,
+    }
+  end
+  local previous_default_size = previous_geometry and
+    tostring(previous_geometry.width) == "8%" and
+    tostring(previous_geometry.height) == "8%"
+
+  local compass_layout_path = ms_path .. "/layout/compass.back.lua"
+  local saved_layout = io.exists and io.exists(compass_layout_path)
+
   compass = {
     dirs = {"n","u","w","look","e","s","d"},
     ratio = mw / mh
   }
-  
-  compass.back = Geyser.Label:new({
+
+  local compass_constraints = {
     name = "compass.back",
     x = "60%",
     y = "82%",
     width = "8%",
     height = "8%",
-  },main)
-  
-  compass.back:setStyleSheet([[
-    background-color: QRadialGradient(cx:.3,cy:1,radius:1,stop:0 rgb(28,0,0),stop:.5 rgb(100,0,0),stop:1 rgb(255,0,0));
-    border-radius: ]]..tostring(compass.back:get_width()/2-36)..[[px;
-    margin: 12px;
-  ]])
-  
+    padding = 4,
+  }
+
+  if previous_geometry then
+    for key, value in pairs(previous_geometry) do
+      compass_constraints[key] = value
+    end
+  end
+
+  compass.back = DD_GUI.new_adjustable_container and
+    DD_GUI.new_adjustable_container(compass_constraints, main) or
+    Geyser.Label:new(compass_constraints, main)
+
+  if compass.back._dd_gui_adjustable and not saved_layout and
+     (not previous_geometry or previous_default_size) then
+    -- Preserve the old compass' square default while allowing later resizing.
+    compass.back:resize(compass.back.width, compass.back:get_width())
+  end
+
+  local compass_parent = compass.back
+  if compass.back._dd_gui_adjustable then
+    compass.surface = Geyser.Label:new({
+      name = "compass.surface",
+      x = 0,
+      y = 0,
+      width = "100%",
+      height = "100%",
+    }, compass.back.Inside)
+    compass_parent = compass.back.Inside
+  else
+    compass.back:setStyleSheet(compass_background_css(compass.back:get_width()))
+  end
+
   compass.box = Geyser.HBox:new({
     name = "compass.box",
     x = 0,
     y = 0,
     width = "100%",
     height = "100%",
-  },compass.back)
-    
+  },compass_parent)
+
   compass.row1 = Geyser.VBox:new({
     name = "compass.row1",
   },compass.box)
@@ -38,47 +89,47 @@ local mw, mh = getMainWindowSize()
   compass.row3 = Geyser.VBox:new({
     name = "compass.row3",
   },compass.box)
-      
+
   compass.nw = Geyser.Label:new({
     name = "compass.nw",
   },compass.row1)
-  
+
   compass.nw:setStyleSheet([[
     background-color: rgba(0,0,0,0%);
   ]])
-      
+
   compass.w = Geyser.Label:new({
     name = "compass.w",
   },compass.row1)
-  
+
   compass.sw = Geyser.Label:new({
     name = "compass.sw",
   },compass.row1)
-  
+
   compass.sw:setStyleSheet([[
     background-color: rgba(0,0,0,0%);
   ]])
-      
+
   compass.n = Geyser.Label:new({
     name = "compass.n",
   },compass.row2)
-    
+
   compass.look = Geyser.Label:new({
     name = "compass.look",
   },compass.row2)
-  
+
   compass.s = Geyser.Label:new({
     name = "compass.s",
   },compass.row2)
-  
+
   compass.u = Geyser.Label:new({
     name = "compass.u",
   },compass.row3)
-  
+
   compass.e = Geyser.Label:new({
     name = "compass.e",
   },compass.row3)
-  
+
   compass.d = Geyser.Label:new({
     name = "compass.d",
   },compass.row3)
@@ -112,8 +163,39 @@ for k,v in pairs(compass.dirs) do
   setLabelOnLeave("compass."..v,"compass.onLeave",v)
 end
 
+function compass.refresh()
+  if compass.surface then
+    compass.surface:setStyleSheet(compass_background_css(compass.surface:get_width()))
+  elseif compass.back and compass.back.setStyleSheet then
+    compass.back:setStyleSheet(compass_background_css(compass.back:get_width()))
+  end
+
+  -- Keep the navigation cells above the adjustable drag surface.
+  if compass.box and compass.box.raise then
+    compass.box:raise()
+  end
+end
+
 function compass.resize()
-  compass.back:resize(compass.back.width, compass.back:get_width())
+  -- The legacy label stays square.  Adjustable users control both dimensions.
+  if compass.back and not compass.back._dd_gui_adjustable then
+    compass.back:resize(compass.back.width, compass.back:get_width())
+  end
+  compass.refresh()
+end
+
+if not DD_GUI.compass_handlers_registered then
+  registerAnonymousEventHandler("sysWindowResizeEvent", function()
+    if compass and compass.refresh then
+      compass.refresh()
+    end
+  end)
+  registerAnonymousEventHandler("AdjustableContainerReposition", function(_, name)
+    if name == "compass.back" and compass and compass.refresh then
+      compass.refresh()
+    end
+  end)
+  DD_GUI.compass_handlers_registered = true
 end
 
 compass.resize()


### PR DESCRIPTION
Adds profile-persistent adjustable containers for the main MUD text viewport and navigation compass. Main-console border margins now follow drag/resize events, compass artwork maintains its aspect-aware surface, and child controls remain clickable.