### PR TITLE
Redesign GUI with classic Gold Box styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ To uninstall the GUI, you can simply type:
 
 `lua uninstallPackage("DD_GUI")`, use the built-in `ugui` alias, or use Mudlet's graphical package manager.
 
+## Layout controls
+
+The interface starts with its movable surfaces locked so normal tabs, compass
+buttons, and console scrollback receive mouse input. Use `layoutgui` to toggle
+layout editing, or `layoutgui on` and `layoutgui off` to choose the state
+explicitly. Leaving layout mode saves the current per-profile positions and
+sizes. Use `resetgui` to restore every region to its default geometry.
+
 
 ## Installation (devs)
 

--- a/src/aliases/DD/aliases.json
+++ b/src/aliases/DD/aliases.json
@@ -10,5 +10,9 @@
         {
                 "name": "resetgui",
                 "regex": "^resetgui$"
+        },
+        {
+                "name": "layoutgui",
+                "regex": "^layoutgui(?:\\s+(on|off))?$"
         }
 ]

--- a/src/aliases/DD/layoutgui.lua
+++ b/src/aliases/DD/layoutgui.lua
@@ -1,0 +1,5 @@
+if DD_GUI and DD_GUI.Layout and type(DD_GUI.Layout.command) == "function" then
+        DD_GUI.Layout:command(matches[2])
+else
+        echo("\nDD_GUI layout mode is unavailable until bootstrap completes.\n")
+end

--- a/src/scripts/DD/AffectsConsole.lua
+++ b/src/scripts/DD/AffectsConsole.lua
@@ -9,4 +9,7 @@ function build_affects_console()
       scrollBar = true,
       fontSize = 10,
     }, DD_GUI.AffectBox)
+    if DD_GUI.Theme then
+      DD_GUI.Theme:style_console(AffectsConsole, 10)
+    end
 end

--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -5,11 +5,40 @@ local function transparent_surface_css(css)
         )
 end
 
-local adjustable_drag_outline_css = [[
-        border-style: solid;
-        border-width: 2px;
-        border-color: rgba(255,255,255,220);
-]]
+local function adjustable_state_css(box)
+        local theme = DD_GUI and DD_GUI.Theme
+        local layout_enabled = DD_GUI and DD_GUI.Layout and
+                DD_GUI.Layout.enabled
+
+        if theme and layout_enabled then
+                return theme:layout_outline_css(box._dd_gui_dragging)
+        end
+
+        if box._dd_gui_dragging then
+                if theme then
+                        return theme:layout_outline_css(true)
+                end
+                return [[
+                        border-style: solid;
+                        border-width: 2px;
+                        border-color: rgba(255,255,255,220);
+                ]]
+        end
+
+        return ""
+end
+
+local function refresh_adjustable_style(box)
+        if not box or not box.adjLabel then
+                return
+        end
+
+        box.adjLabel:setStyleSheet(
+                (box._dd_gui_base_style or "") .. adjustable_state_css(box)
+        )
+end
+
+DD_GUI.refresh_adjustable_style = refresh_adjustable_style
 
 local function set_adjustable_drag_outline(box, active)
         if not box or not box.adjLabel then
@@ -17,12 +46,7 @@ local function set_adjustable_drag_outline(box, active)
         end
 
         box._dd_gui_dragging = active == true
-        local base_style = box._dd_gui_base_style or ""
-        if box._dd_gui_dragging then
-                box.adjLabel:setStyleSheet(base_style .. adjustable_drag_outline_css)
-        else
-                box.adjLabel:setStyleSheet(base_style)
-        end
+        refresh_adjustable_style(box)
 end
 
 DD_GUI.set_adjustable_drag_outline = set_adjustable_drag_outline
@@ -198,12 +222,15 @@ function DD_GUI.new_adjustable_container(cons, parent, options)
                 hide_adjustable_controls(box)
                 box.setStyleSheet = function(self, css)
                         self._dd_gui_base_style = transparent_surface_css(css)
-                        set_adjustable_drag_outline(self, self._dd_gui_dragging)
+                        refresh_adjustable_style(self)
                 end
                 if options and options.direct then
                         box.goInside = false
                 end
                 box._dd_gui_adjustable = true
+                if DD_GUI.Layout and DD_GUI.Layout.apply_box then
+                        DD_GUI.Layout:apply_box(box)
+                end
                 return box
         end
 
@@ -217,7 +244,8 @@ function DD_GUI.new_adjustable_region(cons, parent, css, options)
                 -- content is raised afterwards, so this never tints it.
                 if box.adjLabel and box.adjLabel.setStyleSheet then
                         box._dd_gui_base_style = css or ""
-                        set_adjustable_drag_outline(box, false)
+                        box._dd_gui_dragging = false
+                        refresh_adjustable_style(box)
                 end
                 box._dd_gui_region = true
                 return box
@@ -239,24 +267,17 @@ local function new_info_box(cons, parent)
         return Geyser.Label:new(cons, parent)
 end
 function define_boxes()
-
-        DD_GUI.BoxCSS = CSSMan.new([[
+        local box_css = DD_GUI.Theme and DD_GUI.Theme:panel_css() or [[
           background-color: rgba(0,0,0,100);
           border-style: solid;
-          border-width: 0px;
+          border-width: 1px;
           border-radius: 0px;
-          border-color: red;
+          border-color: grey;
           margin: 1px;
-        ]])
-        
-        DD_GUI.EnemyBoxCSS = CSSMan.new([[
-          background-color: rgba(0,0,0,100);
-          border-style: solid;
-          border-width: 2px;
-          border-radius: 0px;
-          border-color: red;
-          margin: 0px;
-        ]])
+        ]]
+
+        DD_GUI.BoxCSS = CSSMan.new(box_css)
+        DD_GUI.EnemyBoxCSS = CSSMan.new(box_css)
         
         DD_GUI.EnemyBox = new_info_box({
           name = "DD_GUI.EnemyBox",

--- a/src/scripts/DD/ChannelConsole.lua
+++ b/src/scripts/DD/ChannelConsole.lua
@@ -392,6 +392,13 @@ function DD_GUI.Comms:comm_channel(comm)
 end
 
 function DD_GUI.Comms:tab_css(key)
+        if DD_GUI.Theme then
+                return DD_GUI.Theme:tab_css(
+                        key == self.current_tab,
+                        key == self.drag_target and key ~= self.drag_source
+                )
+        end
+
         if key == self.current_tab then
                 return [[
                         background-color: rgba(0,120,135,190);
@@ -429,7 +436,7 @@ function DD_GUI.Comms:style_tab(key)
 
         label:setStyleSheet(self:tab_css(key))
         if key == self.current_tab then
-                label:echo(self:tab_label(key), "white", "c")
+                label:echo(self:tab_label(key), "black", "c")
         else
                 label:echo(self:tab_label(key), "<" .. self:rgb_string(key) .. ">", "c")
         end
@@ -492,8 +499,12 @@ function DD_GUI.Comms:create_tab_button(key)
                 height = "10%",
         }, self.tab_rail)
 
-        tab:setFontSize(8)
-        tab:setBold(1)
+        if DD_GUI.Theme then
+                DD_GUI.Theme:style_label(tab, 8, true)
+        else
+                tab:setFontSize(8)
+                tab:setBold(1)
+        end
         tab:setClickCallback("dd_comms_tab_click", key)
         tab:setReleaseCallback("dd_comms_tab_release", key)
         tab:setMoveCallback("dd_comms_tab_move", key)
@@ -537,6 +548,10 @@ function DD_GUI.Comms:create_console(key)
                 scrollBar = true,
                 fontSize = 8,
         }, self.console_stack)
+
+        if DD_GUI.Theme then
+                DD_GUI.Theme:style_console(console, 8)
+        end
 
         if console.setBufferSize then
                 console:setBufferSize(100000, 1000)

--- a/src/scripts/DD/CharsheetConsole.lua
+++ b/src/scripts/DD/CharsheetConsole.lua
@@ -10,10 +10,25 @@ function build_charsheet_console()
       scrollBar = false,
       fontSize = 10,
     }, DD_GUI.CharsheetBox)
+    if DD_GUI.Theme then
+      DD_GUI.Theme:style_console(CharsheetConsole, 10)
+    end
+
+    CharsheetImageFrame = Geyser.Label:new({
+      name="CharsheetImageFrame",
+      x = "0%", y = "1%",
+      width="105px",
+      height="130px",
+    }, CharsheetConsole)
+    CharsheetImageFrame:setStyleSheet(DD_GUI.Theme and
+      DD_GUI.Theme:image_frame_css() or [[border: 1px solid grey;]])
+    if DD_GUI.set_widget_clickthrough then
+      DD_GUI.set_widget_clickthrough(CharsheetImageFrame, true)
+    end
 
     CharsheetPFPConsole = Geyser.MiniConsole:new({
       name="CharsheetPFPConsole",
-      x = "0%", y = "2%",
+      x = "3px", y = "4px",
       width="99px",
       height="124px",
       autoWrap = false,
@@ -21,6 +36,9 @@ function build_charsheet_console()
       scrollBar = false,
       fontSize = 10,
     }, CharsheetConsole)
