### PR TITLE
Make structural GUI regions adjustable

### DIFF
--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -5,6 +5,21 @@ local function transparent_surface_css(css)
         )
 end
 
+local function raise_children(container)
+        if not container or not container.windows or not container.windowList then
+                return
+        end
+
+        for _, name in ipairs(container.windows) do
+                local child = container.windowList[name]
+                if child and child.raiseAll then
+                        child:raiseAll()
+                elseif child and child.raise then
+                        child:raise()
+                end
+        end
+end
+
 function DD_GUI.raise_info_box_contents()
         if ui and ui.mainconsole_container and ui.mainconsole_container.adjLabel and
            ui.mainconsole_container.adjLabel.raise then
@@ -19,8 +34,30 @@ function DD_GUI.raise_info_box_contents()
                 end
 
                 for _, box in pairs(Adjustable.Container.all) do
-                        if box and box.Inside and box.Inside.raiseAll then
-                                box.Inside:raiseAll()
+                        if box and box.Inside then
+                                -- Raise the contents without raising the
+                                -- full-size Inside container over the drag
+                                -- surface of its parent.
+                                raise_children(box.Inside)
+                        end
+                end
+
+                -- Gauge columns use the adjustable container directly so
+                -- their short row height does not get consumed by nested
+                -- Inside containers.
+                for _, box in pairs(Adjustable.Container.all) do
+                        if box and box.goInside == false and box.raiseAll then
+                                box:raiseAll()
+                        end
+                end
+
+                -- The compass overlaps the bottom gauge row at its default
+                -- position, so its navigation cells must be raised last.
+                if compass and compass.box then
+                        if compass.box.raiseAll then
+                                compass.box:raiseAll()
+                        elseif compass.box.raise then
+                                compass.box:raise()
                         end
                 end
                 return
@@ -44,10 +81,10 @@ function DD_GUI.raise_info_box_contents()
         end
 end
 
-function DD_GUI.new_adjustable_container(cons, parent)
+function DD_GUI.new_adjustable_container(cons, parent, options)
         if Adjustable and Adjustable.Container then
                 cons = cons or {}
-                cons.padding = 4
+                cons.padding = cons.padding or 4
                 cons.autoLoad = true
                 cons.autoSave = true
                 cons.defaultDir = ms_path .. "/layout/"
@@ -69,11 +106,33 @@ function DD_GUI.new_adjustable_container(cons, parent)
                 box.setStyleSheet = function(self, css)
                         self.adjLabel:setStyleSheet(transparent_surface_css(css))
                 end
+                if options and options.direct then
+                        box.goInside = false
+                end
                 box._dd_gui_adjustable = true
                 return box
         end
 
         return nil
+end
+
+function DD_GUI.new_adjustable_region(cons, parent, css, options)
+        local box = DD_GUI.new_adjustable_container(cons, parent, options)
+        if box then
+                -- Keep the region background on the drag layer itself.  The
+                -- content is raised afterwards, so this never tints it.
+                if box.adjLabel and box.adjLabel.setStyleSheet then
+                        box.adjLabel:setStyleSheet(css or "")
+                end
+                box._dd_gui_region = true
+                return box
+        end
+
+        local fallback = Geyser.Label:new(cons, parent)
+        if css then
+                fallback:setStyleSheet(css)
+        end
+        return fallback
 end
 
 local function new_info_box(cons, parent)
@@ -167,12 +226,4 @@ function define_boxes()
         DD_GUI.AffectBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.AffectBox:echo("<center>GUI.AffectBox")
         
-        DD_GUI.GaugesBox = new_info_box({
-          name = "DD_GUI.GaugesBox",
-          x = "5%", y = 0,
-          width = "95%",
-          height = "100%",
-        },DD_GUI.Bottom)
-        DD_GUI.GaugesBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
-        --GUI.GaugesBox:echo("<center>GUI.GaugesBox")
 end

--- a/src/scripts/DD/CreateBackground.lua
+++ b/src/scripts/DD/CreateBackground.lua
@@ -3,27 +3,27 @@ function create_background()
           background-color: rgb(0,0,0);
         ]])
         
-        DD_GUI.Right = Geyser.Label:new({
+        DD_GUI.Right = DD_GUI.new_adjustable_region({
           name = "DD_GUI.Right",
           x = "-26%", y = "0%",
           width = "26%",
           height = "100%",
-        })
-        DD_GUI.Right:setStyleSheet(DD_GUI.BackgroundCSS:getCSS())
+          padding = 0,
+        }, nil, DD_GUI.BackgroundCSS:getCSS())
         
-        DD_GUI.Top = Geyser.Label:new({
+        DD_GUI.Top = DD_GUI.new_adjustable_region({
           name = "DD_GUI.Top",
           x = "0%", y = "0%",
           width = "100%",
           height = "36%",
-        })
-        DD_GUI.Top:setStyleSheet(DD_GUI.BackgroundCSS:getCSS())
+          padding = 0,
+        }, nil, DD_GUI.BackgroundCSS:getCSS())
         
