### PR TITLE
Widen map and align right rail

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -317,7 +317,7 @@ function define_boxes()
         DD_GUI.MapBox = new_info_box({
           name = "DD_GUI.MapBox",
           x = "27%", y = "17%",
-          width = "20%",
+          width = "27%",
           height = "83%",
         },DD_GUI.Top)
         DD_GUI.MapBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
@@ -335,8 +335,8 @@ function define_boxes()
         
         DD_GUI.CharsheetBox = new_info_box({
           name = "DD_GUI.CharsheetBox",
-          x = "47%", y = "17%",
-          width = "19%",
+          x = "54%", y = "17%",
+          width = "18%",
           height = "83%",
         },DD_GUI.Top)
         DD_GUI.CharsheetBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
@@ -344,8 +344,8 @@ function define_boxes()
         
         DD_GUI.ChannelBox = new_info_box({
           name = "DD_GUI.ChannelBox",
-          x = "66%", y = "17%",
-          width = "31%",
+          x = "72%", y = "17%",
+          width = "25%",
           height = "83%",
         },DD_GUI.Top)
         DD_GUI.ChannelBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())

--- a/src/scripts/DD/CreateBackground.lua
+++ b/src/scripts/DD/CreateBackground.lua
@@ -8,8 +8,8 @@ function create_background()
         
         DD_GUI.Right = DD_GUI.new_adjustable_region({
           name = "DD_GUI.Right",
-          x = "-34%", y = "0%",
-          width = "34%",
+          x = "-28%", y = "0%",
+          width = "28%",
           height = "100%",
           padding = 0,
         }, nil, background_css)
@@ -25,7 +25,7 @@ function create_background()
         DD_GUI.Bottom = DD_GUI.new_adjustable_region({
           name = "DD_GUI.Bottom",
           x = "0%", y = "94%",
-          width = "66%",
+          width = "72%",
           height = "6%",
           padding = 0,
         }, nil, background_css, {direct = true})

--- a/src/scripts/DD/MainWindow.lua
+++ b/src/scripts/DD/MainWindow.lua
@@ -32,7 +32,7 @@ function ui_container()
         local mainconsole_constraints = {
                 name = "DD_GUI.MainConsole",
                 x = "4%", y = "38%",
-                width = "62%", height = "56%",
+                width = "68%", height = "56%",
         }
 
         ui.mainconsole_container = DD_GUI.new_adjustable_container and

--- a/src/scripts/DD/ResetLayout.lua
+++ b/src/scripts/DD/ResetLayout.lua
@@ -62,15 +62,21 @@ function DD_GUI.migrate_layout_defaults()
         local char_width = DD_GUI.CharsheetBox and DD_GUI.CharsheetBox.get_width and
                 tonumber(DD_GUI.CharsheetBox:get_width()) or nil
 
-        -- The character sheet used to reserve the same width as the channel
-        -- panel. Migrate only that shipped geometry so user-customized layouts
-        -- remain untouched while the map receives the recovered space.
-        if approximately(map_x, window_width * 0.27, 2) and
-           approximately(map_width, window_width * 0.16, 2) and
-           approximately(char_x, window_width * 0.43, 2) and
-           approximately(char_width, window_width * 0.23, 2) then
-                reset_adjustable_box(DD_GUI.MapBox, "27%", "17%", "20%", "83%")
-                reset_adjustable_box(DD_GUI.CharsheetBox, "47%", "17%", "19%", "83%")
+        -- Migrate only shipped geometries so user-customized layouts remain
+        -- untouched while the map receives the recovered space.
+        local legacy_top_layout =
+                approximately(map_x, window_width * 0.27, 8) and
+                approximately(map_width, window_width * 0.16, 8) and
+                approximately(char_x, window_width * 0.43, 8) and
+                approximately(char_width, window_width * 0.23, 8)
+        local previous_top_layout =
+                approximately(map_x, window_width * 0.27, 8) and
+                approximately(map_width, window_width * 0.20, 8) and
+                approximately(char_x, window_width * 0.47, 8) and
+                approximately(char_width, window_width * 0.19, 8)
+        if legacy_top_layout or previous_top_layout then
+                reset_adjustable_box(DD_GUI.MapBox, "27%", "17%", "27%", "83%")
+                reset_adjustable_box(DD_GUI.CharsheetBox, "54%", "17%", "18%", "83%")
                 changed = true
         end
 