+    if DD_GUI.Theme then
+      DD_GUI.Theme:style_console(CharsheetPFPConsole, 10)
+    end
 
     local chsex_string = 'male'
 
@@ -49,6 +67,9 @@ function build_charsheet_console()
       CharsheetPFPConsole,
       CharsheetConsole,
       pfp_path,
-      { fallback = { width = 160, height = 200 } }
+      {
+        fallback = { width = 160, height = 200 },
+        frame = CharsheetImageFrame,
+      }
     )
 end

--- a/src/scripts/DD/CreateBackground.lua
+++ b/src/scripts/DD/CreateBackground.lua
@@ -1,7 +1,13 @@
 function create_background()
-        DD_GUI.BackgroundCSS = CSSMan.new([[
+        local theme = DD_GUI.Theme
+        local background_css = theme and theme:band_css() or [[
           background-color: rgb(0,0,0);
-        ]])
+        ]]
+        local right_css = theme and theme:band_css("left") or background_css
+        local top_css = theme and theme:band_css("bottom") or background_css
+        local bottom_css = theme and theme:band_css("top") or background_css
+
+        DD_GUI.BackgroundCSS = CSSMan.new(background_css)
         
         DD_GUI.Right = DD_GUI.new_adjustable_region({
           name = "DD_GUI.Right",
@@ -9,7 +15,7 @@ function create_background()
           width = "26%",
           height = "100%",
           padding = 0,
-        }, nil, DD_GUI.BackgroundCSS:getCSS())
+        }, nil, right_css)
         
         DD_GUI.Top = DD_GUI.new_adjustable_region({
           name = "DD_GUI.Top",
@@ -17,7 +23,7 @@ function create_background()
           width = "100%",
           height = "36%",
           padding = 0,
-        }, nil, DD_GUI.BackgroundCSS:getCSS())
+        }, nil, top_css)
         
         DD_GUI.Bottom = DD_GUI.new_adjustable_region({
           name = "DD_GUI.Bottom",
@@ -25,5 +31,5 @@ function create_background()
           width = "74%",
           height = "6%",
           padding = 0,
-        }, nil, DD_GUI.BackgroundCSS:getCSS(), {direct = true})
+        }, nil, bottom_css, {direct = true})
 end

--- a/src/scripts/DD/CreateBackground.lua
+++ b/src/scripts/DD/CreateBackground.lua
@@ -3,9 +3,6 @@ function create_background()
         local background_css = theme and theme:band_css() or [[
           background-color: rgb(0,0,0);
         ]]
-        local right_css = theme and theme:band_css("left") or background_css
-        local top_css = theme and theme:band_css("bottom") or background_css
-        local bottom_css = theme and theme:band_css("top") or background_css
 
         DD_GUI.BackgroundCSS = CSSMan.new(background_css)
         
@@ -15,7 +12,7 @@ function create_background()
           width = "26%",
           height = "100%",
           padding = 0,
-        }, nil, right_css)
+        }, nil, background_css)
         
         DD_GUI.Top = DD_GUI.new_adjustable_region({
           name = "DD_GUI.Top",
@@ -23,7 +20,7 @@ function create_background()
           width = "100%",
           height = "36%",
           padding = 0,
-        }, nil, top_css)
+        }, nil, background_css)
         
         DD_GUI.Bottom = DD_GUI.new_adjustable_region({
           name = "DD_GUI.Bottom",
@@ -31,5 +28,5 @@ function create_background()
           width = "74%",
           height = "6%",
           padding = 0,
-        }, nil, bottom_css, {direct = true})
+        }, nil, background_css, {direct = true})
 end

--- a/src/scripts/DD/DD_GUI.AffectsBox.lua
+++ b/src/scripts/DD/DD_GUI.AffectsBox.lua
@@ -2,6 +2,10 @@ DD_GUI = DD_GUI or {}
 DD_GUI.Affects = DD_GUI.Affects or {}
 
 function DD_GUI.Affects:tab_css()
+        if DD_GUI.Theme then
+                return DD_GUI.Theme:tab_css(true)
+        end
+
         return [[
                 background-color: rgba(0,120,135,190);
                 border-style: solid;
@@ -32,10 +36,14 @@ function DD_GUI.Affects:build_tabs()
                 width = "100%",
                 height = "100%",
         }, self.tab_rail)
-        self.tab_button:setFontSize(8)
-        self.tab_button:setBold(1)
+        if DD_GUI.Theme then
+                DD_GUI.Theme:style_label(self.tab_button, 8, true)
+        else
+                self.tab_button:setFontSize(8)
+                self.tab_button:setBold(1)
+        end
         self.tab_button:setStyleSheet(self:tab_css())
-        self.tab_button:echo("Affects", "white", "c")
+        self.tab_button:echo("Affects", "black", "c")
 end
 
 function build_affects_box()

--- a/src/scripts/DD/DD_GUI.GaugesBox.lua
+++ b/src/scripts/DD/DD_GUI.GaugesBox.lua
@@ -1,10 +1,109 @@
+local function gauge_value(value, maximum)
+    value = tonumber(value) or 0
+    maximum = tonumber(maximum) or 0
+    if maximum <= 0 then
+      return 0
+    end
+    return math.max(0, math.min(1000, (value * 1000) / maximum))
+end
+
+local function delete_existing_widget(widget)
+    if not widget then
+      return
+    end
+
+    if type(widget.delete) == "function" then
+      pcall(function() widget:delete() end)
+    elseif widget.name and type(deleteLabel) == "function" then
+      pcall(deleteLabel, widget.name)
+    end
+end
+
+local function add_gauge_segments(gauge, name)
+    for index = 1, 9 do
+      local separator = Geyser.Label:new({
+        name = name .. ".Segment." .. index,
+        x = tostring(index * 10) .. "%",
+        y = 0,
+        width = 1,
+        height = "100%",
+      }, gauge)
+      separator:setStyleSheet([[
+        background-color: rgba(5,8,18,185);
+        border: 0px;
+        margin: 0px;
+      ]])
+      if DD_GUI.set_widget_clickthrough then
+        DD_GUI.set_widget_clickthrough(separator, true)
+      end
+    end
+end
+
+local function new_status_gauge(name, parent, label_text, color, value, maximum)
+    local theme = DD_GUI.Theme
+    local gauge = Geyser.Gauge:new({
+      name = name,
+      x = "0%", y = "15%",
+      width = "100%", height = "70%",
+    }, parent)
+
+    gauge.back:setStyleSheet(theme and theme:gauge_back_css() or [[
+      background-color: rgb(30,30,30);
+      border: 1px solid grey;
+      border-radius: 0px;
+    ]])
+    gauge.front:setStyleSheet(theme and theme:gauge_front_css(color) or [[
+      background-color: grey;
+      border: 1px solid black;
+      border-radius: 0px;
+    ]])
+    gauge:setValue(gauge_value(value, maximum), 1000)
+    add_gauge_segments(gauge, name)
+
+    local label = Geyser.Label:new({
+      name = name .. ".Label",
+      x = 0, y = 0,
+      width = "100%", height = "100%",
+    }, gauge)
+    label:setColor(0, 0, 0, 0)
+    label:setFgColor("white")
+    label:echo(label_text, "white", "c")
+    if theme then
+      theme:style_label(label, 9, true)
+    else
+      label:setFontSize(9)
+      label:setBold(1)
+    end
+    if DD_GUI.set_widget_clickthrough then
+      DD_GUI.set_widget_clickthrough(label, true)
+    end
+
+    return gauge, label
+end
+
 function build_gauges()
-    local hp      = gmcp.Char.Vitals.hp
-    local maxhp   = gmcp.Char.Vitals.maxhp
-    local mana    = gmcp.Char.Vitals.mana
-    local maxmana = gmcp.Char.Vitals.maxmana
-    local move    = gmcp.Char.Vitals.move
-    local maxmove = gmcp.Char.Vitals.maxmove
+    -- Package upgrades used shorter legacy label names. Remove both those
+    -- labels and the previous gauge tree before rebuilding so an in-session
+    -- update cannot leave old text beneath the segmented bars.
+    if type(deleteLabel) == "function" then
+      for _, legacy_name in ipairs({
+        "HitpointsLabel", "ManaLabel", "XpLabel", "MovesLabel",
+      }) do
+        pcall(deleteLabel, legacy_name)
+      end
+    end
+    delete_existing_widget(HitpointsLabel)
+    delete_existing_widget(ManaLabel)
+    delete_existing_widget(XpLabel)
+    delete_existing_widget(MovesLabel)
+    delete_existing_widget(DD_GUI.Hitpoints)
+    delete_existing_widget(DD_GUI.Mana)
+    delete_existing_widget(DD_GUI.Xp)
+    delete_existing_widget(DD_GUI.Moves)
+    delete_existing_widget(DD_GUI.FirstColumn)
+    delete_existing_widget(DD_GUI.SecondColumn)
+    delete_existing_widget(DD_GUI.ThirdColumn)
+    delete_existing_widget(DD_GUI.FourthColumn)
 
     DD_GUI.GaugesBox = DD_GUI.Bottom
     DD_GUI.Footer = DD_GUI.Bottom
