### PR TITLE
Align affects columns and tighten character panel

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -317,7 +317,7 @@ function define_boxes()
         DD_GUI.MapBox = new_info_box({
           name = "DD_GUI.MapBox",
           x = "27%", y = "17%",
-          width = "16%",
+          width = "20%",
           height = "83%",
         },DD_GUI.Top)
         DD_GUI.MapBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
@@ -335,8 +335,8 @@ function define_boxes()
         
         DD_GUI.CharsheetBox = new_info_box({
           name = "DD_GUI.CharsheetBox",
-          x = "43%", y = "17%",
-          width = "23%",
+          x = "47%", y = "17%",
+          width = "19%",
           height = "83%",
         },DD_GUI.Top)
         DD_GUI.CharsheetBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())

--- a/src/scripts/DD/ResetLayout.lua
+++ b/src/scripts/DD/ResetLayout.lua
@@ -53,6 +53,27 @@ function DD_GUI.migrate_layout_defaults()
         local legacy_default = false
         local changed = false
 
+        local map_x = DD_GUI.MapBox and DD_GUI.MapBox.get_x and
+                tonumber(DD_GUI.MapBox:get_x()) or nil
+        local map_width = DD_GUI.MapBox and DD_GUI.MapBox.get_width and
+                tonumber(DD_GUI.MapBox:get_width()) or nil
+        local char_x = DD_GUI.CharsheetBox and DD_GUI.CharsheetBox.get_x and
+                tonumber(DD_GUI.CharsheetBox:get_x()) or nil
+        local char_width = DD_GUI.CharsheetBox and DD_GUI.CharsheetBox.get_width and
+                tonumber(DD_GUI.CharsheetBox:get_width()) or nil
+
+        -- The character sheet used to reserve the same width as the channel
+        -- panel. Migrate only that shipped geometry so user-customized layouts
+        -- remain untouched while the map receives the recovered space.
+        if approximately(map_x, window_width * 0.27, 2) and
+           approximately(map_width, window_width * 0.16, 2) and
+           approximately(char_x, window_width * 0.43, 2) and
+           approximately(char_width, window_width * 0.23, 2) then
+                reset_adjustable_box(DD_GUI.MapBox, "27%", "17%", "20%", "83%")
+                reset_adjustable_box(DD_GUI.CharsheetBox, "47%", "17%", "19%", "83%")
+                changed = true
+        end
+
         -- Existing profiles may have saved one of the previous shipped
         -- defaults. Only migrate those exact layouts; custom panel sizes and
         -- positions remain untouched.
@@ -103,8 +124,8 @@ function DD_GUI.migrate_layout_defaults()
                 { DD_GUI.Right, "-34%", "0%", "34%", "100%" },
                 { DD_GUI.Bottom, "0%", "94%", "66%", "6%" },
                 { DD_GUI.EnemyBox, "4%", "17%", "23%", "83%" },
-                { DD_GUI.MapBox, "27%", "17%", "16%", "83%" },
-                { DD_GUI.CharsheetBox, "43%", "17%", "23%", "83%" },
+                { DD_GUI.MapBox, "27%", "17%", "20%", "83%" },
+                { DD_GUI.CharsheetBox, "47%", "17%", "19%", "83%" },
                 { DD_GUI.ChannelBox, "66%", "17%", "31%", "83%" },
                 { DD_GUI.InventoryBox, "0%", "36%", "91%", "34%" },
                 { DD_GUI.AffectBox, "0%", "70%", "91%", "30%" },
@@ -144,8 +165,8 @@ function DD_GUI.reset_layout()
                 { DD_GUI.ThirdColumn, "52%", "0%", "23.5%", "100%" },
                 { DD_GUI.FourthColumn, "75.5%", "0%", "23.5%", "100%" },
                 { DD_GUI.EnemyBox, "4%", "17%", "23%", "83%" },
