### PR TITLE
Refine default layout spacing and tab states

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.14",
+  "version": "0.0.19",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -164,6 +164,34 @@ function DD_GUI.raise_info_box_contents()
                         end
                 end
 
+                -- Child consoles sit above the adjustable surface during the
+                -- normal z-order pass. Raise the transparent frame surfaces
+                -- again so their red borders remain visible without masking
+                -- the click-through tab and console contents.
+                for _, box in pairs(Adjustable.Container.all) do
+                        if box and box.goInside ~= false and box.adjLabel and
+                           box.adjLabel.raise then
+                                box.adjLabel:raise()
+                        end
+                end
+
+                -- Keep the named information panels reliable across package
+                -- rebuilds, where Adjustable.Container.all can briefly hold
+                -- stale entries while the new children are being attached.
+                for _, box in ipairs({
+                        DD_GUI.EnemyBox,
+                        DD_GUI.MapBox,
+                        DD_GUI.CharsheetBox,
+                        DD_GUI.ChannelBox,
+                        DD_GUI.InventoryBox,
+                        DD_GUI.AffectBox,
+                }) do
+                        if box and box.adjLabel and box.adjLabel.raise then
+                                box.adjLabel:raise()
+                        end
+                end
+                raise_tab_rails()
+
                 if ui and ui.mainconsole_container and
                    ui.mainconsole_container.adjLabel and
                    ui.mainconsole_container.adjLabel.raise then
@@ -307,18 +335,18 @@ function define_boxes()
         
         DD_GUI.EnemyBox = new_info_box({
           name = "DD_GUI.EnemyBox",
-          x = "4%", y = "17%",
+          x = "4%", y = "2%",
           width = "23%",
-          height = "83%",
+          height = "98%",
         },DD_GUI.Top)
         DD_GUI.EnemyBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.EnemyBox:echo("<center>GUI.EnemyBox")
         
         DD_GUI.MapBox = new_info_box({
           name = "DD_GUI.MapBox",
-          x = "27%", y = "17%",
+          x = "27%", y = "2%",
           width = "27%",
-          height = "83%",
+          height = "98%",
         },DD_GUI.Top)
         DD_GUI.MapBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.MapBox:echo("<center>GUI.MapBox")
@@ -335,18 +363,18 @@ function define_boxes()
         
         DD_GUI.CharsheetBox = new_info_box({
           name = "DD_GUI.CharsheetBox",
-          x = "54%", y = "17%",
+          x = "54%", y = "2%",
           width = "18%",
-          height = "83%",
+          height = "98%",
         },DD_GUI.Top)
         DD_GUI.CharsheetBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.CharsheetBox:echo("<center>GUI.CharsheetBox")
         
         DD_GUI.ChannelBox = new_info_box({
           name = "DD_GUI.ChannelBox",
-          x = "72%", y = "17%",
+          x = "72%", y = "2%",
           width = "25%",
-          height = "83%",
+          height = "98%",
         },DD_GUI.Top)
         DD_GUI.ChannelBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.ChannelBox:echo("<center>GUI.ChannelBox")
@@ -354,7 +382,7 @@ function define_boxes()
         DD_GUI.InventoryBox = new_info_box({
           name = "DD_GUI.InventoryBox",
           x = "0%", y = "36%",
-          width = "91%",
+          width = "89.29%",
           height = "34%",
         },DD_GUI.Right)
         DD_GUI.InventoryBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
@@ -363,7 +391,7 @@ function define_boxes()
         DD_GUI.AffectBox = new_info_box({
           name = "DD_GUI.AffectBox",
           x = "0%", y = "70%",
-          width = "91%",
+          width = "89.29%",
           height = "30%",
         },DD_GUI.Right)
         DD_GUI.AffectBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())

--- a/src/scripts/DD/DD_GUI.GaugesBox.lua
+++ b/src/scripts/DD/DD_GUI.GaugesBox.lua
@@ -116,29 +116,29 @@ function build_gauges()
 
     DD_GUI.FirstColumn = new_gauge_column({
       name = "DD_GUI.FirstColumn",
-      x = "5%", y = "0%",
-      width = "23.5%", height = "100%",
+      x = "5.56%", y = "0%",
+      width = "23.36%", height = "100%",
       padding = 0,
     })
 
     DD_GUI.SecondColumn = new_gauge_column({
       name = "DD_GUI.SecondColumn",
-      x = "28.5%", y = "0%",
-      width = "23.5%", height = "100%",
+      x = "28.92%", y = "0%",
+      width = "23.36%", height = "100%",
       padding = 0,
     })
 
     DD_GUI.ThirdColumn = new_gauge_column({
       name = "DD_GUI.ThirdColumn",
-      x = "52%", y = "0%",
-      width = "23.5%", height = "100%",
+      x = "52.28%", y = "0%",
+      width = "23.36%", height = "100%",
       padding = 0,
     })
 
     DD_GUI.FourthColumn = new_gauge_column({
       name = "DD_GUI.FourthColumn",
-      x = "75.5%", y = "0%",
-      width = "23.5%", height = "100%",
+      x = "75.64%", y = "0%",
+      width = "23.36%", height = "100%",
       padding = 0,
     })
 