@@ -43,180 +142,30 @@ function build_gauges()
       padding = 0,
     })
 
+    local colors = DD_GUI.Theme and DD_GUI.Theme.colors or {
+      hp = "rgb(181,42,48)",
+      mana = "rgb(46,92,184)",
+      xp = "rgb(188,145,43)",
+      moves = "rgb(38,139,126)",
+    }
 
-    --Hitpoints
+    DD_GUI.Hitpoints, HitpointsLabel = new_status_gauge(
+      "DD_GUI.Hitpoints", DD_GUI.FirstColumn, "HITS", colors.hp,
+      gmcp.Char.Vitals.hp, gmcp.Char.Vitals.maxhp)
 
-    DD_GUI.HitpointsGaugeBackCSS = CSSMan.new([[
-        background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #bd3333, stop: 0.1 #bd2020, stop: 0.49 #990000, stop: 0.5 #700000, stop: 1 #990000);
-        border-width: 1px;
-        border-color: black;
-        border-style: solid;
-        border-radius: 7;
-        padding: 10px;
-    ]])
+    DD_GUI.Mana, ManaLabel = new_status_gauge(
+      "DD_GUI.Mana", DD_GUI.SecondColumn, "MANA", colors.mana,
+      gmcp.Char.Vitals.mana, gmcp.Char.Vitals.maxmana)
 
-    DD_GUI.HitpointsGaugeFrontCSS = CSSMan.new([[
-        background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #f04141, stop: 0.1 #ef2929, stop: 0.49 #cc0000, stop: 0.5 #a40000, stop: 1 #cc0000);
-        border-top: 1px black solid;
-        border-left: 1px black solid;
-        border-bottom: 1px black solid;
-        border-radius: 7;
-        padding: 10px;
-    ]])
+    local xplvl = tonumber(gmcp.Char.Worth.xplvl) or 0
+    local xptnl = tonumber(gmcp.Char.Worth.xptnl) or 0
+    local xp_value = xptnl > 0 and math.max(0, xplvl - xptnl) or 1
+    local xp_maximum = xptnl > 0 and xplvl or 1
+    DD_GUI.Xp, XpLabel = new_status_gauge(
+      "DD_GUI.Xp", DD_GUI.ThirdColumn, "XP", colors.xp,
+      xp_value, xp_maximum)
 
-    DD_GUI.Hitpoints = Geyser.Gauge:new({
-      name = "DD_GUI.Hitpoints",
-      x = "0%", y = "15%",
-      width = "100%", height = "70%",
-    }, DD_GUI.FirstColumn)
-    DD_GUI.Hitpoints.back:setStyleSheet(DD_GUI.HitpointsGaugeBackCSS:getCSS())
-    DD_GUI.Hitpoints.front:setStyleSheet(DD_GUI.HitpointsGaugeFrontCSS:getCSS())
-    if (gmcp.Char.Vitals.hp > gmcp.Char.Vitals.maxhp) then
-      hp = maxhp
-    end
-    DD_GUI.Hitpoints:setValue(((hp * 1000) / maxhp),1000)
-
-    HitpointsLabel = Geyser.Label:new({
-      name = "HitpointsLabel",
-      x = 0, y = "15%",
-      width = "50%", height = "70%",
-      fgColor = "black",
-      message = [[&nbsp;Hits]]
-    }, DD_GUI.Hitpoints )
-    HitpointsLabel:setColor(0,0,0,0)
-    HitpointsLabel:setFgColor("Grey")
-    HitpointsLabel:setFontSize(10)
-
-    --Mana
-
-    DD_GUI.ManaGaugeBackCSS = CSSMan.new([[
-        background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #3833bd, stop: 0.1 #2020bd, stop: 0.49 #000399, stop: 0.5 #000470, stop: 1 #000399);
-        border-top: 1px black solid;
-        border-left: 1px black solid;
-        border-bottom: 1px black solid;
-        border-radius: 7;
-        padding: 10px;
-    ]])
-
-    DD_GUI.ManaGaugeFrontCSS = CSSMan.new([[
-        background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #4147f0, stop: 0.1 #2929f0, stop: 0.49 #0007cc, stop: 0.5 #0000a3, stop: 1 #0007cc);
-        border-width: 1px;
-        border-color: black;
-        border-style: solid;
-        border-radius: 7;
-        padding: 10px;
-    ]])
-
-    DD_GUI.Mana = Geyser.Gauge:new({
-      name = "DD_GUI.Mana",
-      x = "0%", y = "15%",
-      width = "100%", height = "70%",
-    }, DD_GUI.SecondColumn)
-    DD_GUI.Mana.back:setStyleSheet(DD_GUI.ManaGaugeBackCSS:getCSS())
-    DD_GUI.Mana.front:setStyleSheet(DD_GUI.ManaGaugeFrontCSS:getCSS())
-    if (gmcp.Char.Vitals.mana > gmcp.Char.Vitals.maxmana) then
-      mana = maxmana
-    end
-    DD_GUI.Mana:setValue(((mana * 1000) / maxmana),1000)
-
-    ManaLabel = Geyser.Label:new({
-      name = "ManaLabel",
-      x = 0, y = "15%",
-      width = "50%", height = "70%",
-      fgColor = "Black",
-      message = [[&nbsp;Mana]]
-    }, DD_GUI.Mana )
-    ManaLabel:setColor(0,0,0,0)
-    ManaLabel:setFgColor("Grey")
-    ManaLabel:setFontSize(10)
-
-    -- XP
-
-    DD_GUI.XpGaugeBackCSS = CSSMan.new([[
-        background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #78bd33, stop: 0.1 #6ebd20, stop: 0.49 #4c9900, stop: 0.5 #387000, stop: 1 #4c9900);
-        border-top: 1px black solid;
-        border-left: 1px black solid;
-        border-bottom: 1px black solid;
-        border-radius: 7;
-        padding: 10px;
-    ]])
-
-    DD_GUI.XpGaugeFrontCSS = CSSMan.new([[
-        background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #98f041, stop: 0.1 #8cf029, stop: 0.49 #66cc00, stop: 0.5 #52a300, stop: 1 #66cc00);
-        border-width: 1px;
-        border-color: black;
-        border-style: solid;
-        border-radius: 7;
-        padding: 10px;
-    ]])
-
-    DD_GUI.Xp = Geyser.Gauge:new({
-      name = "DD_GUI.Xp",
-      x = "0%", y = "15%",
-      width = "100%", height = "70%",
-    }, DD_GUI.ThirdColumn)
-    DD_GUI.Xp.back:setStyleSheet(DD_GUI.XpGaugeBackCSS:getCSS())
-    DD_GUI.Xp.front:setStyleSheet(DD_GUI.XpGaugeFrontCSS:getCSS())
-    --DD_GUI.Xp:setValue(((gmcp.Char.Worth.xplvl * 1000) / (gmcp.Char.Worth.xplvl - gmcp.Char.Worth.xptnl)), 1000)
-
-    if (tonumber(gmcp.Char.Worth.xptnl) > 0 ) then
-      DD_GUI.Xp:setValue((((gmcp.Char.Worth.xplvl - gmcp.Char.Worth.xptnl) * 1000) / gmcp.Char.Worth.xplvl), 1000)
-    else
-      DD_GUI.Xp:setValue(1000, 1000)
-    end
-
-    XpLabel = Geyser.Label:new({
-      name = "XpLabel",
-      x = 0, y = "15%",
-      width = "50%", height = "70%",
-      fgColor = "Black",
-      message = [[&nbsp;Xp]]
-    }, DD_GUI.Xp )
-    XpLabel:setColor(0,0,0,0)
-    XpLabel:setFgColor("White")
-    XpLabel:setFontSize(10)
-
-    --Moves
-
-    DD_GUI.MovesGaugeBackCSS = CSSMan.new([[
-        background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #33bdb4, stop: 0.1 #20bdb0, stop: 0.49 #009996, stop: 0.5 #00706e, stop: 1 #009996);
-        border-top: 1px black solid;
-        border-left: 1px black solid;
-        border-bottom: 1px black solid;
-        border-radius: 7;
-        padding: 10px;
-    ]])
-
-    DD_GUI.MovesGaugeFrontCSS = CSSMan.new([[
-        background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #41f0d6, stop: 0.1 #29f0df, stop: 0.49 #00ccc9, stop: 0.5 #009ea3, stop: 1 #00ccc9);
-        border-width: 1px;
-        border-color: black;
-        border-style: solid;
-        border-radius: 7;
-        padding: 10px;
-    ]])
-
-    DD_GUI.Moves = Geyser.Gauge:new({
-      name = "DD_GUI.Moves",
-      x = "0%", y = "15%",
-      width = "100%", height = "70%",
-    }, DD_GUI.FourthColumn)
-    DD_GUI.Moves.back:setStyleSheet(DD_GUI.MovesGaugeBackCSS:getCSS())
-    DD_GUI.Moves.front:setStyleSheet(DD_GUI.MovesGaugeFrontCSS:getCSS())
-    if (gmcp.Char.Vitals.move > gmcp.Char.Vitals.maxmove) then
-      move = maxmove
-    end
-    DD_GUI.Moves:setValue(((move * 1000) / maxmove),1000)
-
-    MovesLabel = Geyser.Label:new({
-      name = "MovesLabel",
-      x = 0, y = "15%",
-      width = "50%", height = "70%",
-      fgColor = "Black",
-      message = [[&nbsp;Moves]]
-    }, DD_GUI.Moves )
-    MovesLabel:setColor(0,0,0,0)
-    MovesLabel:setFgColor("White")
-    MovesLabel:setFontSize(10)
-
-  end
+    DD_GUI.Moves, MovesLabel = new_status_gauge(
+      "DD_GUI.Moves", DD_GUI.FourthColumn, "MOVES", colors.moves,
+      gmcp.Char.Vitals.move, gmcp.Char.Vitals.maxmove)
+end

