### PR TITLE
Add GUI layout reset alias

### DIFF
--- a/src/aliases/DD/aliases.json
+++ b/src/aliases/DD/aliases.json
@@ -6,5 +6,9 @@
         {
                 "name": "gcc",
                 "regex": "^gcc$"
+        },
+        {
+                "name": "resetgui",
+                "regex": "^resetgui$"
         }
 ]

--- a/src/aliases/DD/resetgui.lua
+++ b/src/aliases/DD/resetgui.lua
@@ -1,0 +1,6 @@
+if DD_GUI and type(DD_GUI.reset_layout) == "function" then
+        DD_GUI.reset_layout()
+        echo("\nDD_GUI layout reset to defaults.\n")
+else
+        echo("\nDD_GUI layout reset is unavailable until bootstrap completes.\n")
+end

--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -5,6 +5,55 @@ local function transparent_surface_css(css)
         )
 end
 
+local adjustable_drag_outline_css = [[
+        border-style: solid;
+        border-width: 2px;
+        border-color: rgba(255,255,255,220);
+]]
+
+local function set_adjustable_drag_outline(box, active)
+        if not box or not box.adjLabel then
+                return
+        end
+
+        box._dd_gui_dragging = active == true
+        local base_style = box._dd_gui_base_style or ""
+        if box._dd_gui_dragging then
+                box.adjLabel:setStyleSheet(base_style .. adjustable_drag_outline_css)
+        else
+                box.adjLabel:setStyleSheet(base_style)
+        end
+end
+
+DD_GUI.set_adjustable_drag_outline = set_adjustable_drag_outline
+
+local function register_adjustable_outline_handlers()
+        if DD_GUI.adjustable_outline_handlers_registered then
+                return
+        end
+
+        registerAnonymousEventHandler("AdjustableContainerReposition", function(
+                _, name, _, _, _, _, is_mouse_action)
+                if not is_mouse_action or not Adjustable or
+                   not Adjustable.Container or not Adjustable.Container.all then
+                        return
+                end
+
+                set_adjustable_drag_outline(
+                        Adjustable.Container.all[name], true)
+        end)
+
+        registerAnonymousEventHandler("AdjustableContainerRepositionFinish", function(
+                _, name)
+                if Adjustable and Adjustable.Container and Adjustable.Container.all then
+                        set_adjustable_drag_outline(
+                                Adjustable.Container.all[name], false)
+                end
+        end)
+
+        DD_GUI.adjustable_outline_handlers_registered = true
+end
+
 local function raise_children(container)
         if not container or not container.windows or not container.windowList then
                 return
@@ -16,6 +65,27 @@ local function raise_children(container)
                         child:raiseAll()
                 elseif child and child.raise then
                         child:raise()
+                end
+        end
+end
+
+local function raise_tab_rails()
+        local rails = {}
+        if DD_GUI.Comms and DD_GUI.Comms.tab_rail then
+                table.insert(rails, DD_GUI.Comms.tab_rail)
+        end
+        if DD_GUI.Inventory and DD_GUI.Inventory.tab_rail then
+                table.insert(rails, DD_GUI.Inventory.tab_rail)
+        end
+        if DD_GUI.Affects and DD_GUI.Affects.tab_rail then
+                table.insert(rails, DD_GUI.Affects.tab_rail)
+        end
+
+        for _, rail in ipairs(rails) do
+                if rail and rail.raiseAll then
+                        rail:raiseAll()
+                elseif rail and rail.raise then
+                        rail:raise()
                 end
         end
 end
@@ -42,6 +112,10 @@ function DD_GUI.raise_info_box_contents()
                         end
                 end
 
+                -- Console widgets can be raised during bootstrap and GMCP
+                -- refreshes. Put the tab controls back on top afterwards.
+                raise_tab_rails()
+
                 -- Gauge columns use the adjustable container directly so
                 -- their short row height does not get consumed by nested
                 -- Inside containers.
@@ -59,6 +133,9 @@ function DD_GUI.raise_info_box_contents()
                         elseif compass.box.raise then
                                 compass.box:raise()
                         end
+                end
+                if compass and compass.handle and compass.handle.raise then
+                        compass.handle:raise()
                 end
                 return
         end
@@ -83,6 +160,7 @@ end
 
 function DD_GUI.new_adjustable_container(cons, parent, options)
         if Adjustable and Adjustable.Container then
+                register_adjustable_outline_handlers()
                 cons = cons or {}
                 cons.padding = cons.padding or 4
                 cons.autoLoad = true