--- a/src/scripts/DD/GoldBoxTheme.lua
+++ b/src/scripts/DD/GoldBoxTheme.lua
@@ -16,6 +16,7 @@ Theme.colors = {
         bright_gold = "rgb(239,210,118)",
         dark_gold = "rgb(105,82,36)",
         ivory = "rgb(240,235,213)",
+        white = "rgb(255,255,255)",
         muted = "rgb(153,160,174)",
         blue_grey = "rgb(72,91,123)",
         hp = "rgb(181,42,48)",
@@ -59,7 +60,7 @@ function Theme:tab_css(active, drop_target)
                         border-color: %s;
                         border-radius: 0px;
                         margin: 1px;
-                ]], self.colors.gold, self.colors.ink, self.colors.bright_frame)
+                ]], self.colors.white, self.colors.ink, self.colors.bright_frame)
         end
 
         if drop_target then

--- a/src/scripts/DD/MainWindow.lua
+++ b/src/scripts/DD/MainWindow.lua
@@ -31,8 +31,8 @@ function ui_container()
         -- Transparent adjustable overlay used to define the main MUD console area.
         local mainconsole_constraints = {
                 name = "DD_GUI.MainConsole",
-                x = "4%", y = "38%",
-                width = "68%", height = "56%",
+                x = "4%", y = "36%",
+                width = "68%", height = "58%",
         }
 
         ui.mainconsole_container = DD_GUI.new_adjustable_container and

--- a/src/scripts/DD/ResetLayout.lua
+++ b/src/scripts/DD/ResetLayout.lua
@@ -52,6 +52,10 @@ function DD_GUI.migrate_layout_defaults()
         local right_width = tonumber(DD_GUI.Right:get_width()) or 0
         local legacy_default = false
         local changed = false
+        local inventory_width = DD_GUI.InventoryBox and DD_GUI.InventoryBox.get_width and
+                tonumber(DD_GUI.InventoryBox:get_width()) or nil
+        local affect_width = DD_GUI.AffectBox and DD_GUI.AffectBox.get_width and
+                tonumber(DD_GUI.AffectBox:get_width()) or nil
 
         local map_x = DD_GUI.MapBox and DD_GUI.MapBox.get_x and
                 tonumber(DD_GUI.MapBox:get_x()) or nil
@@ -61,6 +65,36 @@ function DD_GUI.migrate_layout_defaults()
                 tonumber(DD_GUI.CharsheetBox:get_x()) or nil
         local char_width = DD_GUI.CharsheetBox and DD_GUI.CharsheetBox.get_width and
                 tonumber(DD_GUI.CharsheetBox:get_width()) or nil
+        local map_y = DD_GUI.MapBox and DD_GUI.MapBox.get_y and
+                tonumber(DD_GUI.MapBox:get_y()) or nil
+        local map_height = DD_GUI.MapBox and DD_GUI.MapBox.get_height and
+                tonumber(DD_GUI.MapBox:get_height()) or nil
+        local char_y = DD_GUI.CharsheetBox and DD_GUI.CharsheetBox.get_y and
+                tonumber(DD_GUI.CharsheetBox:get_y()) or nil
+        local char_height = DD_GUI.CharsheetBox and DD_GUI.CharsheetBox.get_height and
+                tonumber(DD_GUI.CharsheetBox:get_height()) or nil
+
+        local main_x = ui and ui.mainconsole_container and
+                ui.mainconsole_container.get_x and
+                tonumber(ui.mainconsole_container:get_x()) or nil
+        local main_y = ui and ui.mainconsole_container and
+                ui.mainconsole_container.get_y and
+                tonumber(ui.mainconsole_container:get_y()) or nil
+        local main_width = ui and ui.mainconsole_container and
+                ui.mainconsole_container.get_width and
+                tonumber(ui.mainconsole_container:get_width()) or nil
+        local main_height = ui and ui.mainconsole_container and
+                ui.mainconsole_container.get_height and
+                tonumber(ui.mainconsole_container:get_height()) or nil
+
+        local bottom_width = DD_GUI.Bottom and DD_GUI.Bottom.get_width and
+                tonumber(DD_GUI.Bottom:get_width()) or window_width * 0.72
+        local gauge_columns = {
+                DD_GUI.FirstColumn,
+                DD_GUI.SecondColumn,
+                DD_GUI.ThirdColumn,
+                DD_GUI.FourthColumn,
+        }
 
         -- Migrate only shipped geometries so user-customized layouts remain
         -- untouched while the map receives the recovered space.