--- a/src/scripts/DD/DD_GUI.InventoryBox.lua
+++ b/src/scripts/DD/DD_GUI.InventoryBox.lua
@@ -7,14 +7,8 @@ DD_GUI.Inventory.tab_definitions = {
 }
 
 function DD_GUI.Inventory:tab_css(key)
-        if key == self.current_tab then
-                return [[
-                        background-color: rgba(0,120,135,190);
-                        border-style: solid;
-                        border-width: 1px;
-                        border-color: cyan;
-                        margin: 1px;
-                ]]
+        if DD_GUI.Theme then
+                return DD_GUI.Theme:tab_css(key == self.current_tab)
         end
 
         return [[
@@ -33,7 +27,11 @@ function DD_GUI.Inventory:style_tab(key)
         end
 
         tab:setStyleSheet(self:tab_css(key))
-        tab:echo(self.tab_labels[key], "white", "c")
+        tab:echo(
+                self.tab_labels[key],
+                key == self.current_tab and "black" or "white",
+                "c"
+        )
 end
 
 function DD_GUI.Inventory:style_tabs()
@@ -81,8 +79,12 @@ function DD_GUI.Inventory:build_tabs()
                         height = "100%",
                 }, self.tab_rail)
 
-                tab:setFontSize(8)
-                tab:setBold(1)
+                if DD_GUI.Theme then
+                        DD_GUI.Theme:style_label(tab, 8, true)
+                else
+                        tab:setFontSize(8)
+                        tab:setBold(1)
+                end
                 tab:setClickCallback("dd_inventory_tab_click", definition.key)
 
                 self.tab_buttons[definition.key] = tab

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -10,17 +10,35 @@ function build_enemy_console()
       scrollBar = false,
       fontSize = 10,
     }, DD_GUI.EnemyBox)
+    if DD_GUI.Theme then
+      DD_GUI.Theme:style_console(EnemyConsole, 10)
+    end
+
+    EnemyImageFrame = Geyser.Label:new({
+      name="EnemyImageFrame",
+      x = "0%", y = "0%",
+      width="100%",
+      height="69%",
+    }, EnemyConsole)
+    EnemyImageFrame:setStyleSheet(DD_GUI.Theme and
+      DD_GUI.Theme:image_frame_css() or [[border: 1px solid grey;]])
+    if DD_GUI.set_widget_clickthrough then
+      DD_GUI.set_widget_clickthrough(EnemyImageFrame, true)
+    end
 
     EnemyTPConsoleTop = Geyser.MiniConsole:new({
       name="EnemyTPConsoleTop",
       x = "0%", y = "0%",
-      width="300px",
+      width="100%",
       height="69%",
       autoWrap = false,
       color = "black",
       scrollBar = false,
       fontSize = 10,
     }, EnemyConsole)
+    if DD_GUI.Theme then
+      DD_GUI.Theme:style_console(EnemyTPConsoleTop, 10)
+    end
 
     EnemyInfoConsole = Geyser.MiniConsole:new({
       name="EnemyInfoConsole",
@@ -32,6 +50,9 @@ function build_enemy_console()
       scrollBar = false,
       fontSize = 10,
     }, EnemyConsole)
+    if DD_GUI.Theme then
+      DD_GUI.Theme:style_console(EnemyInfoConsole, 10)
+    end
 
     EnemyConsoleHitpointsContainerCSS = CSSMan.new([[
       background-color: rgba(89,0,0,100);
@@ -49,37 +70,51 @@ function build_enemy_console()
     },EnemyInfoConsole)
 
 
-    EnemyConsoleHitpointsGaugeBackCSS = CSSMan.new([[
-        background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #bd3333, stop: 0.1 #bd2020, stop: 0.49 #990000, stop: 0.5 #700000, stop: 1 #990000);
-        border-width: 1px;
-        border-color: black;
-        border-style: solid;
-        border-radius: 7;
-        padding: 5px;
-    ]])
-
-    EnemyConsoleHitpointsGaugeFrontCSS = CSSMan.new([[
-        background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #f04141, stop: 0.1 #ef2929, stop: 0.49 #cc0000, stop: 0.5 #a40000, stop: 1 #cc0000);
-        border-top: 1px black solid;
-        border-left: 1px black solid;
-        border-bottom: 1px black solid;
-        border-radius: 7;
-        padding: 5px;
-    ]])
+    local theme = DD_GUI.Theme
+    EnemyConsoleHitpointsGaugeBackCSS = CSSMan.new(theme and
+      theme:gauge_back_css() or [[background-color: rgb(80,0,0);]])
+    EnemyConsoleHitpointsGaugeFrontCSS = CSSMan.new(theme and
+      theme:gauge_front_css(theme.colors.hp) or
+      [[background-color: rgb(180,0,0);]])
 
     EnemyConsoleHitpoints = Geyser.Gauge:new({ name = "EnemyConsoleHitpoints", }, EnemyConsoleHitpointsContainer)
     EnemyConsoleHitpoints.back:setStyleSheet(EnemyConsoleHitpointsGaugeBackCSS:getCSS())
     EnemyConsoleHitpoints.front:setStyleSheet(EnemyConsoleHitpointsGaugeFrontCSS:getCSS())
 
+    for index = 1, 9 do
+      local separator = Geyser.Label:new({
+        name = "EnemyConsoleHitpoints.Segment." .. index,
+        x = tostring(index * 10) .. "%",
+        y = 0,
+        width = 1,
+        height = "100%",
+      }, EnemyConsoleHitpoints)
+      separator:setStyleSheet([[
+        background-color: rgba(5,8,18,185);
+        border: 0px;
+      ]])
+      if DD_GUI.set_widget_clickthrough then
+        DD_GUI.set_widget_clickthrough(separator, true)
+      end
+    end
+
     EnemyHitpointsLabel = Geyser.Label:new({
       name = "EnemyHitpointsLabel",
-      x = 0, y = "15%",
-      width = "30%", height = "70%",
+      x = 0, y = 0,
+      width = "100%", height = "100%",
       fgColor = "black",
-      message = [[&nbsp;Hits]]
+      message = [[HITS]]
     },EnemyConsoleHitpoints )
     EnemyHitpointsLabel:setColor(0,0,0,0)
-    EnemyHitpointsLabel:setFgColor("Grey")
-    EnemyHitpointsLabel:setFontSize(10)
+    EnemyHitpointsLabel:setFgColor("white")
+    EnemyHitpointsLabel:echo("HITS", "white", "c")
+    if theme then
+      theme:style_label(EnemyHitpointsLabel, 9, true)
+    else
+      EnemyHitpointsLabel:setFontSize(9)
+    end
+    if DD_GUI.set_widget_clickthrough then
+      DD_GUI.set_widget_clickthrough(EnemyHitpointsLabel, true)
+    end
 
   end

--- a/src/scripts/DD/GoldBoxTheme.lua
+++ b/src/scripts/DD/GoldBoxTheme.lua
@@ -9,9 +9,9 @@ Theme.colors = {
         navy = "rgb(10,16,34)",
         panel = "rgb(15,24,46)",
         panel_alt = "rgb(22,34,61)",
-        frame = "rgb(181,35,48)",
-        bright_frame = "rgb(239,65,76)",
-        dark_frame = "rgb(92,14,24)",
+        frame = "rgb(151,27,39)",
+        bright_frame = "rgb(205,48,60)",
+        dark_frame = "rgb(72,10,18)",
         gold = "rgb(196,161,78)",
         bright_gold = "rgb(239,210,118)",
         dark_gold = "rgb(105,82,36)",
@@ -32,31 +32,21 @@ function Theme:panel_css(options)
 
         return string.format([[
                 background-color: %s;
-                border-style: double;
-                border-width: 3px;
+                border-style: solid;
+                border-width: 2px;
                 border-color: %s;
                 border-radius: 0px;
                 margin: %dpx;
         ]], background, border, margin)
 end
 
-function Theme:band_css(edge)
-        local border_rule = ""
-        if edge == "left" then
-                border_rule = "border-left: 3px double " .. self.colors.frame .. ";"
-        elseif edge == "top" then
-                border_rule = "border-top: 3px double " .. self.colors.frame .. ";"
-        elseif edge == "bottom" then
-                border_rule = "border-bottom: 3px double " .. self.colors.frame .. ";"
-        end
-
+function Theme:band_css()
         return string.format([[
                 background-color: %s;
                 border: 0px;
-                %s
                 border-radius: 0px;
                 margin: 0px;
-        ]], self.colors.navy, border_rule)
+        ]], self.colors.navy)
 end
 
 function Theme:tab_css(active, drop_target)