-                { DD_GUI.MapBox, "27%", "17%", "16%", "83%" },
-                { DD_GUI.CharsheetBox, "43%", "17%", "23%", "83%" },
+                { DD_GUI.MapBox, "27%", "17%", "20%", "83%" },
+                { DD_GUI.CharsheetBox, "47%", "17%", "19%", "83%" },
                 { DD_GUI.ChannelBox, "66%", "17%", "31%", "83%" },
                 { DD_GUI.InventoryBox, "0%", "36%", "91%", "34%" },
                 { DD_GUI.AffectBox, "0%", "70%", "91%", "30%" },

--- a/src/scripts/DD/UpdateFunctions/update_affects.lua
+++ b/src/scripts/DD/UpdateFunctions/update_affects.lua
@@ -1,59 +1,146 @@
 debug.setmetatable(nil, { __index=function () end })
 
+local function get_duration_text(value)
+  if value == nil then
+    return ""
+  end
+
+  local duration = tonumber(value)
+  if duration and duration < 0 then
+    return "indefinite"
+  elseif duration and duration == 0 then
+    return "< 1"
+  end
+
+  return tostring(value) .. " hrs"
+end
+
+local function get_console_width()
+  local width = tonumber(AffectsConsole:getColumnCount())
+  if not width or width < 1 then
+    return 60
+  end
+
+  return width
+end
+
+local function right_align(value, width)
+  value = tostring(value or "")
+  if #value >= width then
+    return value
+  end
+
+  return string.rep(" ", width - #value) .. value
+end
+
+local function center_align(value, width)
+  value = tostring(value or "")
+  if #value >= width then
+    return value
+  end
+
+  local padding = width - #value
+  local left_padding = math.floor(padding / 2)
+  return string.rep(" ", left_padding) .. value .. string.rep(" ", padding - left_padding)
+end
+
+local function emit_name_line(name, duration, width, duration_width)
+  name = tostring(name or "")
+  duration = tostring(duration or "")
+
+  if duration == "" then
+    AffectsConsole:cecho("<white>" .. name .. "<reset>\n")
+    return
+  end
+
+  local gap = width - #name - duration_width
+  if gap < 1 then
+    -- Keep long names intact and let the console wrap them before the duration.
+    AffectsConsole:cecho("<white>" .. name .. "<reset>\n")
+    AffectsConsole:cecho("<green>" .. right_align(duration, duration_width) .. "<reset>\n")
+    return
+  end
+
+  AffectsConsole:cecho("<white>" .. name .. "<reset>")
+  AffectsConsole:decho(string.rep(" ", gap))
+  AffectsConsole:cecho("<green>" .. right_align(duration, duration_width) .. "<reset>\n")
+end
+
 function update_affects()
   local duration_ordered = {}
-  for key, value in orderedPairs(gmcp.Char.Affect[1]) do
+  local affects = gmcp.Char.Affect[1]
+  for key, value in orderedPairs(affects) do
     duration_ordered[key] = value.duration
   end
 
-  --display(dump(duration_ordered))
-  local sorted_dur_keys = getKeysSortedByValue(duration_ordered, function(a, b) return tonumber(b) < tonumber(a) end)
-  --display(dump(sorted_dur_keys))
+  local sorted_dur_keys = getKeysSortedByValue(
+    duration_ordered,
+    function(a, b) return tonumber(b) < tonumber(a) end
+  )
 
   AffectsConsole:clear()
-  AffectsConsole:resetAutoWrap ()
+  AffectsConsole:resetAutoWrap()
   if next(sorted_dur_keys) == nil then
     AffectsConsole:cecho("Nothing.<reset>")
+    return
   end
 
-  for i, count in ipairs(sorted_dur_keys) do
-    local has_mod = 0
-    --display(name)
-    if (gmcp.Char.Affect[1][count].name) ~= nil then
+  local rows = {}
+  local duration_width = 0
+  local modifier_width = 0
+
+  for _, count in ipairs(sorted_dur_keys) do
+    local affect = affects[count]
+    local modifier = tostring(affect.modifies or "")
+    if string.lower(modifier) == "none" then
+      modifier = ""
+    end
+
+    local amount = ""
+    if affect.mod_amount ~= nil and tonumber(affect.mod_amount) ~= 0 then
+      amount = tostring(affect.mod_amount)
+    end
+
+    local duration = get_duration_text(affect.duration)
+    rows[#rows + 1] = {
+      name = affect.name or "",
+      modifier = modifier,
+      amount = amount,
+      duration = duration,
+      has_detail = modifier ~= "" or amount ~= ""
+    }
+
+    duration_width = math.max(duration_width, #duration)
+    modifier_width = math.max(modifier_width, #modifier)
+  end
+
+  local width = get_console_width()
+  duration_width = math.max(1, duration_width)
+
+  -- Reserve the final column for durations, and center amounts in everything
+  -- between the left-hand modifier column and that duration column.
+  local left_width = math.max(1, modifier_width)
+  local available_left = math.max(1, width - duration_width - 3)
+  left_width = math.min(left_width, available_left)
+  local middle_width = math.max(1, width - left_width - duration_width - 2)
+
+  for _, row in ipairs(rows) do
+    if row.has_detail then
+      emit_name_line(row.name, "", width, duration_width)
+
+      local modifier_field = string.rep(" ", left_width)
+      if row.modifier ~= "" then
+        modifier_field = row.modifier
+      end
+
+      local amount_field = center_align(row.amount, middle_width)
       AffectsConsole:cecho(
-        "<white>" .. tostring(gmcp.Char.Affect[1][count].name) .. "<reset>"
+        "<green>" .. modifier_field .. "<reset> " ..
+        "<yellow>" .. amount_field .. "<reset> " ..
+        "<green>" .. right_align(row.duration, duration_width) .. "<reset>\n"
       )
-    end
-    --[[if gmcp.Char.Affect[1][count].gives ~= nil then
-      if gmcp.Char.Affect[1][count].gives ~= "some unknown effect" then
-        AffectsConsole:cecho("gives: <green>"     ..gmcp.Char.Affect[1][count].gives..      "<reset>\n")
-      end
-    end]]--
-    if gmcp.Char.Affect[1][count].modifies ~= nil then
-      if gmcp.Char.Affect[1][count].modifies ~= "none" then
-        AffectsConsole:cecho("\n<green>"..string.format("%-13s", gmcp.Char.Affect[1][count].modifies).."<reset>")
-      end
-    end
-    if gmcp.Char.Affect[1][count].mod_amount ~= nil then
-      if tonumber(gmcp.Char.Affect[1][count].mod_amount) ~= 0 then
-        has_mod = 1
-        AffectsConsole:cecho("<yellow>"       ..string.format("%11s", gmcp.Char.Affect[1][count].mod_amount).. "<reset>")
-      end
-    end
-    if gmcp.Char.Affect[1][count].duration ~= nil then
-      if tonumber(gmcp.Char.Affect[1][count].duration) < 0 then
-        AffectsConsole:cecho("<green>" ..string.format("%17s","indefinite").. "<reset>\n")
-      elseif tonumber(gmcp.Char.Affect[1][count].duration) == 0 and has_mod == 1 then
-        AffectsConsole:cecho("<green>" ..string.format("%13s","< 1").. "<reset>\n")
-        has_mod = 0
-      elseif tonumber(gmcp.Char.Affect[1][count].duration) == 0 and has_mod == 0 then
-        AffectsConsole:cecho("<green>" ..string.format("%17s","< 1").. "<reset>\n")
-      elseif has_mod == 1 then
-        AffectsConsole:cecho("<green>"  ..string.format("%9s",gmcp.Char.Affect[1][count].duration)..   "<reset> hrs\n")
-        has_mod = 0
-      else
-        AffectsConsole:cecho("<green>"  ..string.format("%15s",gmcp.Char.Affect[1][count].duration)..   "<reset> hrs\n")
-      end
+    else
+      emit_name_line(row.name, row.duration, width, duration_width)
     end
   end
 end


### PR DESCRIPTION
## Summary\n- align affect names, modifier amounts, and durations into responsive columns\n- tighten the character sheet panel and expand the map\n- migrate existing default layouts and publish DD_GUI 0.0.11\n\n## Verification\n- built and uploaded with scripts/build-and-upload.ps1\n- visually checked in the Mudlet DD4 - Owltest profile