@@ -79,12 +85,11 @@ function DD_GUI.migrate_layout_defaults()
         -- positions remain untouched.
         for _, legacy in ipairs({
                 { x = 0.74, width = 0.26 },
-                { x = 0.72, width = 0.28 },
                 { x = 0.68, width = 0.32 },
                 { x = 0.66, width = 0.34 },
         }) do
-                if approximately(right_x, window_width * legacy.x, 2) and
-                   approximately(right_width, window_width * legacy.width, 2) then
+                if approximately(right_x, window_width * legacy.x, 12) and
+                   approximately(right_width, window_width * legacy.width, 12) then
                         legacy_default = true
                         break
                 end
@@ -120,13 +125,13 @@ function DD_GUI.migrate_layout_defaults()
         end
 
         local defaults = {
-                { ui and ui.mainconsole_container, "4%", "38%", "62%", "56%" },
-                { DD_GUI.Right, "-34%", "0%", "34%", "100%" },
-                { DD_GUI.Bottom, "0%", "94%", "66%", "6%" },
+                { ui and ui.mainconsole_container, "4%", "38%", "68%", "56%" },
+                { DD_GUI.Right, "-28%", "0%", "28%", "100%" },
+                { DD_GUI.Bottom, "0%", "94%", "72%", "6%" },
                 { DD_GUI.EnemyBox, "4%", "17%", "23%", "83%" },
-                { DD_GUI.MapBox, "27%", "17%", "20%", "83%" },
-                { DD_GUI.CharsheetBox, "47%", "17%", "19%", "83%" },
-                { DD_GUI.ChannelBox, "66%", "17%", "31%", "83%" },
+                { DD_GUI.MapBox, "27%", "17%", "27%", "83%" },
+                { DD_GUI.CharsheetBox, "54%", "17%", "18%", "83%" },
+                { DD_GUI.ChannelBox, "72%", "17%", "25%", "83%" },
                 { DD_GUI.InventoryBox, "0%", "36%", "91%", "34%" },
                 { DD_GUI.AffectBox, "0%", "70%", "91%", "30%" },
         }
@@ -156,18 +161,18 @@ end
 
 function DD_GUI.reset_layout()
         local defaults = {
-                { ui and ui.mainconsole_container, "4%", "38%", "62%", "56%" },
-                { DD_GUI.Right, "-34%", "0%", "34%", "100%" },
+                { ui and ui.mainconsole_container, "4%", "38%", "68%", "56%" },
+                { DD_GUI.Right, "-28%", "0%", "28%", "100%" },
                 { DD_GUI.Top, "0%", "0%", "100%", "36%" },
-                { DD_GUI.Bottom, "0%", "94%", "66%", "6%" },
+                { DD_GUI.Bottom, "0%", "94%", "72%", "6%" },
                 { DD_GUI.FirstColumn, "5%", "0%", "23.5%", "100%" },
                 { DD_GUI.SecondColumn, "28.5%", "0%", "23.5%", "100%" },
                 { DD_GUI.ThirdColumn, "52%", "0%", "23.5%", "100%" },
                 { DD_GUI.FourthColumn, "75.5%", "0%", "23.5%", "100%" },
                 { DD_GUI.EnemyBox, "4%", "17%", "23%", "83%" },
-                { DD_GUI.MapBox, "27%", "17%", "20%", "83%" },
-                { DD_GUI.CharsheetBox, "47%", "17%", "19%", "83%" },
-                { DD_GUI.ChannelBox, "66%", "17%", "31%", "83%" },
+                { DD_GUI.MapBox, "27%", "17%", "27%", "83%" },
+                { DD_GUI.CharsheetBox, "54%", "17%", "18%", "83%" },
+                { DD_GUI.ChannelBox, "72%", "17%", "25%", "83%" },
                 { DD_GUI.InventoryBox, "0%", "36%", "91%", "34%" },
                 { DD_GUI.AffectBox, "0%", "70%", "91%", "30%" },
         }

