### PR TITLE
Hide adjustable window controls

### DIFF
--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -27,6 +27,21 @@ end
 
 DD_GUI.set_adjustable_drag_outline = set_adjustable_drag_outline
 
+local function hide_adjustable_controls(box)
+        if not box then
+                return
+        end
+
+        if box.exitLabel and box.exitLabel.hide then
+                box.exitLabel:hide()
+        end
+        if box.minimizeLabel and box.minimizeLabel.hide then
+                box.minimizeLabel:hide()
+        end
+end
+
+DD_GUI.hide_adjustable_controls = hide_adjustable_controls
+
 local function register_adjustable_outline_handlers()
         if DD_GUI.adjustable_outline_handlers_registered then
                 return
@@ -180,8 +195,7 @@ function DD_GUI.new_adjustable_container(cons, parent, options)
                 local box = Adjustable.Container:new(cons, parent)
                 box.adjLabel:echo("")
                 box._dd_gui_base_style = box.adjLabelstyle or ""
-                box.exitLabel:hide()
-                box.minimizeLabel:hide()
+                hide_adjustable_controls(box)
                 box.setStyleSheet = function(self, css)
                         self._dd_gui_base_style = transparent_surface_css(css)
                         set_adjustable_drag_outline(self, self._dd_gui_dragging)

--- a/src/scripts/DD/ResetLayout.lua
+++ b/src/scripts/DD/ResetLayout.lua
@@ -22,6 +22,9 @@ local function reset_adjustable_box(box, x, y, width, height)
         if type(box.show) == "function" then
                 box:show()
         end
+        if DD_GUI.hide_adjustable_controls then
+                DD_GUI.hide_adjustable_controls(box)
+        end
 
         box:move(x, y)
         box:resize(width, height)


### PR DESCRIPTION
Fixes the adjustable-container minimize and close labels becoming visible after resetgui. The controls are now hidden through a shared helper both at construction and after containers are shown. Built, uploaded, reinstalled in live Mudlet, and verified after resetgui with zero visible control marks.