### PR TITLE
Refine layout framing and right column sizing

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -151,6 +151,11 @@ function DD_GUI.raise_info_box_contents()
                         end
                 end
 
+                if DD_GUI.Affects and DD_GUI.Affects.frame and
+                   DD_GUI.Affects.frame.raise then
+                        DD_GUI.Affects.frame:raise()
+                end
+
                 -- Console widgets can be raised during bootstrap and GMCP
                 -- refreshes. Put the tab controls back on top afterwards.
                 raise_tab_rails()
@@ -164,8 +169,20 @@ function DD_GUI.raise_info_box_contents()
                         end
                 end
 
+                if ui and ui.mainconsole_frame and ui.mainconsole_frame.raise then
+                        ui.mainconsole_frame:raise()
+                end
+
                 -- The compass overlaps the bottom gauge row at its default
-                -- position, so its navigation cells must be raised last.
+                -- position, so its parent and navigation cells must be raised
+                -- last.
+                if compass and compass.back and compass.back.raise then
+                        compass.back:raise()
+                end
+                if compass and compass.back and compass.back.Inside and
+                   compass.back.Inside.raiseAll then
+                        compass.back.Inside:raiseAll()
+                end
                 if compass and compass.box then
                         if compass.box.raiseAll then
                                 compass.box:raiseAll()
@@ -194,6 +211,20 @@ function DD_GUI.raise_info_box_contents()
                 if box and box.Inside and box.Inside.raiseAll then
                         box.Inside:raiseAll()
                 end
+        end
+
+        if DD_GUI.Affects and DD_GUI.Affects.frame and
+           DD_GUI.Affects.frame.raise then
+                DD_GUI.Affects.frame:raise()
+        end
+        if ui and ui.mainconsole_frame and ui.mainconsole_frame.raise then
+                ui.mainconsole_frame:raise()
+        end
+        if compass and compass.back and compass.back.raise then
+                compass.back:raise()
+        end
+        if compass and compass.box and compass.box.raiseAll then
+                compass.box:raiseAll()
         end
 end
 
@@ -291,7 +322,7 @@ function define_boxes()
         DD_GUI.MapBox = new_info_box({
           name = "DD_GUI.MapBox",
           x = "27%", y = "17%",
-          width = "24%",
+          width = "16%",
           height = "83%",
         },DD_GUI.Top)
         DD_GUI.MapBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
@@ -309,7 +340,7 @@ function define_boxes()
         
         DD_GUI.CharsheetBox = new_info_box({
           name = "DD_GUI.CharsheetBox",
-          x = "51%", y = "17%",
+          x = "43%", y = "17%",
           width = "23%",
           height = "83%",
         },DD_GUI.Top)
@@ -318,8 +349,8 @@ function define_boxes()
         
         DD_GUI.ChannelBox = new_info_box({
           name = "DD_GUI.ChannelBox",
-          x = "74%", y = "17%",
-          width = "23%",
+          x = "66%", y = "17%",
+          width = "31%",
           height = "83%",
         },DD_GUI.Top)
         DD_GUI.ChannelBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
@@ -328,7 +359,7 @@ function define_boxes()
         DD_GUI.InventoryBox = new_info_box({
           name = "DD_GUI.InventoryBox",
           x = "0%", y = "36%",
-          width = "89%",
+          width = "91%",
           height = "34%",
         },DD_GUI.Right)
         DD_GUI.InventoryBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
@@ -337,7 +368,7 @@ function define_boxes()
         DD_GUI.AffectBox = new_info_box({
           name = "DD_GUI.AffectBox",
           x = "0%", y = "70%",
-          width = "89%",
+          width = "91%",
           height = "30%",
         },DD_GUI.Right)
         DD_GUI.AffectBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())

--- a/src/scripts/DD/CreateBackground.lua
+++ b/src/scripts/DD/CreateBackground.lua
@@ -8,8 +8,8 @@ function create_background()
         
         DD_GUI.Right = DD_GUI.new_adjustable_region({
           name = "DD_GUI.Right",
-          x = "-26%", y = "0%",
-          width = "26%",
+          x = "-34%", y = "0%",
+          width = "34%",
           height = "100%",
           padding = 0,
         }, nil, background_css)
@@ -25,7 +25,7 @@ function create_background()
         DD_GUI.Bottom = DD_GUI.new_adjustable_region({
           name = "DD_GUI.Bottom",
           x = "0%", y = "94%",
-          width = "74%",
+          width = "66%",
           height = "6%",
           padding = 0,
         }, nil, background_css, {direct = true})