--- a/src/scripts/DD/SetBorders.lua
+++ b/src/scripts/DD/SetBorders.lua
@@ -3,6 +3,6 @@ function set_borders()
         local padding = tonumber(DD_GUI and DD_GUI.mainconsole_padding) or 8
         setBorderTop((h * 36) / 100 + padding)
         setBorderBottom((h * 6) / 100 + padding)
-        setBorderRight((w * 34) / 100 + padding)
+        setBorderRight((w * 28) / 100 + padding)
         setBorderLeft(padding)
 end

--- a/src/scripts/DD/UpdateFunctions/update_affects.lua
+++ b/src/scripts/DD/UpdateFunctions/update_affects.lua
@@ -87,7 +87,7 @@ function update_affects()
 
   local rows = {}
   local duration_width = 0
-  local modifier_width = 0
+  local amount_width = 0
 
   for _, count in ipairs(sorted_dur_keys) do
     local affect = affects[count]
@@ -111,32 +111,37 @@ function update_affects()
     }
 
     duration_width = math.max(duration_width, #duration)
-    modifier_width = math.max(modifier_width, #modifier)
+    amount_width = math.max(amount_width, #amount)
   end
 
   local width = get_console_width()
   duration_width = math.max(1, duration_width)
 
-  -- Reserve the final column for durations, and center amounts in everything
-  -- between the left-hand modifier column and that duration column.
-  local left_width = math.max(1, modifier_width)
-  local available_left = math.max(1, width - duration_width - 3)
-  left_width = math.min(left_width, available_left)
-  local middle_width = math.max(1, width - left_width - duration_width - 2)
+  -- Keep the modifier at the left edge, the amount at the center of the
+  -- console, and the duration at the right edge. The fields are calculated
+  -- from the current console width so the layout survives panel resizing.
+  amount_width = math.max(1, amount_width)
+  local left_width = math.max(1, math.floor((width - amount_width) / 2) - 1)
+  local trailing_width = width - left_width - amount_width - duration_width - 2
+  if trailing_width < 1 then
+    trailing_width = 1
+    left_width = math.max(1, width - amount_width - duration_width - 3)
+  end
 
   for _, row in ipairs(rows) do
     if row.has_detail then
       emit_name_line(row.name, "", width, duration_width)
 
-      local modifier_field = string.rep(" ", left_width)
-      if row.modifier ~= "" then
-        modifier_field = row.modifier
+      local modifier_field = row.modifier
+      if #modifier_field < left_width then
+        modifier_field = modifier_field .. string.rep(" ", left_width - #modifier_field)
       end
 
-      local amount_field = center_align(row.amount, middle_width)
+      local amount_field = center_align(row.amount, amount_width)
       AffectsConsole:cecho(
         "<green>" .. modifier_field .. "<reset> " ..
         "<yellow>" .. amount_field .. "<reset> " ..
+        string.rep(" ", trailing_width) ..
         "<green>" .. right_align(row.duration, duration_width) .. "<reset>\n"
       )
     else


### PR DESCRIPTION
## Summary
- move the right rail to 28% and align main, channel, and gauge borders
- widen the map and tighten the character sheet
- center affect amounts and align durations responsively
- publish DD_GUI 0.0.13

## Verification
- built and uploaded with scripts/build-and-upload.ps1
- visually checked in Mudlet DD4 - Owltest