@@ -120,8 +110,8 @@ end
 function Theme:image_frame_css()
         return string.format([[
                 background-color: rgba(0,0,0,0);
-                border-style: double;
-                border-width: 3px;
+                border-style: solid;
+                border-width: 2px;
                 border-color: %s;
                 border-radius: 0px;
                 margin: 0px;

--- a/src/scripts/DD/GoldBoxTheme.lua
+++ b/src/scripts/DD/GoldBoxTheme.lua
@@ -1,0 +1,355 @@
+DD_GUI = DD_GUI or {}
+
+DD_GUI.Theme = DD_GUI.Theme or {}
+local Theme = DD_GUI.Theme
+
+Theme.font = "Consolas"
+Theme.colors = {
+        ink = "rgb(5,8,18)",
+        navy = "rgb(10,16,34)",
+        panel = "rgb(15,24,46)",
+        panel_alt = "rgb(22,34,61)",
+        frame = "rgb(181,35,48)",
+        bright_frame = "rgb(239,65,76)",
+        dark_frame = "rgb(92,14,24)",
+        gold = "rgb(196,161,78)",
+        bright_gold = "rgb(239,210,118)",
+        dark_gold = "rgb(105,82,36)",
+        ivory = "rgb(240,235,213)",
+        muted = "rgb(153,160,174)",
+        blue_grey = "rgb(72,91,123)",
+        hp = "rgb(181,42,48)",
+        mana = "rgb(46,92,184)",
+        xp = "rgb(188,145,43)",
+        moves = "rgb(38,139,126)",
+}
+
+function Theme:panel_css(options)
+        options = options or {}
+        local background = options.background or self.colors.ink
+        local border = options.border or self.colors.frame
+        local margin = options.margin or 1
+
+        return string.format([[
+                background-color: %s;
+                border-style: double;
+                border-width: 3px;
+                border-color: %s;
+                border-radius: 0px;
+                margin: %dpx;
+        ]], background, border, margin)
+end
+
+function Theme:band_css(edge)
+        local border_rule = ""
+        if edge == "left" then
+                border_rule = "border-left: 3px double " .. self.colors.frame .. ";"
+        elseif edge == "top" then
+                border_rule = "border-top: 3px double " .. self.colors.frame .. ";"
+        elseif edge == "bottom" then
+                border_rule = "border-bottom: 3px double " .. self.colors.frame .. ";"
+        end
+
+        return string.format([[
+                background-color: %s;
+                border: 0px;
+                %s
+                border-radius: 0px;
+                margin: 0px;
+        ]], self.colors.navy, border_rule)
+end
+
+function Theme:tab_css(active, drop_target)
+        if active then
+                return string.format([[
+                        background-color: %s;
+                        color: %s;
+                        border-style: outset;
+                        border-width: 2px;
+                        border-color: %s;
+                        border-radius: 0px;
+                        margin: 1px;
+                ]], self.colors.gold, self.colors.ink, self.colors.bright_frame)
+        end
+
+        if drop_target then
+                return string.format([[
+                        background-color: %s;
+                        color: %s;
+                        border-style: double;
+                        border-width: 3px;
+                        border-color: %s;
+                        border-radius: 0px;
+                        margin: 1px;
+                ]], self.colors.panel_alt, self.colors.ivory, self.colors.bright_frame)
+        end
+
+        return string.format([[
+                background-color: %s;
+                color: %s;
+                border-style: solid;
+                border-width: 1px;
+                border-color: %s;
+                border-radius: 0px;
+                margin: 1px;
+        ]], self.colors.navy, self.colors.ivory, self.colors.dark_frame)
+end
+
+function Theme:gauge_back_css()
+        return string.format([[
+                background-color: %s;
+                border-style: inset;
+                border-width: 2px;
+                border-color: %s;
+                border-radius: 0px;
+                padding: 0px;
+        ]], self.colors.panel_alt, self.colors.dark_frame)
+end
+
+function Theme:gauge_front_css(color)
+        return string.format([[
+                background-color: %s;
+                border-style: solid;
+                border-width: 1px;
+                border-color: %s;
+                border-radius: 0px;
+                padding: 0px;
+        ]], color, self.colors.ink)
+end
+
+function Theme:image_frame_css()
+        return string.format([[
+                background-color: rgba(0,0,0,0);
+                border-style: double;
+                border-width: 3px;
+                border-color: %s;
+                border-radius: 0px;
+                margin: 0px;
+        ]], self.colors.frame)
+end
+
+function Theme:compass_cell_css(hovered, blank)
+        if blank then
+                return string.format([[
+                        background-color: %s;
+                        border-style: inset;
+                        border-width: 1px;
+                        border-color: %s;
+                        border-radius: 0px;
+                        margin: 1px;
+                ]], self.colors.ink, self.colors.dark_frame)
+        end
+
+        if hovered then
+                return string.format([[
+                        background-color: %s;
+                        color: %s;
+                        border-style: inset;
+                        border-width: 2px;
+                        border-color: %s;
+                        border-radius: 0px;
+                        margin: 1px;
+                ]], self.colors.bright_gold, self.colors.ink, self.colors.bright_frame)
+        end
+
+        return string.format([[
+                background-color: %s;
+                color: %s;
+                border-style: outset;
+                border-width: 2px;
+                border-color: %s;
+                border-radius: 0px;
+                margin: 1px;
+        ]], self.colors.panel, self.colors.ivory, self.colors.frame)
+end
+
+function Theme:layout_outline_css(dragging)
+        if dragging then
+                return string.format([[
+                        border-style: solid;
+                        border-width: 3px;
+                        border-color: %s;
+                ]], self.colors.ivory)
+        end
+
+        return string.format([[
+                border-style: dashed;
+                border-width: 2px;
+                border-color: %s;
+        ]], self.colors.bright_gold)
+end
+
+function Theme:move_handle_css()
+        return string.format([[
+                background-color: %s;
+                color: %s;
+                border-style: solid;
+                border-width: 1px;
+                border-color: %s;
+                border-radius: 0px;
+                margin: 0px;
+        ]], self.colors.gold, self.colors.ink, self.colors.bright_gold)
+end
+
+function Theme:style_label(label, size, bold)
+        if not label then
+                return
+        end
+
+        if type(label.setFont) == "function" then
+                pcall(function() label:setFont(self.font) end)
+        end
+        if size and type(label.setFontSize) == "function" then
+                label:setFontSize(size)
+        end
+        if bold ~= nil and type(label.setBold) == "function" then
+                label:setBold(bold and 1 or 0)
+        end
+end
+
+function Theme:style_console(console, size)
+        if not console then
+                return
+        end
+
+        if type(console.setFont) == "function" then
+                pcall(function() console:setFont(self.font) end)
+        end
+        if size and type(console.setFontSize) == "function" then
+                pcall(function() console:setFontSize(size) end)
+        end
+        if type(console.setColor) == "function" then
+                pcall(function() console:setColor(5, 8, 18) end)
+        end
+end
+
+local function set_clickthrough(widget, enabled)
+        if not widget then
+                return
+        end
+
+        local method
+        if enabled then
+                method = widget.enableClickthrough
+        else
+                method = widget.disableClickthrough
+        end
+        if type(method) == "function" then
+                pcall(function() method(widget) end)
+                return
+        end
+
+        local global_method
+        if enabled then
+                global_method = enableClickthrough
+        else
+                global_method = disableClickthrough
+        end
+        if type(global_method) == "function" and widget.name then
+                pcall(global_method, widget.name)
+        end
+end
+
+DD_GUI.set_widget_clickthrough = set_clickthrough
+
+DD_GUI.Layout = DD_GUI.Layout or {}
+local Layout = DD_GUI.Layout
+Layout.enabled = false
+
+function Layout:each_box(callback)
+        if not Adjustable or not Adjustable.Container or
+           not Adjustable.Container.all then
+                return
+        end
+
+        for _, box in pairs(Adjustable.Container.all) do
+                if box and box._dd_gui_adjustable then
+                        callback(box)
+                end
+        end
+end
+
+function Layout:apply_box(box)
+        if not box or not box.adjLabel then
+                return
+        end
+
+        set_clickthrough(box.adjLabel, not self.enabled)
+        if DD_GUI.hide_adjustable_controls then
+                DD_GUI.hide_adjustable_controls(box)
+        end
+        if DD_GUI.refresh_adjustable_style then
+                DD_GUI.refresh_adjustable_style(box)
+        end
+end
+
+function Layout:apply_compass()
+        if not compass or not compass.handle then
+                return
+        end
+
+        if self.enabled then
+                compass.handle:show()
+                set_clickthrough(compass.handle, false)
+                compass.handle:setStyleSheet(Theme:move_handle_css())
+                compass.handle:echo("MOVE", "black", "c")
+                compass.handle:setCursor("OpenHand")
+                compass.handle:raise()
+        else
+                set_clickthrough(compass.handle, true)
+                compass.handle:hide()
+        end
+end
+
+function Layout:apply(enabled)
+        if enabled ~= nil then
+                self.enabled = enabled == true
+        end
+
+        self:each_box(function(box)
+                self:apply_box(box)
+        end)
+        self:apply_compass()
+
+        if DD_GUI.raise_info_box_contents then
+                DD_GUI.raise_info_box_contents()
+        end
+end
+
+function Layout:save()
+        self:each_box(function(box)
+                if type(box.save) == "function" then
+                        pcall(function() box:save() end)
+                end
+        end)
+end
+
+function Layout:set_enabled(enabled)
+        self.enabled = enabled == true
+        self:apply()
+        if not self.enabled then
+                self:save()
+        end
+        return self.enabled
+end
+
+function Layout:command(raw_mode)
+        local mode = tostring(raw_mode or ""):lower()
+        mode = mode:gsub("^%s+", ""):gsub("%s+$", "")
+
+        local enabled
+        if mode == "on" then
+                enabled = true
+        elseif mode == "off" then
+                enabled = false
+        else
+                enabled = not self.enabled
+        end
+
+        self:set_enabled(enabled)
+        if enabled then
+                cecho("\n<gold>DD_GUI layout mode: <white>ON<reset> - drag or resize the gold-outlined regions.\n")
+        else
+                cecho("\n<gold>DD_GUI layout mode: <white>OFF<reset> - controls are locked and input passes through.\n")
+        end
+end

--- a/src/scripts/DD/ImageFit.lua
+++ b/src/scripts/DD/ImageFit.lua
@@ -47,8 +47,26 @@ function DD_GUI.ImageFit:refresh_widget(state)
         width = math.max(1, width)
         height = math.max(1, height)
 
+        if state.align_x == "center" then
+                x = parent_width * state.x_ratio + (max_width - width) / 2
+        end
+        if state.align_y == "center" then
+                y = parent_height * state.y_ratio + (max_height - height) / 2
+        end
+
         widget:move(math.floor(x + 0.5), math.floor(y + 0.5))
         widget:resize(math.floor(width + 0.5), math.floor(height + 0.5))
+
+        if state.frame then
+                state.frame:move(math.floor(x + 0.5), math.floor(y + 0.5))
+                state.frame:resize(
+                        math.floor(width + 0.5),
+                        math.floor(height + 0.5)
+                )
+                if state.frame.raise then
+                        state.frame:raise()
+                end
+        end
 end
 
 function DD_GUI.ImageFit:refresh_all()
@@ -88,6 +106,9 @@ function DD_GUI.ImageFit:set(widget, parent, path, options)
 
         state.parent = parent
         state.path = path
+        state.frame = options.frame or state.frame
+        state.align_x = options.align_x or state.align_x
+        state.align_y = options.align_y or state.align_y
         state.image_width, state.image_height = image_dimensions(path, options.fallback)
 
         if widget.setBackgroundImage then

--- a/src/scripts/DD/InventoryConsole.lua
+++ b/src/scripts/DD/InventoryConsole.lua
@@ -19,6 +19,9 @@ function build_inventory_console()
       scrollBar = true,
       fontSize = 10,
     }, DD_GUI.Inventory.content_stack)
+    if DD_GUI.Theme then
+      DD_GUI.Theme:style_console(InventoryConsole, 10)
+    end
 
     EquippedConsole = Geyser.MiniConsole:new({
       name="EquippedConsole",
@@ -32,6 +35,9 @@ function build_inventory_console()
       horizontalScrollBar = false,
       fontSize = 10,
     }, DD_GUI.Inventory.content_stack)
+    if DD_GUI.Theme then
+      DD_GUI.Theme:style_console(EquippedConsole, 10)
+    end
 
     DD_GUI.Inventory.consoles.inventory = InventoryConsole
     DD_GUI.Inventory.consoles.equipped = EquippedConsole

--- a/src/scripts/DD/MainWindow.lua
+++ b/src/scripts/DD/MainWindow.lua
@@ -29,6 +29,12 @@ function ui_container()
                 DD_GUI.new_adjustable_container(mainconsole_constraints) or
                 Geyser.Container:new(mainconsole_constraints)
 
+        if ui.mainconsole_container.setStyleSheet and DD_GUI.Theme then
+                ui.mainconsole_container:setStyleSheet(
+                        DD_GUI.Theme:panel_css({ background = "rgba(0,0,0,0)" })
+                )
+        end
+
         if ui.mainconsole_container.adjLabel then
                 ui.mainconsole_container.adjLabel:setWheelCallback(
                         "dd_gui_main_console_wheel"

--- a/src/scripts/DD/ResetLayout.lua
+++ b/src/scripts/DD/ResetLayout.lua
@@ -87,4 +87,8 @@ function DD_GUI.reset_layout()
         if DD_GUI.raise_info_box_contents then
                 DD_GUI.raise_info_box_contents()
         end
+
+        if DD_GUI.Layout then
+                DD_GUI.Layout:apply()
+        end
 end

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -21,12 +21,22 @@ function bootstrap()
         get_custom_content()
         update_travel()
 
+        -- Resizing and moving are opt-in. Normal play leaves the adjustable
+        -- surfaces click-through so tabs, compass controls, and scrollback
+        -- receive mouse input directly.
+        if DD_GUI.Layout then
+                DD_GUI.Layout:apply(false)
+        end
+
         if DD_GUI.raise_info_box_contents then
                 DD_GUI.raise_info_box_contents()
                 -- Geyser completes its initial z-order pass after bootstrap.
                 tempTimer(0.1, function()
                         if DD_GUI.raise_info_box_contents then
                                 DD_GUI.raise_info_box_contents()
+                        end
+                        if DD_GUI.Layout then
+                                DD_GUI.Layout:apply(false)
                         end
                 end)
         end

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -30,14 +30,22 @@ function update_enemy()
                                 EnemyTPConsoleTop,
                                 EnemyConsole,
                                 enemy_image,
-                                { fallback = { width = 560, height = 300 } }
+                                {
+                                        fallback = { width = 560, height = 300 },
+                                        frame = EnemyImageFrame,
+                                        align_x = "center",
+                                }
                         )
                 else
                         DD_GUI.ImageFit:set(
                                 EnemyTPConsoleTop,
                                 EnemyConsole,
                                 def_enemy_image,
-                                { fallback = { width = 560, height = 300 } }
+                                {
+                                        fallback = { width = 560, height = 300 },
+                                        frame = EnemyImageFrame,
+                                        align_x = "center",
+                                }
                         )
                 end
 

--- a/src/scripts/DD/UpdateFunctions/update_travel.lua
+++ b/src/scripts/DD/UpdateFunctions/update_travel.lua
@@ -103,7 +103,11 @@ function update_travel()
                     EnemyTPConsoleTop,
                     EnemyConsole,
                     room_image,
-                    { fallback = { width = 560, height = 300 } }
+                    {
+                            fallback = { width = 560, height = 300 },
+                            frame = EnemyImageFrame,
+                            align_x = "center",
+                    }
             )
 
             local stripped_room_name = string.gsub(gmcp.Room.Info.name, "\{[a-zA-Z]", "")

