### PR TITLE
Use pure black GUI backgrounds

### DIFF
--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -268,7 +268,7 @@ local function new_info_box(cons, parent)
 end
 function define_boxes()
         local box_css = DD_GUI.Theme and DD_GUI.Theme:panel_css() or [[
-          background-color: rgba(0,0,0,100);
+          background-color: rgb(0,0,0);
           border-style: solid;
           border-width: 1px;
           border-radius: 0px;
@@ -304,6 +304,7 @@ function define_boxes()
           width = "100%", 
           height = "100%"
         }, DD_GUI.MapBox)
+        DD_GUI.Mapper:setColor(0, 0, 0, 255)
         
         
         DD_GUI.CharsheetBox = new_info_box({

--- a/src/scripts/DD/ChannelConsole.lua
+++ b/src/scripts/DD/ChannelConsole.lua
@@ -411,7 +411,7 @@ function DD_GUI.Comms:tab_css(key)
 
         if key == self.drag_target and key ~= self.drag_source then
                 return [[
-                        background-color: rgba(50,80,90,180);
+                        background-color: rgba(0,0,0,180);
                         border-style: solid;
                         border-width: 1px;
                         border-color: cyan;
@@ -420,7 +420,7 @@ function DD_GUI.Comms:tab_css(key)
         end
 
         return [[
-                background-color: rgba(20,20,20,170);
+                background-color: rgba(0,0,0,170);
                 border-style: solid;
                 border-width: 1px;
                 border-color: rgb(45,45,45);

--- a/src/scripts/DD/DD_GUI.AffectsBox.lua
+++ b/src/scripts/DD/DD_GUI.AffectsBox.lua
@@ -20,6 +20,26 @@ function DD_GUI.Affects:build_tabs()
                 self.tab_rail:hide()
         end
 
+        if not self.frame then
+                self.frame = Geyser.Label:new({
+                        name = "DD_GUI.Affects.Frame",
+                        x = "0%",
+                        y = "0%",
+                        width = "100%",
+                        height = "100%",
+                }, DD_GUI.AffectBox)
+                self.frame:setStyleSheet(DD_GUI.Theme and
+                        DD_GUI.Theme:image_frame_css() or [[
+                                background-color: rgba(0,0,0,0);
+                                border: 2px solid rgb(151,27,39);
+                                border-radius: 0px;
+                                margin: 0px;
+                        ]])
+                if DD_GUI.set_widget_clickthrough then
+                        DD_GUI.set_widget_clickthrough(self.frame, true)
+                end
+        end
+
         self.tab_rail = Geyser.Label:new({
                 name = "DD_GUI.Affects.TabRail",
                 x = "4%",

--- a/src/scripts/DD/DD_GUI.GaugesBox.lua
+++ b/src/scripts/DD/DD_GUI.GaugesBox.lua
@@ -29,7 +29,7 @@ local function add_gauge_segments(gauge, name)
         height = "100%",
       }, gauge)
       separator:setStyleSheet([[
-        background-color: rgba(5,8,18,185);
+        background-color: rgba(0,0,0,185);
         border: 0px;
         margin: 0px;
       ]])
@@ -48,7 +48,7 @@ local function new_status_gauge(name, parent, label_text, color, value, maximum)
     }, parent)
 
     gauge.back:setStyleSheet(theme and theme:gauge_back_css() or [[
-      background-color: rgb(30,30,30);
+      background-color: rgb(0,0,0);
       border: 1px solid grey;
       border-radius: 0px;
     ]])

--- a/src/scripts/DD/DD_GUI.InventoryBox.lua
+++ b/src/scripts/DD/DD_GUI.InventoryBox.lua
@@ -12,7 +12,7 @@ function DD_GUI.Inventory:tab_css(key)
         end
 
         return [[
-                background-color: rgba(20,20,20,170);
+                background-color: rgba(0,0,0,170);
                 border-style: solid;
                 border-width: 1px;
                 border-color: rgb(45,45,45);

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -55,7 +55,7 @@ function build_enemy_console()
     end
 
     EnemyConsoleHitpointsContainerCSS = CSSMan.new([[
-      background-color: rgba(89,0,0,100);
+      background-color: rgb(0,0,0);
       border-style: solid;
       border-width: 0px;
       border-radius: 5px;
@@ -72,7 +72,7 @@ function build_enemy_console()
 
     local theme = DD_GUI.Theme
     EnemyConsoleHitpointsGaugeBackCSS = CSSMan.new(theme and
-      theme:gauge_back_css() or [[background-color: rgb(80,0,0);]])
+      theme:gauge_back_css() or [[background-color: rgb(0,0,0);]])
     EnemyConsoleHitpointsGaugeFrontCSS = CSSMan.new(theme and
       theme:gauge_front_css(theme.colors.hp) or
       [[background-color: rgb(180,0,0);]])
@@ -90,7 +90,7 @@ function build_enemy_console()
         height = "100%",
       }, EnemyConsoleHitpoints)
       separator:setStyleSheet([[
-        background-color: rgba(5,8,18,185);
+        background-color: rgba(0,0,0,185);
         border: 0px;
       ]])
       if DD_GUI.set_widget_clickthrough then

--- a/src/scripts/DD/GoldBoxTheme.lua
+++ b/src/scripts/DD/GoldBoxTheme.lua
@@ -5,10 +5,10 @@ local Theme = DD_GUI.Theme
 
 Theme.font = "Consolas"
 Theme.colors = {
-        ink = "rgb(5,8,18)",
-        navy = "rgb(10,16,34)",
-        panel = "rgb(15,24,46)",
-        panel_alt = "rgb(22,34,61)",
+        ink = "rgb(0,0,0)",
+        navy = "rgb(0,0,0)",
+        panel = "rgb(0,0,0)",
+        panel_alt = "rgb(0,0,0)",
         frame = "rgb(151,27,39)",
         bright_frame = "rgb(205,48,60)",
         dark_frame = "rgb(72,10,18)",
@@ -209,7 +209,7 @@ function Theme:style_console(console, size)
                 pcall(function() console:setFontSize(size) end)
         end
         if type(console.setColor) == "function" then
-                pcall(function() console:setColor(5, 8, 18) end)
+                pcall(function() console:setColor(0, 0, 0) end)
         end
 end
 

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -20,6 +20,9 @@ function bootstrap()
         load_dd_mapper()
         get_custom_content()
         update_travel()
+        if DD_GUI.Mapper and DD_GUI.Mapper.setColor then
+                DD_GUI.Mapper:setColor(0, 0, 0, 255)
+        end
 
         -- Resizing and moving are opt-in. Normal play leaves the adjustable
         -- surfaces click-through so tabs, compass controls, and scrollback

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -3,7 +3,7 @@ local function compass_surface_css()
     return DD_GUI.Theme:panel_css({ margin = 0 })
   end
   return [[
-    background-color: rgb(10,10,20);
+    background-color: rgb(0,0,0);
     border: 2px solid grey;
     border-radius: 0px;
     margin: 0px;
@@ -190,7 +190,7 @@ function build_compass()
   for _, blank in ipairs({"nw", "sw"}) do
     compass[blank]:setStyleSheet(theme and
       theme:compass_cell_css(false, true) or
-      [[background-color: rgb(5,5,10); border: 1px solid grey;]])
+      [[background-color: rgb(0,0,0); border: 1px solid grey;]])
     if DD_GUI.set_widget_clickthrough then
       DD_GUI.set_widget_clickthrough(compass[blank], true)
     end


### PR DESCRIPTION
## Summary
- normalize GUI surface, band, console, gauge well, tab, and compass backgrounds to pure black
- keep colored gauges and active controls intact
- add a click-through red frame to the Affects panel
- repaint the native mapper after bootstrap so its room strip stays black

## Verification
- `./scripts/build-and-upload.ps1` completed successfully
- production package size matches the local build
- installed and verified in the live Mudlet session after `bootstrap()`