@@ -74,9 +108,102 @@ function DD_GUI.migrate_layout_defaults()
                 approximately(map_width, window_width * 0.20, 8) and
                 approximately(char_x, window_width * 0.47, 8) and
                 approximately(char_width, window_width * 0.19, 8)
-        if legacy_top_layout or previous_top_layout then
-                reset_adjustable_box(DD_GUI.MapBox, "27%", "17%", "27%", "83%")
-                reset_adjustable_box(DD_GUI.CharsheetBox, "54%", "17%", "18%", "83%")
+
+        local current_top_layout =
+                approximately(map_x, window_width * 0.27, 8) and
+                approximately(map_width, window_width * 0.27, 8) and
+                approximately(map_y, window_height * 0.0612, 8) and
+                approximately(map_height, window_height * 0.2988, 8) and
+                approximately(char_x, window_width * 0.54, 8) and
+                approximately(char_width, window_width * 0.18, 8) and
+                approximately(char_y, window_height * 0.0612, 8) and
+                approximately(char_height, window_height * 0.2988, 8)
+        if legacy_top_layout or previous_top_layout or current_top_layout then
+                reset_adjustable_box(DD_GUI.EnemyBox, "4%", "2%", "23%", "98%")
+                reset_adjustable_box(DD_GUI.MapBox, "27%", "2%", "27%", "98%")
+                reset_adjustable_box(DD_GUI.CharsheetBox, "54%", "2%", "18%", "98%")
+                reset_adjustable_box(DD_GUI.ChannelBox, "72%", "2%", "25%", "98%")
+                changed = true
+        end
+
+        if approximately(main_x, window_width * 0.04, 8) and
+           approximately(main_y, window_height * 0.38, 8) and
+           approximately(main_width, window_width * 0.68, 8) and
+           approximately(main_height, window_height * 0.56, 8) then
+                reset_adjustable_box(
+                        ui and ui.mainconsole_container,
+                        "4%", "36%", "68%", "58%"
+                )
+                changed = true
+        end
+
+        local old_gauge_columns = true
+        local old_gauge_positions = { 0.05, 0.285, 0.52, 0.755 }
+        local current_gauge_columns = true
+        local current_gauge_positions = { 0.0556, 0.2917, 0.5278, 0.7639 }
+        for index, column in ipairs(gauge_columns) do
+                local column_x = column and column.get_x and
+                        tonumber(column:get_x()) or nil
+                local column_width = column and column.get_width and
+                        tonumber(column:get_width()) or nil
+                local matches_old = column and column.get_x and
+                        column.get_width and
+                        approximately(
+                                column_x,
+                                bottom_width * old_gauge_positions[index],
+                                8
+                        ) and approximately(
+                                column_width,
+                                bottom_width * 0.235,
+                                8
+                        )
+                local matches_current = column and column.get_x and
+                        column.get_width and
+                        approximately(
+                                column_x,
+                                bottom_width * current_gauge_positions[index],
+                                8
+                        ) and approximately(
+                                column_width,
+                                bottom_width * 0.2361,
+                                8
+                        )
+                if not matches_old then
+                        old_gauge_columns = false
+                end
+                if not matches_current then
+                        current_gauge_columns = false
+                end
+        end
+        if old_gauge_columns or current_gauge_columns then
+                local new_gauge_columns = {
+                        { "5.56%", "23.36%" },
+                        { "28.92%", "23.36%" },
+                        { "52.28%", "23.36%" },
+                        { "75.64%", "23.36%" },
+                }
+                for index, column in ipairs(gauge_columns) do
+                        reset_adjustable_box(
+                                column,
+                                new_gauge_columns[index][1],
+                                "0%",
+                                new_gauge_columns[index][2],
+                                "100%"
+                        )
+                end
+                changed = true
+        end
+
+        if approximately(inventory_width, right_width * 0.91, 8) and
+           approximately(affect_width, right_width * 0.91, 8) then
+                reset_adjustable_box(
+                        DD_GUI.InventoryBox,
+                        "0%", "36%", "89.29%", "34%"
+                )
+                reset_adjustable_box(
+                        DD_GUI.AffectBox,
+                        "0%", "70%", "89.29%", "30%"
+                )
                 changed = true
         end
 