-        DD_GUI.Bottom = Geyser.Label:new({
+        DD_GUI.Bottom = DD_GUI.new_adjustable_region({
           name = "DD_GUI.Bottom",
           x = "0%", y = "94%",
           width = "74%",
           height = "6%",
-        })
-        DD_GUI.Bottom:setStyleSheet(DD_GUI.BackgroundCSS:getCSS())
+          padding = 0,
+        }, nil, DD_GUI.BackgroundCSS:getCSS(), {direct = true})
 end

--- a/src/scripts/DD/DD_GUI.GaugesBox.lua
+++ b/src/scripts/DD/DD_GUI.GaugesBox.lua
@@ -6,35 +6,42 @@ function build_gauges()
     local move    = gmcp.Char.Vitals.move
     local maxmove = gmcp.Char.Vitals.maxmove
 
-    DD_GUI.Footer = Geyser.HBox:new({
-      name = "DD_GUI.Footer",
-      x = "5%", y = "15%",
-      width = "94%", height = "70%",
-    },DD_GUI.Bottom )
+    DD_GUI.GaugesBox = DD_GUI.Bottom
+    DD_GUI.Footer = DD_GUI.Bottom
 
-    DD_GUI.FirstColumn = Geyser.VBox:new({
+    local function new_gauge_column(constraints)
+      local column = DD_GUI.new_adjustable_container and
+        DD_GUI.new_adjustable_container(constraints, DD_GUI.Bottom, {direct = true})
+      return column or Geyser.Container:new(constraints, DD_GUI.Bottom)
+    end
+
+    DD_GUI.FirstColumn = new_gauge_column({
       name = "DD_GUI.FirstColumn",
-      x = "0%", y = "0%",
-      width = "25%", height = "100%",
-    },DD_GUI.Footer)
+      x = "5%", y = "0%",
+      width = "23.5%", height = "100%",
+      padding = 0,
+    })
 
-    DD_GUI.SecondColumn = Geyser.VBox:new({
+    DD_GUI.SecondColumn = new_gauge_column({
       name = "DD_GUI.SecondColumn",
-      x = "0%", y = "0%",
-      width = "25%", height = "100%",
-    },DD_GUI.Footer)
+      x = "28.5%", y = "0%",
+      width = "23.5%", height = "100%",
+      padding = 0,
+    })
 
-    DD_GUI.ThirdColumn = Geyser.VBox:new({
+    DD_GUI.ThirdColumn = new_gauge_column({
       name = "DD_GUI.ThirdColumn",
-      x = "0%", y = "0%",
-      width = "25%", height = "100%",
-    },DD_GUI.Footer)
+      x = "52%", y = "0%",
+      width = "23.5%", height = "100%",
+      padding = 0,
+    })
 
-    DD_GUI.FourthColumn = Geyser.VBox:new({
+    DD_GUI.FourthColumn = new_gauge_column({
       name = "DD_GUI.FourthColumn",
-      x = "0%", y = "0%",
-      width = "25%", height = "100%",
-    },DD_GUI.Footer)
+      x = "75.5%", y = "0%",
+      width = "23.5%", height = "100%",
+      padding = 0,
+    })
 
 
     --Hitpoints
@@ -57,7 +64,11 @@ function build_gauges()
         padding: 10px;
     ]])
 
-    DD_GUI.Hitpoints = Geyser.Gauge:new({ name = "DD_GUI.Hitpoints", },DD_GUI.FirstColumn)
+    DD_GUI.Hitpoints = Geyser.Gauge:new({
+      name = "DD_GUI.Hitpoints",
+      x = "0%", y = "15%",
+      width = "100%", height = "70%",
+    }, DD_GUI.FirstColumn)
     DD_GUI.Hitpoints.back:setStyleSheet(DD_GUI.HitpointsGaugeBackCSS:getCSS())
     DD_GUI.Hitpoints.front:setStyleSheet(DD_GUI.HitpointsGaugeFrontCSS:getCSS())
     if (gmcp.Char.Vitals.hp > gmcp.Char.Vitals.maxhp) then
@@ -96,7 +107,11 @@ function build_gauges()
         padding: 10px;
     ]])
 
-    DD_GUI.Mana = Geyser.Gauge:new({ name = "DD_GUI.Mana", },DD_GUI.SecondColumn)
+    DD_GUI.Mana = Geyser.Gauge:new({
+      name = "DD_GUI.Mana",
+      x = "0%", y = "15%",
+      width = "100%", height = "70%",
+    }, DD_GUI.SecondColumn)
     DD_GUI.Mana.back:setStyleSheet(DD_GUI.ManaGaugeBackCSS:getCSS())
     DD_GUI.Mana.front:setStyleSheet(DD_GUI.ManaGaugeFrontCSS:getCSS())
     if (gmcp.Char.Vitals.mana > gmcp.Char.Vitals.maxmana) then