@@ -101,10 +179,12 @@ function DD_GUI.new_adjustable_container(cons, parent, options)
 
                 local box = Adjustable.Container:new(cons, parent)
                 box.adjLabel:echo("")
+                box._dd_gui_base_style = box.adjLabelstyle or ""
                 box.exitLabel:hide()
                 box.minimizeLabel:hide()
                 box.setStyleSheet = function(self, css)
-                        self.adjLabel:setStyleSheet(transparent_surface_css(css))
+                        self._dd_gui_base_style = transparent_surface_css(css)
+                        set_adjustable_drag_outline(self, self._dd_gui_dragging)
                 end
                 if options and options.direct then
                         box.goInside = false
@@ -122,7 +202,8 @@ function DD_GUI.new_adjustable_region(cons, parent, css, options)
                 -- Keep the region background on the drag layer itself.  The
                 -- content is raised afterwards, so this never tints it.
                 if box.adjLabel and box.adjLabel.setStyleSheet then
-                        box.adjLabel:setStyleSheet(css or "")
+                        box._dd_gui_base_style = css or ""
+                        set_adjustable_drag_outline(box, false)
                 end
                 box._dd_gui_region = true
                 return box

--- a/src/scripts/DD/ResetLayout.lua
+++ b/src/scripts/DD/ResetLayout.lua
@@ -1,0 +1,87 @@
+DD_GUI = DD_GUI or {}
+
+local function reset_adjustable_box(box, x, y, width, height)
+        if not box then
+                return
+        end
+
+        -- User resizing can leave a container locked, minimized, or attached
+        -- to another border. Clear those states before applying the defaults.
+        if type(box.disconnect) == "function" then
+                pcall(function() box:disconnect() end)
+        end
+        if type(box.detach) == "function" then
+                pcall(function() box:detach() end)
+        end
+        if type(box.restore) == "function" then
+                pcall(function() box:restore() end)
+        end
+        if type(box.unlockContainer) == "function" then
+                pcall(function() box:unlockContainer() end)
+        end
+        if type(box.show) == "function" then
+                box:show()
+        end
+
+        box:move(x, y)
+        box:resize(width, height)
+
+        if DD_GUI.set_adjustable_drag_outline then
+                DD_GUI.set_adjustable_drag_outline(box, false)
+        end
+        if type(box.save) == "function" then
+                box:save()
+        end
+end
+
+function DD_GUI.reset_layout()
+        local defaults = {
+                { ui and ui.mainconsole_container, "4%", "38%", "75%", "56%" },
+                { DD_GUI.Right, "-26%", "0%", "26%", "100%" },
+                { DD_GUI.Top, "0%", "0%", "100%", "36%" },
+                { DD_GUI.Bottom, "0%", "94%", "74%", "6%" },
+                { DD_GUI.FirstColumn, "5%", "0%", "23.5%", "100%" },
+                { DD_GUI.SecondColumn, "28.5%", "0%", "23.5%", "100%" },
+                { DD_GUI.ThirdColumn, "52%", "0%", "23.5%", "100%" },
+                { DD_GUI.FourthColumn, "75.5%", "0%", "23.5%", "100%" },
+                { DD_GUI.EnemyBox, "4%", "17%", "23%", "83%" },
+                { DD_GUI.MapBox, "27%", "17%", "24%", "83%" },
+                { DD_GUI.CharsheetBox, "51%", "17%", "23%", "83%" },
+                { DD_GUI.ChannelBox, "74%", "17%", "23%", "83%" },
+                { DD_GUI.InventoryBox, "0%", "36%", "89%", "34%" },
+                { DD_GUI.AffectBox, "0%", "70%", "89%", "30%" },
+        }
+
+        for _, default_box in ipairs(defaults) do
+                reset_adjustable_box(
+                        default_box[1],
+                        default_box[2],
+                        default_box[3],
+                        default_box[4],
+                        default_box[5]
+                )
+        end
+
+        if compass and compass.back then
+                reset_adjustable_box(compass.back, "60%", "82%", "8%", "8%")
+
+                -- Keep the default compass square even when the terminal is
+                -- not square. Its width remains responsive while its height
+                -- is stored in pixels to preserve the intended aspect ratio.
+                if type(compass.back.get_width) == "function" then
+                        compass.back:resize("8%", compass.back:get_width())
+                        if type(compass.back.save) == "function" then
+                                compass.back:save()
+                        end
+                end
+        end
+
+        if ui and ui.updateBorderSizes then
+                ui.window_width = nil
+                ui.updateBorderSizes()
+        end
+
+        if DD_GUI.raise_info_box_contents then
+                DD_GUI.raise_info_box_contents()
+        end
+end

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -8,6 +8,64 @@ local function compass_background_css(width)
   ]]
 end
 
