### PR TITLE
Align main text boundary and migrate saved layouts

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/MainWindow.lua
+++ b/src/scripts/DD/MainWindow.lua
@@ -25,7 +25,7 @@ function ui_container()
         local mainconsole_constraints = {
                 name = "DD_GUI.MainConsole",
                 x = "4%", y = "38%",
-                width = "66%", height = "56%",
+                width = "62%", height = "56%",
         }
 
         ui.mainconsole_container = DD_GUI.new_adjustable_container and

--- a/src/scripts/DD/ResetLayout.lua
+++ b/src/scripts/DD/ResetLayout.lua
@@ -37,9 +37,78 @@ local function reset_adjustable_box(box, x, y, width, height)
         end
 end
 
+local function approximately(value, target, tolerance)
+        return value and math.abs(value - target) <= tolerance
+end
+
+function DD_GUI.migrate_layout_defaults()
+        if not DD_GUI.Right or not DD_GUI.Right.get_x or
+           not DD_GUI.Right.get_width or type(getMainWindowSize) ~= "function" then
+                return false
+        end
+
+        local window_width = getMainWindowSize()
+        local right_x = tonumber(DD_GUI.Right:get_x()) or 0
+        local right_width = tonumber(DD_GUI.Right:get_width()) or 0
+        local legacy_default = false
+
+        -- Existing profiles may have saved one of the previous shipped
+        -- defaults. Only migrate those exact layouts; custom panel sizes and
+        -- positions remain untouched.
+        for _, legacy in ipairs({
+                { x = 0.74, width = 0.26 },
+                { x = 0.72, width = 0.28 },
+                { x = 0.68, width = 0.32 },
+                { x = 0.66, width = 0.34 },
+        }) do
+                if approximately(right_x, window_width * legacy.x, 2) and
+                   approximately(right_width, window_width * legacy.width, 2) then
+                        legacy_default = true
+                        break
+                end
+        end
+
+        if not legacy_default then
+                return false
+        end
+
+        local defaults = {
+                { ui and ui.mainconsole_container, "4%", "38%", "62%", "56%" },
+                { DD_GUI.Right, "-34%", "0%", "34%", "100%" },
+                { DD_GUI.Bottom, "0%", "94%", "66%", "6%" },
+                { DD_GUI.EnemyBox, "4%", "17%", "23%", "83%" },
+                { DD_GUI.MapBox, "27%", "17%", "16%", "83%" },
+                { DD_GUI.CharsheetBox, "43%", "17%", "23%", "83%" },
+                { DD_GUI.ChannelBox, "66%", "17%", "31%", "83%" },
+                { DD_GUI.InventoryBox, "0%", "36%", "91%", "34%" },
+                { DD_GUI.AffectBox, "0%", "70%", "91%", "30%" },
+        }
+
+        for _, default_box in ipairs(defaults) do
+                reset_adjustable_box(
+                        default_box[1],
+                        default_box[2],
+                        default_box[3],
+                        default_box[4],
+                        default_box[5]
+                )
+        end
+
+        if ui and ui.updateBorderSizes then
+                ui.window_width = nil
+                ui.updateBorderSizes()
+        end
+
+        if DD_GUI.raise_info_box_contents then
+                DD_GUI.raise_info_box_contents()
+        end
+
+        return true
+end
+
 function DD_GUI.reset_layout()
         local defaults = {
-                { ui and ui.mainconsole_container, "4%", "38%", "66%", "56%" },
+                { ui and ui.mainconsole_container, "4%", "38%", "62%", "56%" },
                 { DD_GUI.Right, "-34%", "0%", "34%", "100%" },
                 { DD_GUI.Top, "0%", "0%", "100%", "36%" },
                 { DD_GUI.Bottom, "0%", "94%", "66%", "6%" },

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -16,6 +16,9 @@ function bootstrap()
         build_enemy_box()
         build_enemy_console()
         build_compass()
+        if DD_GUI.migrate_layout_defaults then
+                DD_GUI.migrate_layout_defaults()
+        end
         initialise_mapper()
         load_dd_mapper()
         get_custom_content()

--- a/src/scripts/DD/UpdateFunctions/update_vitals.lua
+++ b/src/scripts/DD/UpdateFunctions/update_vitals.lua
@@ -23,6 +23,9 @@ function update_vitals()
         build_enemy_box()
         build_enemy_console()
         build_compass()
+        if DD_GUI.migrate_layout_defaults then
+                DD_GUI.migrate_layout_defaults()
+        end
 
         if DD_GUI.raise_info_box_contents then
                 DD_GUI.raise_info_box_contents()


### PR DESCRIPTION
## Summary
- align the main Mud text viewport's right edge with the 34% right rail
- migrate existing profiles that still have shipped legacy rail geometry
- bump the package to 0.0.7 so Mudlet recognizes the correction

## Verification
- `./scripts/build-and-upload.ps1` completed successfully
- uploaded package content length matches the local build
- `git diff --check` is clean