### PR TITLE
Fix stale layout frames and text clipping

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.7",
+  "version": "0.0.10",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/AffectsConsole.lua
+++ b/src/scripts/DD/AffectsConsole.lua
@@ -1,12 +1,13 @@
 function build_affects_console()
     AffectsConsole = Geyser.MiniConsole:new({
       name="AffectsConsole",
-      x = "4%", y = "14%",
-      width="92%",
+      x = "2%", y = "14%",
+      width="96%",
       height="82%",
-      autoWrap = false,
+      autoWrap = true,
       color = "black",
       scrollBar = true,
+      horizontalScrollBar = false,
       fontSize = 10,
     }, DD_GUI.AffectBox)
     if DD_GUI.Theme then

--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -151,11 +151,6 @@ function DD_GUI.raise_info_box_contents()
                         end
                 end
 
-                if DD_GUI.Affects and DD_GUI.Affects.frame and
-                   DD_GUI.Affects.frame.raise then
-                        DD_GUI.Affects.frame:raise()
-                end
-
                 -- Console widgets can be raised during bootstrap and GMCP
                 -- refreshes. Put the tab controls back on top afterwards.
                 raise_tab_rails()
@@ -169,8 +164,10 @@ function DD_GUI.raise_info_box_contents()
                         end
                 end
 
-                if ui and ui.mainconsole_frame and ui.mainconsole_frame.raise then
-                        ui.mainconsole_frame:raise()
+                if ui and ui.mainconsole_container and
+                   ui.mainconsole_container.adjLabel and
+                   ui.mainconsole_container.adjLabel.raise then
+                        ui.mainconsole_container.adjLabel:raise()
                 end
 
                 -- The compass overlaps the bottom gauge row at its default
@@ -213,12 +210,10 @@ function DD_GUI.raise_info_box_contents()
                 end
         end
 
-        if DD_GUI.Affects and DD_GUI.Affects.frame and
-           DD_GUI.Affects.frame.raise then
-                DD_GUI.Affects.frame:raise()
-        end
-        if ui and ui.mainconsole_frame and ui.mainconsole_frame.raise then
-                ui.mainconsole_frame:raise()
+        if ui and ui.mainconsole_container and
+           ui.mainconsole_container.adjLabel and
+           ui.mainconsole_container.adjLabel.raise then
+                ui.mainconsole_container.adjLabel:raise()
         end
         if compass and compass.back and compass.back.raise then
                 compass.back:raise()

--- a/src/scripts/DD/DD_GUI.AffectsBox.lua
+++ b/src/scripts/DD/DD_GUI.AffectsBox.lua
@@ -20,32 +20,21 @@ function DD_GUI.Affects:build_tabs()
                 self.tab_rail:hide()
         end
 
-        if not self.frame then
-                local frame_parent = DD_GUI.AffectBox.Inside or DD_GUI.AffectBox
-                self.frame = Geyser.Label:new({
-                        name = "DD_GUI.Affects.Frame",
-                        x = "0%",
-                        y = "0%",
-                        width = "100%",
-                        height = "100%",
-                }, frame_parent)
-                self.frame:setStyleSheet(DD_GUI.Theme and
-                        DD_GUI.Theme:image_frame_css() or [[
-                                background-color: rgba(0,0,0,0);
-                                border: 2px solid rgb(151,27,39);
-                                border-radius: 0px;
-                                margin: 0px;
-                        ]])
-                if DD_GUI.set_widget_clickthrough then
-                        DD_GUI.set_widget_clickthrough(self.frame, true)
-                end
+        -- Older package versions added a second full-size frame. Remove it
+        -- during rebuild so AffectBox's own red border is the only outline.
+        if self.frame and self.frame.delete then
+                self.frame:delete()
         end
+        if type(deleteLabel) == "function" then
+                pcall(deleteLabel, "DD_GUI.Affects.Frame")
+        end
+        self.frame = nil
 
         self.tab_rail = Geyser.Label:new({
                 name = "DD_GUI.Affects.TabRail",
-                x = "4%",
+                x = "2%",
                 y = "3%",
-                width = "92%",
+                width = "96%",
                 height = "10%",
         }, DD_GUI.AffectBox)
         self.tab_rail:setColor(0, 0, 0, 0)