+function dd_gui_compass_handle_click(event)
+  if not event or event.button ~= "LeftButton" or
+     not compass or not compass.back then
+    return
+  end
+
+  local mouse_x, mouse_y = getMousePosition()
+  compass.handle_drag = {
+    mouse_x = mouse_x,
+    mouse_y = mouse_y,
+    x = compass.back:get_x(),
+    y = compass.back:get_y(),
+    width = compass.back:get_width(),
+    height = compass.back:get_height(),
+  }
+
+  if DD_GUI.set_adjustable_drag_outline then
+    DD_GUI.set_adjustable_drag_outline(compass.back, true)
+  end
+  compass.handle:setCursor("ClosedHand")
+end
+
+function dd_gui_compass_handle_move(event)
+  if not compass or not compass.back or not compass.handle_drag then
+    return
+  end
+
+  local mouse_x, mouse_y = getMousePosition()
+  local drag = compass.handle_drag
+  local win_width, win_height = getMainWindowSize()
+  local x = math.max(0, math.min(win_width - drag.width,
+    drag.x + mouse_x - drag.mouse_x))
+  local y = math.max(0, math.min(win_height - drag.height,
+    drag.y + mouse_y - drag.mouse_y))
+
+  compass.back:move(
+    string.format("%.5f%%", (x / win_width) * 100),
+    string.format("%.5f%%", (y / win_height) * 100))
+end
+
+function dd_gui_compass_handle_release(event)
+  if not event or event.button ~= "LeftButton" or
+     not compass or not compass.back then
+    return
+  end
+
+  compass.handle_drag = nil
+  if DD_GUI.set_adjustable_drag_outline then
+    DD_GUI.set_adjustable_drag_outline(compass.back, false)
+  end
+  if compass.handle then
+    compass.handle:setCursor("OpenHand")
+  end
+  if compass.back.save then
+    compass.back:save()
+  end
+end
+
 function build_compass()
 
 local mw, mh = getMainWindowSize()
@@ -27,6 +85,13 @@ local mw, mh = getMainWindowSize()
 
   local compass_layout_path = ms_path .. "/layout/compass.back.lua"
   local saved_layout = io.exists and io.exists(compass_layout_path)
+
+  -- Vitals can rebuild the compass after the initial bootstrap. Remove the
+  -- previous native widget tree so its drag surface cannot remain visible or
+  -- steal mouse events from the current handle.
+  if compass and compass.back and compass.back.delete then
+    compass.back:delete()
+  end
 
   compass = {
     dirs = {"n","u","w","look","e","s","d"},
@@ -60,6 +125,29 @@ local mw, mh = getMainWindowSize()
 
   local compass_parent = compass.back
   if compass.back._dd_gui_adjustable then
+    -- The adjustable container's native drag label is covered by the
+    -- compass contents. Keep a full-width top rail above those contents and
+    -- forward its mouse events to the native adjustable handlers.
+    local go_inside = compass.back.goInside
+    compass.back.goInside = false
+    compass.handle = Geyser.Label:new({
+      name = "compass.handle",
+      x = 0,
+      y = 0,
+      width = "100%",
+      height = 14,
+    }, compass.back)
+    compass.back.goInside = go_inside
+    compass.handle:setStyleSheet([[
+      background-color: rgba(0,0,0,0);
+      border: 0px;
+      margin: 0px;
+    ]])
+    compass.handle:echo("")
+    compass.handle:setClickCallback("dd_gui_compass_handle_click")
+    compass.handle:setReleaseCallback("dd_gui_compass_handle_release")
+    compass.handle:setMoveCallback("dd_gui_compass_handle_move")
+
     compass.surface = Geyser.Label:new({
       name = "compass.surface",
       x = 0,
@@ -177,6 +265,10 @@ function compass.refresh()
     elseif compass.box.raise then
       compass.box:raise()
     end
+  end
+
+  if compass.handle and compass.handle.raise then
+    compass.handle:raise()
   end
 end
 

--- a/src/scripts/DD/scripts.json
+++ b/src/scripts/DD/scripts.json
@@ -9,6 +9,9 @@
         "name": "BoxesDefinitions"
   },
   {
+        "name": "ResetLayout"
+  },
+  {
         "name": "ImageFit"
   },
   {


### PR DESCRIPTION
Adds resetgui to restore adjustable GUI regions, compass geometry, and Mudlet borders to defaults. Retains the compass drag outline and tab z-order fixes. Built, uploaded, installed in live Mudlet, and verified.