--- a/src/scripts/DD/DD_GUI.AffectsBox.lua
+++ b/src/scripts/DD/DD_GUI.AffectsBox.lua
@@ -21,13 +21,14 @@ function DD_GUI.Affects:build_tabs()
         end
 
         if not self.frame then
+                local frame_parent = DD_GUI.AffectBox.Inside or DD_GUI.AffectBox
                 self.frame = Geyser.Label:new({
                         name = "DD_GUI.Affects.Frame",
                         x = "0%",
                         y = "0%",
                         width = "100%",
                         height = "100%",
-                }, DD_GUI.AffectBox)
+                }, frame_parent)
                 self.frame:setStyleSheet(DD_GUI.Theme and
                         DD_GUI.Theme:image_frame_css() or [[
                                 background-color: rgba(0,0,0,0);

--- a/src/scripts/DD/ImageFit.lua
+++ b/src/scripts/DD/ImageFit.lua
@@ -32,15 +32,21 @@ function DD_GUI.ImageFit:refresh_widget(state)
         local y = parent_height * state.y_ratio
         local max_width = math.max(1, parent_width * state.width_ratio)
         local max_height = math.max(1, parent_height * state.height_ratio)
-        local image_ratio = state.image_height / state.image_width
+        local width
+        local height
+        if state.stretch then
+                width = math.min(max_width, parent_width - x)
+                height = math.min(max_height, parent_height - y)
+        else
+                local image_ratio = state.image_height / state.image_width
+                width = math.min(max_width, max_height / image_ratio)
+                height = width * image_ratio
 
-        local width = math.min(max_width, max_height / image_ratio)
-        local height = width * image_ratio
-
-        width = math.min(width, parent_width - x)
-        height = width * image_ratio
-        height = math.min(height, parent_height - y)
-        width = height / image_ratio
+                width = math.min(width, parent_width - x)
+                height = width * image_ratio
+                height = math.min(height, parent_height - y)
+                width = height / image_ratio
+        end
 
         x = math.max(0, x)
         y = math.max(0, y)
@@ -109,6 +115,9 @@ function DD_GUI.ImageFit:set(widget, parent, path, options)
         state.frame = options.frame or state.frame
         state.align_x = options.align_x or state.align_x
         state.align_y = options.align_y or state.align_y
+        if options.stretch ~= nil then
+                state.stretch = options.stretch == true
+        end
         state.image_width, state.image_height = image_dimensions(path, options.fallback)
 
         if widget.setBackgroundImage then

--- a/src/scripts/DD/MainWindow.lua
+++ b/src/scripts/DD/MainWindow.lua
@@ -12,6 +12,9 @@ function dd_gui_main_console_wheel(event)
         end
 end
 
+DD_GUI = DD_GUI or {}
+DD_GUI.mainconsole_padding = 8
+
 function ui_container()
 
         -- interfacescript
@@ -22,7 +25,7 @@ function ui_container()
         local mainconsole_constraints = {
                 name = "DD_GUI.MainConsole",
                 x = "4%", y = "38%",
-                width = "75%", height = "56%",
+                width = "66%", height = "56%",
         }
 
         ui.mainconsole_container = DD_GUI.new_adjustable_container and
@@ -33,6 +36,27 @@ function ui_container()
                 ui.mainconsole_container:setStyleSheet(
                         DD_GUI.Theme:panel_css({ background = "rgba(0,0,0,0)" })
                 )
+        end
+
+        if ui.mainconsole_frame and ui.mainconsole_frame.delete then
+                ui.mainconsole_frame:delete()
+        end
+        local mainconsole_parent = ui.mainconsole_container.Inside or
+                ui.mainconsole_container
+        ui.mainconsole_frame = Geyser.Label:new({
+                name = "DD_GUI.MainConsole.Frame",
+                x = "0%", y = "0%",
+                width = "100%", height = "100%",
+        }, mainconsole_parent)
+        ui.mainconsole_frame:setStyleSheet(DD_GUI.Theme and
+                DD_GUI.Theme:image_frame_css() or [[
+                        background-color: rgba(0,0,0,0);
+                        border: 2px solid rgb(151,27,39);
+                        border-radius: 0px;
+                        margin: 0px;
+                ]])
+        if DD_GUI.set_widget_clickthrough then
+                DD_GUI.set_widget_clickthrough(ui.mainconsole_frame, true)
         end
 
         if ui.mainconsole_container.adjLabel then
@@ -52,10 +76,11 @@ function ui_container()
                 local cw = tonumber(ui.mainconsole_container:get_width()) or w
                 local ch = tonumber(ui.mainconsole_container:get_height()) or h
 
-                local left = math.max(0, cx)
-                local top = math.max(0, cy)
-                local right = math.max(0, w - cx - cw)
-                local bottom = math.max(0, h - cy - ch)
+                local padding = tonumber(DD_GUI.mainconsole_padding) or 8
+                local left = math.max(0, cx + padding)
+                local top = math.max(0, cy + padding)
+                local right = math.max(0, w - cx - cw + padding)
+                local bottom = math.max(0, h - cy - ch + padding)
 
                 if w ~= ui.window_width or h ~= ui.window_height or
                    left ~= ui.border_left or top ~= ui.border_top or

--- a/src/scripts/DD/ResetLayout.lua
+++ b/src/scripts/DD/ResetLayout.lua
@@ -39,20 +39,20 @@ end
 
 function DD_GUI.reset_layout()
         local defaults = {
-                { ui and ui.mainconsole_container, "4%", "38%", "75%", "56%" },
-                { DD_GUI.Right, "-26%", "0%", "26%", "100%" },
+                { ui and ui.mainconsole_container, "4%", "38%", "66%", "56%" },
+                { DD_GUI.Right, "-34%", "0%", "34%", "100%" },
                 { DD_GUI.Top, "0%", "0%", "100%", "36%" },
-                { DD_GUI.Bottom, "0%", "94%", "74%", "6%" },
+                { DD_GUI.Bottom, "0%", "94%", "66%", "6%" },
                 { DD_GUI.FirstColumn, "5%", "0%", "23.5%", "100%" },
                 { DD_GUI.SecondColumn, "28.5%", "0%", "23.5%", "100%" },
                 { DD_GUI.ThirdColumn, "52%", "0%", "23.5%", "100%" },
                 { DD_GUI.FourthColumn, "75.5%", "0%", "23.5%", "100%" },
                 { DD_GUI.EnemyBox, "4%", "17%", "23%", "83%" },
-                { DD_GUI.MapBox, "27%", "17%", "24%", "83%" },
-                { DD_GUI.CharsheetBox, "51%", "17%", "23%", "83%" },
-                { DD_GUI.ChannelBox, "74%", "17%", "23%", "83%" },
-                { DD_GUI.InventoryBox, "0%", "36%", "89%", "34%" },
-                { DD_GUI.AffectBox, "0%", "70%", "89%", "30%" },
+                { DD_GUI.MapBox, "27%", "17%", "16%", "83%" },
+                { DD_GUI.CharsheetBox, "43%", "17%", "23%", "83%" },
+                { DD_GUI.ChannelBox, "66%", "17%", "31%", "83%" },
+                { DD_GUI.InventoryBox, "0%", "36%", "91%", "34%" },
+                { DD_GUI.AffectBox, "0%", "70%", "91%", "30%" },
         }
 
         for _, default_box in ipairs(defaults) do

--- a/src/scripts/DD/SetBorders.lua
+++ b/src/scripts/DD/SetBorders.lua
@@ -1,6 +1,8 @@
 function set_borders()
         local w,h = getMainWindowSize()
-        setBorderTop((h * 36) / 100)
-        setBorderBottom((h * 6) / 100)
-        setBorderRight((w * 26) / 100)
+        local padding = tonumber(DD_GUI and DD_GUI.mainconsole_padding) or 8
+        setBorderTop((h * 36) / 100 + padding)
+        setBorderBottom((h * 6) / 100 + padding)
+        setBorderRight((w * 34) / 100 + padding)
+        setBorderLeft(padding)
 end

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -34,6 +34,7 @@ function update_enemy()
                                         fallback = { width = 560, height = 300 },
                                         frame = EnemyImageFrame,
                                         align_x = "center",
+                                        stretch = true,
                                 }
                         )
                 else
@@ -45,6 +46,7 @@ function update_enemy()
                                         fallback = { width = 560, height = 300 },
                                         frame = EnemyImageFrame,
                                         align_x = "center",
+                                        stretch = true,
                                 }
                         )
                 end

--- a/src/scripts/DD/UpdateFunctions/update_travel.lua
+++ b/src/scripts/DD/UpdateFunctions/update_travel.lua
@@ -107,6 +107,7 @@ function update_travel()
                             fallback = { width = 560, height = 300 },
                             frame = EnemyImageFrame,
                             align_x = "center",
+                            stretch = true,
                     }
             )
 


### PR DESCRIPTION
## Summary
- stretch travel and enemy artwork into the complete 56:30 image frame
- widen the default right rail to 34% and keep adjacent borders aligned
- inset and visibly frame the main Mud text viewport
- keep the compass above the gauges and restore the Affects red outline
- bump the package to 0.0.6 for reliable Mudlet update detection

## Verification
- `./scripts/build-and-upload.ps1` completed successfully
- uploaded package content length matches the local build
- packaged XML contains the new rail, frame, and compass layering changes