--- a/src/scripts/DD/DD_GUI.InventoryBox.lua
+++ b/src/scripts/DD/DD_GUI.InventoryBox.lua
@@ -54,18 +54,18 @@ function DD_GUI.Inventory:build_tabs()
 
         self.tab_rail = Geyser.Label:new({
                 name = "DD_GUI.Inventory.TabRail",
-                x = "4%",
+                x = "2%",
                 y = "3%",
-                width = "92%",
+                width = "96%",
                 height = "10%",
         }, DD_GUI.InventoryBox)
         self.tab_rail:setColor(0, 0, 0, 0)
 
         self.content_stack = Geyser.Label:new({
                 name = "DD_GUI.Inventory.ContentStack",
-                x = "4%",
+                x = "2%",
                 y = "14%",
-                width = "92%",
+                width = "96%",
                 height = "82%",
         }, DD_GUI.InventoryBox)
         self.content_stack:setColor(0, 0, 0, 255)

--- a/src/scripts/DD/InventoryConsole.lua
+++ b/src/scripts/DD/InventoryConsole.lua
@@ -17,6 +17,7 @@ function build_inventory_console()
       autoWrap = true,
       color = "black",
       scrollBar = true,
+      horizontalScrollBar = false,
       fontSize = 10,
     }, DD_GUI.Inventory.content_stack)
     if DD_GUI.Theme then

--- a/src/scripts/DD/MainWindow.lua
+++ b/src/scripts/DD/MainWindow.lua
@@ -21,6 +21,13 @@ function ui_container()
         --------------------------------
         ui = ui or {} -- user interface related stuff goes into this table
 
+        -- Remove the old named frame as well as the Lua reference below. A
+        -- package update can leave that label alive after its parent is
+        -- rebuilt, which otherwise creates a second border over the console.
+        if type(deleteLabel) == "function" then
+                pcall(deleteLabel, "DD_GUI.MainConsole.Frame")
+        end
+
         -- Transparent adjustable overlay used to define the main MUD console area.
         local mainconsole_constraints = {
                 name = "DD_GUI.MainConsole",
@@ -38,26 +45,13 @@ function ui_container()
                 )
         end
 
+        -- Older package versions created a second full-size frame here.
+        -- Remove it when upgrading; the adjustable container's own border is
+        -- the single visible frame for the Mud text viewport.
         if ui.mainconsole_frame and ui.mainconsole_frame.delete then
                 ui.mainconsole_frame:delete()
         end