@@ -125,15 +252,19 @@ function DD_GUI.migrate_layout_defaults()
         end
 
         local defaults = {
-                { ui and ui.mainconsole_container, "4%", "38%", "68%", "56%" },
+                { ui and ui.mainconsole_container, "4%", "36%", "68%", "58%" },
                 { DD_GUI.Right, "-28%", "0%", "28%", "100%" },
                 { DD_GUI.Bottom, "0%", "94%", "72%", "6%" },
-                { DD_GUI.EnemyBox, "4%", "17%", "23%", "83%" },
-                { DD_GUI.MapBox, "27%", "17%", "27%", "83%" },
-                { DD_GUI.CharsheetBox, "54%", "17%", "18%", "83%" },
-                { DD_GUI.ChannelBox, "72%", "17%", "25%", "83%" },
-                { DD_GUI.InventoryBox, "0%", "36%", "91%", "34%" },
-                { DD_GUI.AffectBox, "0%", "70%", "91%", "30%" },
+                { DD_GUI.FirstColumn, "5.56%", "0%", "23.36%", "100%" },
+                { DD_GUI.SecondColumn, "28.92%", "0%", "23.36%", "100%" },
+                { DD_GUI.ThirdColumn, "52.28%", "0%", "23.36%", "100%" },
+                { DD_GUI.FourthColumn, "75.64%", "0%", "23.36%", "100%" },
+                { DD_GUI.EnemyBox, "4%", "2%", "23%", "98%" },
+                { DD_GUI.MapBox, "27%", "2%", "27%", "98%" },
+                { DD_GUI.CharsheetBox, "54%", "2%", "18%", "98%" },
+                { DD_GUI.ChannelBox, "72%", "2%", "25%", "98%" },
+                { DD_GUI.InventoryBox, "0%", "36%", "89.29%", "34%" },
+                { DD_GUI.AffectBox, "0%", "70%", "89.29%", "30%" },
         }
 
         for _, default_box in ipairs(defaults) do
@@ -161,20 +292,20 @@ end
 
 function DD_GUI.reset_layout()
         local defaults = {
-                { ui and ui.mainconsole_container, "4%", "38%", "68%", "56%" },
+                { ui and ui.mainconsole_container, "4%", "36%", "68%", "58%" },
                 { DD_GUI.Right, "-28%", "0%", "28%", "100%" },
                 { DD_GUI.Top, "0%", "0%", "100%", "36%" },
                 { DD_GUI.Bottom, "0%", "94%", "72%", "6%" },
-                { DD_GUI.FirstColumn, "5%", "0%", "23.5%", "100%" },
-                { DD_GUI.SecondColumn, "28.5%", "0%", "23.5%", "100%" },
-                { DD_GUI.ThirdColumn, "52%", "0%", "23.5%", "100%" },
-                { DD_GUI.FourthColumn, "75.5%", "0%", "23.5%", "100%" },
-                { DD_GUI.EnemyBox, "4%", "17%", "23%", "83%" },
-                { DD_GUI.MapBox, "27%", "17%", "27%", "83%" },
-                { DD_GUI.CharsheetBox, "54%", "17%", "18%", "83%" },
-                { DD_GUI.ChannelBox, "72%", "17%", "25%", "83%" },
-                { DD_GUI.InventoryBox, "0%", "36%", "91%", "34%" },
-                { DD_GUI.AffectBox, "0%", "70%", "91%", "30%" },
+                { DD_GUI.FirstColumn, "5.56%", "0%", "23.36%", "100%" },
+                { DD_GUI.SecondColumn, "28.92%", "0%", "23.36%", "100%" },
+                { DD_GUI.ThirdColumn, "52.28%", "0%", "23.36%", "100%" },
+                { DD_GUI.FourthColumn, "75.64%", "0%", "23.36%", "100%" },
+                { DD_GUI.EnemyBox, "4%", "2%", "23%", "98%" },
+                { DD_GUI.MapBox, "27%", "2%", "27%", "98%" },
+                { DD_GUI.CharsheetBox, "54%", "2%", "18%", "98%" },
+                { DD_GUI.ChannelBox, "72%", "2%", "25%", "98%" },
+                { DD_GUI.InventoryBox, "0%", "36%", "89.29%", "34%" },
+                { DD_GUI.AffectBox, "0%", "70%", "89.29%", "30%" },
         }
 
         for _, default_box in ipairs(defaults) do


### PR DESCRIPTION
## Summary
- balance the default top and bottom black margins and butt the main console to the top row
- keep inventory and affects frames aligned with the comms right edge
- retain a small right margin after the Moves gauge and align gauges to the main console
- keep panel frames visible after z-order rebuilds
- render active tabs white with black text
- publish DD_GUI 0.0.19

## Verification
- built and uploaded with scripts/build-and-upload.ps1
- installed in Mudlet DD4 - Owltest
- visually checked at full-screen dimensions