@@ -135,7 +150,11 @@ function build_gauges()
         padding: 10px;
     ]])
 
-    DD_GUI.Xp = Geyser.Gauge:new({ name = "DD_GUI.Xp", },DD_GUI.ThirdColumn)
+    DD_GUI.Xp = Geyser.Gauge:new({
+      name = "DD_GUI.Xp",
+      x = "0%", y = "15%",
+      width = "100%", height = "70%",
+    }, DD_GUI.ThirdColumn)
     DD_GUI.Xp.back:setStyleSheet(DD_GUI.XpGaugeBackCSS:getCSS())
     DD_GUI.Xp.front:setStyleSheet(DD_GUI.XpGaugeFrontCSS:getCSS())
     --DD_GUI.Xp:setValue(((gmcp.Char.Worth.xplvl * 1000) / (gmcp.Char.Worth.xplvl - gmcp.Char.Worth.xptnl)), 1000)
@@ -177,7 +196,11 @@ function build_gauges()
         padding: 10px;
     ]])
 
-    DD_GUI.Moves = Geyser.Gauge:new({ name = "DD_GUI.Moves", }, DD_GUI.FourthColumn)
+    DD_GUI.Moves = Geyser.Gauge:new({
+      name = "DD_GUI.Moves",
+      x = "0%", y = "15%",
+      width = "100%", height = "70%",
+    }, DD_GUI.FourthColumn)
     DD_GUI.Moves.back:setStyleSheet(DD_GUI.MovesGaugeBackCSS:getCSS())
     DD_GUI.Moves.front:setStyleSheet(DD_GUI.MovesGaugeFrontCSS:getCSS())
     if (gmcp.Char.Vitals.move > gmcp.Char.Vitals.maxmove) then

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -23,5 +23,11 @@ function bootstrap()
 
         if DD_GUI.raise_info_box_contents then
                 DD_GUI.raise_info_box_contents()
+                -- Geyser completes its initial z-order pass after bootstrap.
+                tempTimer(0.1, function()
+                        if DD_GUI.raise_info_box_contents then
+                                DD_GUI.raise_info_box_contents()
+                        end
+                end)
         end
 end

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -171,8 +171,12 @@ function compass.refresh()
   end
 
   -- Keep the navigation cells above the adjustable drag surface.
-  if compass.box and compass.box.raise then
-    compass.box:raise()
+  if compass.box then
+    if compass.box.raiseAll then
+      compass.box:raiseAll()
+    elseif compass.box.raise then
+      compass.box:raise()
+    end
   end
 end
 

--- a/src/triggers/DD/LoginBootstrap.lua
+++ b/src/triggers/DD/LoginBootstrap.lua
@@ -1,8 +1,35 @@
-bootstrap()
-update_affects()
-update_vitals()
-update_inventory()
-update_equipped()
-update_enemy()
-update_travel()
-echo("\nBootstrapping GUI...")
+local function dd_gui_character_data_ready()
+        return gmcp and gmcp.Char and gmcp.Char.Base and gmcp.Char.Vitals and
+                gmcp.Char.Stats and gmcp.Char.Worth and
+                gmcp.Char.Base.name and gmcp.Char.Vitals.hp
+end
+
+local attempts = 0
+
+local function dd_gui_bootstrap_when_ready()
+        DD_GUI.login_bootstrap_timer = nil
+
+        if not dd_gui_character_data_ready() then
+                attempts = attempts + 1
+                if attempts < 20 then
+                        DD_GUI.login_bootstrap_timer = tempTimer(
+                                0.5, dd_gui_bootstrap_when_ready)
+                end
+                return
+        end
+
+        bootstrap()
+        update_affects()
+        update_vitals()
+        update_inventory()
+        update_equipped()
+        update_enemy()
+        update_travel()
+        echo("\nBootstrapping GUI...")
+end
+
+if DD_GUI.login_bootstrap_timer then
+        killTimer(DD_GUI.login_bootstrap_timer)
+end
+
+DD_GUI.login_bootstrap_timer = tempTimer(0, dd_gui_bootstrap_when_ready)

--- a/src/triggers/DD/triggers.json
+++ b/src/triggers/DD/triggers.json
@@ -15,6 +15,14 @@
                         {
                             "pattern": "^Welcome to the Dragons Domain... tread carefully, adventurer!",
                             "type": "regex"
+                        },
+                        {
+                            "pattern": "Welcome Traveller, to the",
+                            "type": "regex"
+                        },
+                        {
+                            "pattern": "^Reconnecting\\.$",
+                            "type": "regex"
                         }
 
                 ]


### PR DESCRIPTION
Make the top, right, bottom, and gauge-column regions independently adjustable and persistent. Preserve content z-order so drag surfaces remain usable, keep the compass above the gauges, and rebuild the GUI automatically on DD4 reconnect/welcome banners after GMCP data is ready.