-        local mainconsole_parent = ui.mainconsole_container.Inside or
-                ui.mainconsole_container
-        ui.mainconsole_frame = Geyser.Label:new({
-                name = "DD_GUI.MainConsole.Frame",
-                x = "0%", y = "0%",
-                width = "100%", height = "100%",
-        }, mainconsole_parent)
-        ui.mainconsole_frame:setStyleSheet(DD_GUI.Theme and
-                DD_GUI.Theme:image_frame_css() or [[
-                        background-color: rgba(0,0,0,0);
-                        border: 2px solid rgb(151,27,39);
-                        border-radius: 0px;
-                        margin: 0px;
-                ]])
-        if DD_GUI.set_widget_clickthrough then
-                DD_GUI.set_widget_clickthrough(ui.mainconsole_frame, true)
-        end
+        ui.mainconsole_frame = nil
 
         if ui.mainconsole_container.adjLabel then
                 ui.mainconsole_container.adjLabel:setWheelCallback(

--- a/src/scripts/DD/ResetLayout.lua
+++ b/src/scripts/DD/ResetLayout.lua
@@ -47,10 +47,11 @@ function DD_GUI.migrate_layout_defaults()
                 return false
         end
 
-        local window_width = getMainWindowSize()
+        local window_width, window_height = getMainWindowSize()
         local right_x = tonumber(DD_GUI.Right:get_x()) or 0
         local right_width = tonumber(DD_GUI.Right:get_width()) or 0
         local legacy_default = false
+        local changed = false
 
         -- Existing profiles may have saved one of the previous shipped
         -- defaults. Only migrate those exact layouts; custom panel sizes and
@@ -68,8 +69,33 @@ function DD_GUI.migrate_layout_defaults()
                 end
         end
 
+        if compass and compass.back and compass.back.get_x and
+           compass.back.get_y then
+                local compass_x = tonumber(compass.back:get_x()) or 0
+                local compass_y = tonumber(compass.back:get_y()) or 0
+                local legacy_compass =
+                        tostring(compass.back.x) == "60%" and
+                        tostring(compass.back.y) == "82%"
+                if legacy_compass or
+                   (approximately(compass_x, window_width * 0.60, 2) and
+                    approximately(compass_y, window_height * 0.82, 2)) then
+                        compass.back:move("52%", "70%")
+                        compass.back:resize("8%", "8%")
+                        if compass.back.get_width then
+                                compass.back:resize("8%", compass.back:get_width())
+                        end
+                        if compass.back.save then
+                                compass.back:save()
+                        end
+                        changed = true
+                end
+        end
+
         if not legacy_default then
-                return false
+                if changed and DD_GUI.raise_info_box_contents then
+                        DD_GUI.raise_info_box_contents()
+                end
+                return changed
         end
 
         local defaults = {
@@ -93,6 +119,7 @@ function DD_GUI.migrate_layout_defaults()
                         default_box[5]
                 )
         end
+        changed = true
 
         if ui and ui.updateBorderSizes then
                 ui.window_width = nil
@@ -103,7 +130,7 @@ function DD_GUI.migrate_layout_defaults()
                 DD_GUI.raise_info_box_contents()
         end
 
-        return true
+        return changed
 end
 
 function DD_GUI.reset_layout()
@@ -135,7 +162,7 @@ function DD_GUI.reset_layout()
         end
 
         if compass and compass.back then
-                reset_adjustable_box(compass.back, "60%", "82%", "8%", "8%")
+                reset_adjustable_box(compass.back, "52%", "70%", "8%", "8%")
 
                 -- Keep the default compass square even when the terminal is
                 -- not square. Its width remains responsive while its height

--- a/src/scripts/DD/UpdateFunctions/update_affects.lua
+++ b/src/scripts/DD/UpdateFunctions/update_affects.lua
@@ -20,13 +20,9 @@ function update_affects()
     local has_mod = 0
     --display(name)
     if (gmcp.Char.Affect[1][count].name) ~= nil then
-      if (#gmcp.Char.Affect[1][count].name) > 18 then
-        local tmp_string = replace_char(18, gmcp.Char.Affect[1][count].name, '.')
-        local tmp_string = replace_char(17, tmp_string, '.')
-        AffectsConsole:cecho("<white>"..string.format("%.18s",tmp_string).."<reset>")
-      else
-        AffectsConsole:cecho("<white>"..string.format("%-18s", gmcp.Char.Affect[1][count].name).."<reset>")
-      end
+      AffectsConsole:cecho(
+        "<white>" .. tostring(gmcp.Char.Affect[1][count].name) .. "<reset>"
+      )
     end
     --[[if gmcp.Char.Affect[1][count].gives ~= nil then
       if gmcp.Char.Affect[1][count].gives ~= "some unknown effect" then

--- a/src/scripts/DD/UpdateFunctions/update_inventory.lua
+++ b/src/scripts/DD/UpdateFunctions/update_inventory.lua
@@ -44,14 +44,6 @@ local function compact_inventory_name(value)
   return name
 end
 
-local function fit_inventory_name(name, width)
-  if #name > width then
-    return string.sub(name, 1, width - 2) .. ".."
-  end
-
-  return string.format("%-" .. width .. "s", name)
-end
-
 function update_inventory()
   if not InventoryConsole then
     return
@@ -82,6 +74,6 @@ function update_inventory()
 
     InventoryConsole:cecho(
       "<white>" .. string.format("(%3d)", quantity) .. "<reset> ")
-    InventoryConsole:decho(fit_inventory_name(desc_string, 28) .. "\n")
+    InventoryConsole:decho(desc_string .. "\n")
   end
 end

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -110,8 +110,8 @@ function build_compass()
 
   local compass_constraints = {
     name = "compass.back",
-    x = "60%",
-    y = "82%",
+    x = "52%",
+    y = "70%",
     width = "8%",
     height = "8%",
     padding = 4,
@@ -126,6 +126,21 @@ function build_compass()
   compass.back = DD_GUI.new_adjustable_container and
     DD_GUI.new_adjustable_container(compass_constraints, main) or
     Geyser.Label:new(compass_constraints, main)
+
+  -- Migrate the old shipped position after Adjustable.Container has loaded
+  -- the profile layout. This keeps the correction one-time and preserves any
+  -- position the player has chosen themselves.
+  if tostring(compass.back.x) == "60%" and
+     tostring(compass.back.y) == "82%" then
+    compass.back:move("52%", "70%")
+    compass.back:resize("8%", "8%")
+    if compass.back.get_width then
+      compass.back:resize("8%", compass.back:get_width())
+    end
+    if compass.back.save then
+      compass.back:save()
+    end
+  end
 
   if compass.back._dd_gui_adjustable and not saved_layout and
      (not previous_geometry or previous_default_size) then


### PR DESCRIPTION
## Summary
- remove stale duplicate main-console and affects frames during package rebuilds
- migrate the compass from the old lower-right default and keep it clear of the console and gauges
- widen Inventory/Affects content and preserve full item and effect names with wrapping
- build and upload DD_GUI 0.0.10

## Verification
- ran `./scripts/build-and-upload.ps1`
- installed the uploaded package in a fresh Mudlet profile session
- visually verified borders, compass placement, and long inventory/affect text wrapping