--- a/src/scripts/DD/UpdateFunctions/update_vitals.lua
+++ b/src/scripts/DD/UpdateFunctions/update_vitals.lua
@@ -152,14 +152,20 @@ function update_vitals()
           CharsheetPFPConsole,
           CharsheetConsole,
           char_image,
-          { fallback = { width = 160, height = 200 } }
+          {
+            fallback = { width = 160, height = 200 },
+            frame = CharsheetImageFrame,
+          }
         )
   else
         DD_GUI.ImageFit:set(
           CharsheetPFPConsole,
           CharsheetConsole,
           def_image,
-          { fallback = { width = 160, height = 200 } }
+          {
+            fallback = { width = 160, height = 200 },
+            frame = CharsheetImageFrame,
+          }
         )
   end
 
@@ -172,9 +178,9 @@ function update_vitals()
 
 CharsheetConsole:cecho(
     "<white>"
-    ..string.format("              Name:  <ansi_white>%s\n",
+    ..string.format("                Name:  <ansi_white>%s\n",
         gmcp.Char.Base.name)
-    ..string.format("              <white>Race:  <ansi_white>%s",
+    ..string.format("                <white>Race:  <ansi_white>%s",
         gmcp.Char.Base.race)
     .."<reset>\n"
  )
@@ -182,14 +188,14 @@ CharsheetConsole:cecho(
  if (gmcp.Char.Base.subclass == "none") then
     CharsheetConsole:cecho(
         "<white>"
-        ..string.format("              <white>Class: <ansi_white>%s",
+        ..string.format("                <white>Class: <ansi_white>%s",
             gmcp.Char.Base.class)
         .."<reset>\n"
     )
 else
     CharsheetConsole:cecho(
         "<white>"
-        ..string.format("              <white>Class: <ansi_white>%s",
+        ..string.format("                <white>Class: <ansi_white>%s",
             gmcp.Char.Base.subclass)
         .."<reset>\n"
     )
@@ -197,7 +203,7 @@ end
 
 CharsheetConsole:cecho(
     "<white>"
-    ..string.format("              <white>Level: <ansi_white>%d <white>Sex: <ansi_white>%s\n",
+    ..string.format("                <white>Level: <ansi_white>%d <white>Sex: <ansi_white>%s\n",
         gmcp.Char.Worth.level, firstToUpper(chsex_string))
     .."<reset>"
 )
@@ -206,7 +212,7 @@ if (gmcp.Char.Base.class == "Shape Shifter") or (gmcp.Char.Base.subclass == "Wer
     if (gmcp.Char.Affect[1][1].name ~= "mist walk") then
     CharsheetConsole:cecho(
       "<white>"
-      ..string.format("              <white>Form:  <ansi_white>%s\n",
+      ..string.format("                <white>Form:  <ansi_white>%s\n",
           firstToUpper(gmcp.Char.Vitals.form))
       .."<reset>"
     )
@@ -216,7 +222,7 @@ end
 if (gmcp.Char.Affect[1][1].name =="mist walk")  then
     CharsheetConsole:cecho(
       "<white>"
-      ..string.format("              <white>Form:  <ansi_white>Mist\n")
+      ..string.format("                <white>Form:  <ansi_white>Mist\n")
       .."<reset>"
     )
 end
@@ -224,7 +230,7 @@ end
 if (gmcp.Char.Base.subclass == "Werewolf") or (gmcp.Char.Base.subclass == "Vampire") then
   CharsheetConsole:cecho(
     "<white>"
-    ..string.format("              <white>Rage:  <red>%s<reset>/<red>%s<reset>\n",
+    ..string.format("                <white>Rage:  <red>%s<reset>/<red>%s<reset>\n",
         gmcp.Char.Vitals.rage,
         gmcp.Char.Vitals.maxrage)
     .."<reset>"
@@ -232,19 +238,19 @@ if (gmcp.Char.Base.subclass == "Werewolf") or (gmcp.Char.Base.subclass == "Vampi
 end
 
 CharsheetConsole:cecho(""
-    ..string.format("\n              <white>Str: <cyan>%s<reset>(<ansi_cyan>%s<reset>)",
+    ..string.format("\n                <white>Str: <cyan>%s<reset>(<ansi_cyan>%s<reset>)",
         gmcp.Char.Stats.str_mod,
         gmcp.Char.Stats.str)
     ..string.format(" <white>Int: <cyan>%s<reset>(<ansi_cyan>%s<reset>)\n",
         gmcp.Char.Stats.int_mod,
         gmcp.Char.Stats.int)
-    ..string.format("              <white>Wis: <cyan>%s<reset>(<ansi_cyan>%s<reset>)",
+    ..string.format("                <white>Wis: <cyan>%s<reset>(<ansi_cyan>%s<reset>)",
         gmcp.Char.Stats.wis_mod,
         gmcp.Char.Stats.wis)
     ..string.format(" <white>Dex: <cyan>%s<reset>(<ansi_cyan>%s<reset>)\n",
         gmcp.Char.Stats.dex_mod,
         gmcp.Char.Stats.dex)
-    ..string.format("              <white>Con: <cyan>%s<reset>(<ansi_cyan>%s<reset>)",
+    ..string.format("                <white>Con: <cyan>%s<reset>(<ansi_cyan>%s<reset>)",
         gmcp.Char.Stats.con_mod,
         gmcp.Char.Stats.con)
     ..string.format(" <white>Fame: <cyan>%s<reset>\n",

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -1,15 +1,18 @@
-local function compass_background_css(width)
-  local radius = math.max(0, (tonumber(width) or 0) / 2 - 36)
-
+local function compass_surface_css()
+  if DD_GUI.Theme then
+    return DD_GUI.Theme:panel_css({ margin = 0 })
+  end
   return [[
-    background-color: QRadialGradient(cx:.3,cy:1,radius:1,stop:0 rgb(28,0,0),stop:.5 rgb(100,0,0),stop:1 rgb(255,0,0));
-    border-radius: ]] .. tostring(radius) .. [[px;
-    margin: 12px;
+    background-color: rgb(10,10,20);
+    border: 2px solid grey;
+    border-radius: 0px;
+    margin: 0px;
   ]]
 end
 
 function dd_gui_compass_handle_click(event)
-  if not event or event.button ~= "LeftButton" or
+  if not DD_GUI.Layout or not DD_GUI.Layout.enabled or
+     not event or event.button ~= "LeftButton" or
      not compass or not compass.back then
     return
   end
@@ -31,7 +34,8 @@ function dd_gui_compass_handle_click(event)
 end
 
 function dd_gui_compass_handle_move(event)
-  if not compass or not compass.back or not compass.handle_drag then
+  if not DD_GUI.Layout or not DD_GUI.Layout.enabled or
+     not compass or not compass.back or not compass.handle_drag then
     return
   end
 
@@ -49,7 +53,8 @@ function dd_gui_compass_handle_move(event)
 end
 
 function dd_gui_compass_handle_release(event)
-  if not event or event.button ~= "LeftButton" or
+  if not DD_GUI.Layout or not DD_GUI.Layout.enabled or
+     not event or event.button ~= "LeftButton" or
      not compass or not compass.back then
     return
   end
@@ -67,8 +72,7 @@ function dd_gui_compass_handle_release(event)
 end
 
 function build_compass()
-
-local mw, mh = getMainWindowSize()
+  local mw, mh = getMainWindowSize()
 
   local previous_geometry
   if compass and compass.back and compass.back._dd_gui_adjustable then
@@ -86,16 +90,22 @@ local mw, mh = getMainWindowSize()
   local compass_layout_path = ms_path .. "/layout/compass.back.lua"
   local saved_layout = io.exists and io.exists(compass_layout_path)
 
-  -- Vitals can rebuild the compass after the initial bootstrap. Remove the
-  -- previous native widget tree so its drag surface cannot remain visible or
-  -- steal mouse events from the current handle.
   if compass and compass.back and compass.back.delete then
     compass.back:delete()
   end
 
   compass = {
-    dirs = {"n","u","w","look","e","s","d"},
-    ratio = mw / mh
+    dirs = {"n", "u", "w", "look", "e", "s", "d"},
+    ratio = mw / mh,
+    labels = {
+      n = "N",
+      u = "UP",
+      w = "W",
+      look = "LOOK",
+      e = "E",
+      s = "S",
+      d = "DOWN",
+    },
   }
 
   local compass_constraints = {
@@ -119,15 +129,11 @@ local mw, mh = getMainWindowSize()
 
   if compass.back._dd_gui_adjustable and not saved_layout and
      (not previous_geometry or previous_default_size) then
-    -- Preserve the old compass' square default while allowing later resizing.
     compass.back:resize(compass.back.width, compass.back:get_width())
   end
 
   local compass_parent = compass.back
   if compass.back._dd_gui_adjustable then
-    -- The adjustable container's native drag label is covered by the
-    -- compass contents. Keep a full-width top rail above those contents and
-    -- forward its mouse events to the native adjustable handlers.
     local go_inside = compass.back.goInside
     compass.back.goInside = false
     compass.handle = Geyser.Label:new({
@@ -135,15 +141,9 @@ local mw, mh = getMainWindowSize()
       x = 0,
       y = 0,
       width = "100%",
-      height = 14,
+      height = 16,
     }, compass.back)
     compass.back.goInside = go_inside
-    compass.handle:setStyleSheet([[
-      background-color: rgba(0,0,0,0);
-      border: 0px;
-      margin: 0px;
-    ]])
-    compass.handle:echo("")
     compass.handle:setClickCallback("dd_gui_compass_handle_click")
     compass.handle:setReleaseCallback("dd_gui_compass_handle_release")
     compass.handle:setMoveCallback("dd_gui_compass_handle_move")
@@ -155,144 +155,119 @@ local mw, mh = getMainWindowSize()
       width = "100%",
       height = "100%",
     }, compass.back.Inside)
+    compass.surface:setStyleSheet(compass_surface_css())
+    if DD_GUI.set_widget_clickthrough then
+      DD_GUI.set_widget_clickthrough(compass.surface, true)
+    end
     compass_parent = compass.back.Inside
   else
-    compass.back:setStyleSheet(compass_background_css(compass.back:get_width()))
+    compass.back:setStyleSheet(compass_surface_css())
   end
 
   compass.box = Geyser.HBox:new({
     name = "compass.box",
-    x = 0,
-    y = 0,
-    width = "100%",
-    height = "100%",
-  },compass_parent)
+    x = "3%",
+    y = "3%",
+    width = "94%",
+    height = "94%",
+  }, compass_parent)
 
-  compass.row1 = Geyser.VBox:new({
-    name = "compass.row1",
-  },compass.box)
-  compass.row2 = Geyser.VBox:new({
-    name = "compass.row2",
-  },compass.box)
-  compass.row3 = Geyser.VBox:new({
-    name = "compass.row3",
-  },compass.box)
+  compass.row1 = Geyser.VBox:new({name = "compass.row1"}, compass.box)
+  compass.row2 = Geyser.VBox:new({name = "compass.row2"}, compass.box)
+  compass.row3 = Geyser.VBox:new({name = "compass.row3"}, compass.box)
 
-  compass.nw = Geyser.Label:new({
-    name = "compass.nw",
-  },compass.row1)
+  compass.nw = Geyser.Label:new({name = "compass.nw"}, compass.row1)
+  compass.w = Geyser.Label:new({name = "compass.w"}, compass.row1)
+  compass.sw = Geyser.Label:new({name = "compass.sw"}, compass.row1)
+  compass.n = Geyser.Label:new({name = "compass.n"}, compass.row2)
+  compass.look = Geyser.Label:new({name = "compass.look"}, compass.row2)
+  compass.s = Geyser.Label:new({name = "compass.s"}, compass.row2)
+  compass.u = Geyser.Label:new({name = "compass.u"}, compass.row3)
+  compass.e = Geyser.Label:new({name = "compass.e"}, compass.row3)
+  compass.d = Geyser.Label:new({name = "compass.d"}, compass.row3)
 
-  compass.nw:setStyleSheet([[
-    background-color: rgba(0,0,0,0%);
-  ]])
-
-  compass.w = Geyser.Label:new({
-    name = "compass.w",
-  },compass.row1)
-
-  compass.sw = Geyser.Label:new({
-    name = "compass.sw",
-  },compass.row1)
-
-  compass.sw:setStyleSheet([[
-    background-color: rgba(0,0,0,0%);
-  ]])
-
-  compass.n = Geyser.Label:new({
-    name = "compass.n",
-  },compass.row2)
-
-  compass.look = Geyser.Label:new({
-    name = "compass.look",
-  },compass.row2)
-
-  compass.s = Geyser.Label:new({
-    name = "compass.s",
-  },compass.row2)
-
-  compass.u = Geyser.Label:new({
-    name = "compass.u",
-  },compass.row3)
-
-  compass.e = Geyser.Label:new({
-    name = "compass.e",
-  },compass.row3)
-
-  compass.d = Geyser.Label:new({
-    name = "compass.d",
-  },compass.row3)
-
-
-function compass.click(name)
-  send(name)
-end
-
-function compass.onEnter(name)
-  compass[name]:setStyleSheet([[
-    border-image: url("]]..getMudletHomeDir()..[[/DD_GUI/compass/]]..name..[[hover.png");
-    margin: 5px;
-  ]])
-end
-
-function compass.onLeave(name)
-  compass[name]:setStyleSheet([[
-    border-image: url("]]..getMudletHomeDir()..[[/DD_GUI/compass/]]..name..[[.png");
-    margin: 5px;
-  ]])
-end
-
-for k,v in pairs(compass.dirs) do
-  compass[v]:setStyleSheet([[
-    border-image: url("]]..getMudletHomeDir()..[[/DD_GUI/compass/]]..v..[[.png");
-    margin: 5px;
-  ]])
-  compass[v]:setClickCallback("compass.click",v)
-  setLabelOnEnter("compass."..v,"compass.onEnter",v)
-  setLabelOnLeave("compass."..v,"compass.onLeave",v)
-end
-
-function compass.refresh()
-  if compass.surface then
-    compass.surface:setStyleSheet(compass_background_css(compass.surface:get_width()))
-  elseif compass.back and compass.back.setStyleSheet then
-    compass.back:setStyleSheet(compass_background_css(compass.back:get_width()))
-  end
-
-  -- Keep the navigation cells above the adjustable drag surface.
-  if compass.box then
-    if compass.box.raiseAll then
-      compass.box:raiseAll()
-    elseif compass.box.raise then
-      compass.box:raise()
+  local theme = DD_GUI.Theme
+  for _, blank in ipairs({"nw", "sw"}) do
+    compass[blank]:setStyleSheet(theme and
+      theme:compass_cell_css(false, true) or
+      [[background-color: rgb(5,5,10); border: 1px solid grey;]])
+    if DD_GUI.set_widget_clickthrough then
+      DD_GUI.set_widget_clickthrough(compass[blank], true)
     end
   end
 
-  if compass.handle and compass.handle.raise then
-    compass.handle:raise()
+  function compass.click(name)
+    send(name)
   end
-end
 
-function compass.resize()
-  -- The legacy label stays square.  Adjustable users control both dimensions.
-  if compass.back and not compass.back._dd_gui_adjustable then
-    compass.back:resize(compass.back.width, compass.back:get_width())
+  function compass.onEnter(name)
+    compass[name]:setStyleSheet(theme and
+      theme:compass_cell_css(true, false) or
+      [[background-color: white; color: black; border: 1px solid grey;]])
+    compass[name]:echo(compass.labels[name], "black", "c")
   end
-  compass.refresh()
-end
 
-if not DD_GUI.compass_handlers_registered then
-  registerAnonymousEventHandler("sysWindowResizeEvent", function()
-    if compass and compass.refresh then
-      compass.refresh()
-    end
-  end)
-  registerAnonymousEventHandler("AdjustableContainerReposition", function(_, name)
-    if name == "compass.back" and compass and compass.refresh then
-      compass.refresh()
-    end
-  end)
-  DD_GUI.compass_handlers_registered = true
-end
+  function compass.onLeave(name)
+    compass[name]:setStyleSheet(theme and
+      theme:compass_cell_css(false, false) or
+      [[background-color: black; color: white; border: 1px solid grey;]])
+    compass[name]:echo(compass.labels[name], "white", "c")
+  end
 
-compass.resize()
+  for _, direction in ipairs(compass.dirs) do
+    local cell = compass[direction]
+    compass.onLeave(direction)
+    if theme then
+      theme:style_label(cell, 8, true)
+    else
+      cell:setFontSize(8)
+      cell:setBold(1)
+    end
+    cell:setClickCallback("compass.click", direction)
+    setLabelOnEnter("compass." .. direction, "compass.onEnter", direction)
+    setLabelOnLeave("compass." .. direction, "compass.onLeave", direction)
+  end
+
+  function compass.refresh()
+    if compass.surface then
+      compass.surface:setStyleSheet(compass_surface_css())
+    elseif compass.back and compass.back.setStyleSheet then
+      compass.back:setStyleSheet(compass_surface_css())
+    end
+
+    if compass.box then
+      if compass.box.raiseAll then
+        compass.box:raiseAll()
+      elseif compass.box.raise then
+        compass.box:raise()
+      end
+    end
+
+    if DD_GUI.Layout then
+      DD_GUI.Layout:apply_compass()
+    end
+  end
+
+  function compass.resize()
+    if compass.back and not compass.back._dd_gui_adjustable then
+      compass.back:resize(compass.back.width, compass.back:get_width())
+    end
+    compass.refresh()
+  end
+
+  if not DD_GUI.compass_handlers_registered then
+    registerAnonymousEventHandler("sysWindowResizeEvent", function()
+      if compass and compass.refresh then
+        compass.refresh()
+      end
+    end)
+    registerAnonymousEventHandler("AdjustableContainerReposition", function(_, name)
+      if name == "compass.back" and compass and compass.refresh then
+        compass.refresh()
+      end
+    end)
+    DD_GUI.compass_handlers_registered = true
+  end
+
+  compass.resize()
 end

--- a/src/scripts/DD/scripts.json
+++ b/src/scripts/DD/scripts.json
@@ -6,6 +6,9 @@
         "name": "AffectsConsole"
   },
   {
+        "name": "GoldBoxTheme"
+  },
+  {
         "name": "BoxesDefinitions"
   },
   {


### PR DESCRIPTION
## Summary
- restyle the GUI around the classic SSI Gold Box pane hierarchy with black/navy surfaces, red structural frames, restrained gold selections, compact tabs, and segmented status gauges
- replace the ornate compass with a square 3x3 command pad while preserving commands, saved geometry, and responsive resizing
- add locked-by-default `layoutgui` editing so normal clicks and scroll input pass through, with visible edit outlines and a temporary compass move handle
- keep room and enemy artwork centered at its native 560:300 aspect and synchronize the visible frame to the fitted image geometry
- unify Inventory, Equipped, and Affects styling and preserve custom artwork, channel colors, dynamic comms tabs, and per-profile layout/reset behavior

## Verification
- `git diff --check`
- `./scripts/build-and-upload.ps1`
- installed the built package into the live Owltest Mudlet session with no Lua errors
- physically switched Inventory/Equipped and comms tabs, scrolled the main buffer, and invoked LOOK from the compass
- verified `layoutgui` alias expansion and normal-mode click-through
- verified room image and frame both render at 295x158 in the current layout, with layout mode disabled after bootstrap
- verified the production package HTTP content length matches the local 8,408,343-byte artifact before the final one-line XP compatibility rebuild; the final upload helper also completed successfully