### PR TITLE
Restore GUI data after rebuilds and enlarge compass

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.19",
+  "version": "0.0.23",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -108,6 +108,46 @@ local function raise_children(container)
         end
 end
 
+local function raise_widget(widget)
+        if not widget then
+                return
+        end
+
+        if widget.raise then
+                widget:raise()
+        elseif widget.raiseAll then
+                widget:raiseAll()
+        end
+end
+
+local function raise_data_surfaces()
+        -- Adjustable.Container keeps its drag surface above its children.
+        -- Raise the actual data widgets after the frame pass so a transparent
+        -- border can never hide text, images, or channel history.
+        for _, widget in ipairs({
+                DD_GUI and DD_GUI.Mapper,
+                EnemyConsole,
+                EnemyTPConsoleTop,
+                EnemyInfoConsole,
+                EnemyConsoleHitpointsContainer,
+                EnemyConsoleHitpoints,
+                EnemyHitpointsLabel,
+                CharsheetPFPConsole,
+                CharsheetConsole,
+                InventoryConsole,
+                EquippedConsole,
+                AffectsConsole,
+        }) do
+                raise_widget(widget)
+        end
+
+        if DD_GUI and DD_GUI.Comms and DD_GUI.Comms.consoles then
+                for _, console in pairs(DD_GUI.Comms.consoles) do
+                        raise_widget(console)
+                end
+        end
+end
+
 local function raise_tab_rails()
         local rails = {}
         if DD_GUI.Comms and DD_GUI.Comms.tab_rail then
@@ -126,6 +166,26 @@ local function raise_tab_rails()
                 elseif rail and rail.raise then
                         rail:raise()
                 end
+        end
+end
+
+local function raise_tab_controls()
+        raise_tab_rails()
+
+        if DD_GUI and DD_GUI.Comms and DD_GUI.Comms.tab_buttons then
+                for _, button in pairs(DD_GUI.Comms.tab_buttons) do
+                        raise_widget(button)
+                end
+        end
+
+        if DD_GUI and DD_GUI.Inventory and DD_GUI.Inventory.tab_buttons then
+                for _, button in pairs(DD_GUI.Inventory.tab_buttons) do
+                        raise_widget(button)
+                end
+        end
+
+        if DD_GUI and DD_GUI.Affects and DD_GUI.Affects.tab_button then
+                raise_widget(DD_GUI.Affects.tab_button)
         end
 end
 
@@ -191,6 +251,8 @@ function DD_GUI.raise_info_box_contents()
                         end
                 end
                 raise_tab_rails()
+                raise_data_surfaces()
+                raise_tab_controls()
 
                 if ui and ui.mainconsole_container and
                    ui.mainconsole_container.adjLabel and
@@ -218,6 +280,7 @@ function DD_GUI.raise_info_box_contents()
                 if compass and compass.handle and compass.handle.raise then
                         compass.handle:raise()
                 end
+                raise_tab_controls()
                 return
         end
 
@@ -237,6 +300,9 @@ function DD_GUI.raise_info_box_contents()
                         box.Inside:raiseAll()
                 end
         end
+
+        raise_data_surfaces()
+        raise_tab_controls()
 
         if ui and ui.mainconsole_container and
            ui.mainconsole_container.adjLabel and

--- a/src/scripts/DD/ChannelConsole.lua
+++ b/src/scripts/DD/ChannelConsole.lua
@@ -436,7 +436,7 @@ function DD_GUI.Comms:style_tab(key)
 
         label:setStyleSheet(self:tab_css(key))
         if key == self.current_tab then
-                label:echo(self:tab_label(key), "black", "c")
+                label:echo(self:tab_label(key), "white", "c")
         else
                 label:echo(self:tab_label(key), "<" .. self:rgb_string(key) .. ">", "c")
         end

--- a/src/scripts/DD/DD_GUI.AffectsBox.lua
+++ b/src/scripts/DD/DD_GUI.AffectsBox.lua
@@ -53,7 +53,7 @@ function DD_GUI.Affects:build_tabs()
                 self.tab_button:setBold(1)
         end
         self.tab_button:setStyleSheet(self:tab_css())
-        self.tab_button:echo("Affects", "black", "c")
+        self.tab_button:echo("Affects", "white", "c")
 end
 
 function build_affects_box()

--- a/src/scripts/DD/DD_GUI.InventoryBox.lua
+++ b/src/scripts/DD/DD_GUI.InventoryBox.lua
@@ -29,7 +29,7 @@ function DD_GUI.Inventory:style_tab(key)
         tab:setStyleSheet(self:tab_css(key))
         tab:echo(
                 self.tab_labels[key],
-                key == self.current_tab and "black" or "white",
+                "white",
                 "c"
         )
 end

--- a/src/scripts/DD/GoldBoxTheme.lua
+++ b/src/scripts/DD/GoldBoxTheme.lua
@@ -17,6 +17,7 @@ Theme.colors = {
         dark_gold = "rgb(105,82,36)",
         ivory = "rgb(240,235,213)",
         white = "rgb(255,255,255)",
+        active_tab = "rgb(45,45,45)",
         muted = "rgb(153,160,174)",
         blue_grey = "rgb(72,91,123)",
         hp = "rgb(181,42,48)",
@@ -60,7 +61,7 @@ function Theme:tab_css(active, drop_target)
                         border-color: %s;
                         border-radius: 0px;
                         margin: 1px;
-                ]], self.colors.white, self.colors.ink, self.colors.bright_frame)
+                ]], self.colors.active_tab, self.colors.white, self.colors.bright_frame)
         end
 
         if drop_target then

--- a/src/scripts/DD/ResetLayout.lua
+++ b/src/scripts/DD/ResetLayout.lua
@@ -229,13 +229,19 @@ function DD_GUI.migrate_layout_defaults()
                 local legacy_compass =
                         tostring(compass.back.x) == "60%" and
                         tostring(compass.back.y) == "82%"
+                local shipped_compass =
+                        tostring(compass.back.x) == "52%" and
+                        tostring(compass.back.y) == "70%" and
+                        (tostring(compass.back.width) == "8%" or
+                                tostring(compass.back.width) == "9%")
                 if legacy_compass or
+                   shipped_compass or
                    (approximately(compass_x, window_width * 0.60, 2) and
                     approximately(compass_y, window_height * 0.82, 2)) then
                         compass.back:move("52%", "70%")
-                        compass.back:resize("8%", "8%")
+                        compass.back:resize("11%", "11%")
                         if compass.back.get_width then
-                                compass.back:resize("8%", compass.back:get_width())
+                                compass.back:resize("11%", compass.back:get_width())
                         end
                         if compass.back.save then
                                 compass.back:save()
@@ -319,13 +325,13 @@ function DD_GUI.reset_layout()
         end
 
         if compass and compass.back then
-                reset_adjustable_box(compass.back, "52%", "70%", "8%", "8%")
+                reset_adjustable_box(compass.back, "52%", "70%", "11%", "11%")
 
                 -- Keep the default compass square even when the terminal is
                 -- not square. Its width remains responsive while its height
                 -- is stored in pixels to preserve the intended aspect ratio.
                 if type(compass.back.get_width) == "function" then
-                        compass.back:resize("8%", compass.back:get_width())
+                        compass.back:resize("11%", compass.back:get_width())
                         if type(compass.back.save) == "function" then
                                 compass.back:save()
                         end

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -1,4 +1,68 @@
--- Run all GUI build functions when you first log in.
+DD_GUI = DD_GUI or {}
+
+local function run_update(fn)
+        if type(fn) ~= "function" then
+                return
+        end
+
+        local ok, err = pcall(fn)
+        if not ok then
+                DD_GUI.last_data_refresh_error = tostring(err)
+        end
+end
+
+function DD_GUI.refresh_data()
+        if not gmcp or type(gmcp.Char) ~= "table" then
+                return
+        end
+
+        DD_GUI.last_data_refresh_error = nil
+        local char = gmcp.Char
+        local vitals = char.Vitals
+        local affect = char.Affect
+
+        if type(vitals) == "table" and type(char.Base) == "table" and
+           type(char.Stats) == "table" and type(char.Worth) == "table" then
+                run_update(update_vitals)
+        end
+
+        if type(affect) == "table" then
+                run_update(update_affects)
+        end
+
+        if type(char.Items) == "table" then
+                run_update(update_inventory)
+        end
+
+        if type(vitals) == "table" or type(char.Worn) == "table" then
+                run_update(update_equipped)
+        end
+
+        local room = gmcp.Room and gmcp.Room.Info
+        local position = type(vitals) == "table" and tonumber(vitals.position)
+        local enemy_rows = char.Enemies
+        local has_enemy = type(enemy_rows) == "table" and
+                type(enemy_rows[1]) == "table" and
+                type(enemy_rows[1][1]) == "table"
+
+        if position == 6 and has_enemy then
+                run_update(update_enemy)
+        elseif type(room) == "table" and type(vitals) == "table" then
+                run_update(update_travel)
+        end
+
+        if gmcp.Comm and type(gmcp.Comm.Channel) == "table" then
+                run_update(update_comms)
+        end
+
+        if type(char.Channels) == "table" then
+                run_update(update_channel_status)
+        end
+end
+
+-- Rebuilds can happen while the server already has a complete GMCP snapshot.
+-- Replay that snapshot after creating the widgets instead of waiting for the
+-- next GMCP event to arrive.
 function bootstrap()
         set_borders()
         ui_container()
@@ -22,7 +86,6 @@ function bootstrap()
         initialise_mapper()
         load_dd_mapper()
         get_custom_content()
-        update_travel()
         if DD_GUI.Mapper and DD_GUI.Mapper.setColor then
                 DD_GUI.Mapper:setColor(0, 0, 0, 255)
         end
@@ -34,16 +97,26 @@ function bootstrap()
                 DD_GUI.Layout:apply(false)
         end
 
+        DD_GUI.refresh_data()
+
         if DD_GUI.raise_info_box_contents then
                 DD_GUI.raise_info_box_contents()
-                -- Geyser completes its initial z-order pass after bootstrap.
-                tempTimer(0.1, function()
-                        if DD_GUI.raise_info_box_contents then
-                                DD_GUI.raise_info_box_contents()
-                        end
-                        if DD_GUI.Layout then
-                                DD_GUI.Layout:apply(false)
-                        end
-                end)
         end
+
+        -- Geyser completes its initial geometry and stacking pass after
+        -- bootstrap. Refresh once more so package updates also repaint the
+        -- newly created consoles after that pass.
+        if DD_GUI.bootstrap_refresh_timer then
+                killTimer(DD_GUI.bootstrap_refresh_timer)
+        end
+        DD_GUI.bootstrap_refresh_timer = tempTimer(0.1, function()
+                DD_GUI.bootstrap_refresh_timer = nil
+                DD_GUI.refresh_data()
+                if DD_GUI.raise_info_box_contents then
+                        DD_GUI.raise_info_box_contents()
+                end
+                if DD_GUI.Layout then
+                        DD_GUI.Layout:apply(false)
+                end
+        end)
 end

--- a/src/scripts/DD/UpdateFunctions/update_affects.lua
+++ b/src/scripts/DD/UpdateFunctions/update_affects.lua
@@ -56,8 +56,21 @@ local function emit_name_line(name, duration, width, duration_width)
 end
 
 function update_affects()
+  if not AffectsConsole then
+    return
+  end
+
   local duration_ordered = {}
-  local affects = gmcp.Char.Affect[1]
+  local affect_data = gmcp and gmcp.Char and gmcp.Char.Affect
+  local affects = type(affect_data) == "table" and affect_data[1] or nil
+
+  AffectsConsole:clear()
+  AffectsConsole:resetAutoWrap()
+  if type(affects) ~= "table" then
+    AffectsConsole:cecho("Nothing.<reset>")
+    return
+  end
+
   for key, value in orderedPairs(affects) do
     duration_ordered[key] = value.duration
   end
@@ -67,8 +80,6 @@ function update_affects()
     function(a, b) return tonumber(b) < tonumber(a) end
   )
 
-  AffectsConsole:clear()
-  AffectsConsole:resetAutoWrap()
   if next(sorted_dur_keys) == nil then
     AffectsConsole:cecho("Nothing.<reset>")
     return

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -1,5 +1,10 @@
 function update_enemy()
-        if (tonumber(gmcp.Char.Vitals.position) == 6) then
+        local enemies = gmcp and gmcp.Char and gmcp.Char.Enemies
+        local enemy = type(enemies) == "table" and type(enemies[1]) == "table" and
+                enemies[1][1]
+
+        if type(enemy) == "table" and
+           (tonumber(gmcp.Char.Vitals.position) == 6) then
 
                 DD_GUI.EnemyBox:setStyleSheet(DD_GUI.EnemyBoxCSS:getCSS())
                 EnemyConsoleHitpointsContainer:show()
@@ -11,12 +16,12 @@ function update_enemy()
                 local def_enemy_image   = ms_path .. "/mobs/0_default.png"
 
                 -- 0 if a PC, otherwise the VNUM of the mob
-                if (gmcp.Char.Enemies[1][1].isnpc ~= 0) then
+                if (enemy.isnpc ~= 0) then
                         enemy_image = ms_path
                         .."/mobs/"
-                        ..tonumber(gmcp.Char.Enemies[1][1].isnpc)
+                        ..tonumber(enemy.isnpc)
                         .."_"
-                        ..string.lower(string.gsub(gmcp.Char.Enemies[1][1].name, " ", "_"))
+                        ..string.lower(string.gsub(enemy.name, " ", "_"))
                         ..".png"
                 end
 
@@ -51,13 +56,13 @@ function update_enemy()
                         )
                 end
 
-                for i, count in ipairs(gmcp.Char.Enemies) do
+                for i, count in ipairs(enemies) do
                         --display(i)
                         --display(count)
-                        if (gmcp.Char.Enemies[1][i].name) ~= nil then
-                                EnemyInfoConsole:cecho("<white>Enemy: <reset>"..string.format("%-22s", firstToUpper(gmcp.Char.Enemies[1][1].name)))
-                                EnemyInfoConsole:cecho("\n<white>Lvl: <reset>" ..string.format("%-3s", gmcp.Char.Enemies[1][1].level))
-                                EnemyConsoleHitpoints:setValue(((gmcp.Char.Enemies[1][1].hp * 1000) / gmcp.Char.Enemies[1][1].maxhp),1000)
+                        if (enemies[1][i].name) ~= nil then
+                                EnemyInfoConsole:cecho("<white>Enemy: <reset>"..string.format("%-22s", firstToUpper(enemy.name)))
+                                EnemyInfoConsole:cecho("\n<white>Lvl: <reset>" ..string.format("%-3s", enemy.level))
+                                EnemyConsoleHitpoints:setValue(((enemy.hp * 1000) / enemy.maxhp),1000)
                         end
                 end
         end

--- a/src/scripts/DD/UpdateFunctions/update_travel.lua
+++ b/src/scripts/DD/UpdateFunctions/update_travel.lua
@@ -1,6 +1,12 @@
 function update_travel()
 
-    if (tonumber(gmcp.Char.Vitals.position) ~= 6) then
+    local vitals = gmcp and gmcp.Char and gmcp.Char.Vitals
+    local room = gmcp and gmcp.Room and gmcp.Room.Info
+    if type(vitals) ~= "table" or type(room) ~= "table" then
+            return
+    end
+
+    if (tonumber(vitals.position) ~= 6) then
 
             EnemyConsole:clear()
             DD_GUI.EnemyBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())

--- a/src/scripts/DD/UpdateFunctions/update_vitals.lua
+++ b/src/scripts/DD/UpdateFunctions/update_vitals.lua
@@ -1,6 +1,22 @@
 debug.setmetatable(nil, { __index=function () end })
 
+local function current_affect_name()
+    local affects = gmcp and gmcp.Char and gmcp.Char.Affect
+    if type(affects) ~= "table" or type(affects[1]) ~= "table" or
+       type(affects[1][1]) ~= "table" then
+        return ""
+    end
+
+    return tostring(affects[1][1].name or "")
+end
+
 function update_vitals()
+    if not gmcp or not gmcp.Char or type(gmcp.Char.Vitals) ~= "table" or
+       type(gmcp.Char.Base) ~= "table" or type(gmcp.Char.Stats) ~= "table" or
+       type(gmcp.Char.Worth) ~= "table" then
+        return
+    end
+
     if not hasFocus() then
         lost_focus = true
       end
@@ -143,7 +159,7 @@ function update_vitals()
     pfp_filename = 'bat_form.png'
   end
 
-  if (gmcp.Char.Affect[1][1].name == "mist walk") then
+  if (current_affect_name() == "mist walk") then
     pfp_filename = 'mist_form.png'
   end
 
@@ -212,7 +228,7 @@ CharsheetConsole:cecho(
 )
 
 if (gmcp.Char.Base.class == "Shape Shifter") or (gmcp.Char.Base.subclass == "Werewolf") then
-    if (gmcp.Char.Affect[1][1].name ~= "mist walk") then
+    if (current_affect_name() ~= "mist walk") then
     CharsheetConsole:cecho(
       "<white>"
       ..string.format("                <white>Form:  <ansi_white>%s\n",
@@ -222,7 +238,7 @@ if (gmcp.Char.Base.class == "Shape Shifter") or (gmcp.Char.Base.subclass == "Wer
     end
 end
 
-if (gmcp.Char.Affect[1][1].name =="mist walk")  then
+if (current_affect_name() == "mist walk")  then
     CharsheetConsole:cecho(
       "<white>"
       ..string.format("                <white>Form:  <ansi_white>Mist\n")

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -84,8 +84,10 @@ function build_compass()
     }
   end
   local previous_default_size = previous_geometry and
-    tostring(previous_geometry.width) == "8%" and
-    tostring(previous_geometry.height) == "8%"
+    (tostring(previous_geometry.width) == "8%" or
+      tostring(previous_geometry.width) == "9%") and
+    (tostring(previous_geometry.height) == "8%" or
+      tostring(previous_geometry.height) == "9%")
 
   local compass_layout_path = ms_path .. "/layout/compass.back.lua"
   local saved_layout = io.exists and io.exists(compass_layout_path)
@@ -112,8 +114,8 @@ function build_compass()
     name = "compass.back",
     x = "52%",
     y = "70%",
-    width = "8%",
-    height = "8%",
+    width = "11%",
+    height = "11%",
     padding = 4,
   }
 
@@ -133,9 +135,19 @@ function build_compass()
   if tostring(compass.back.x) == "60%" and
      tostring(compass.back.y) == "82%" then
     compass.back:move("52%", "70%")
-    compass.back:resize("8%", "8%")
+    compass.back:resize("11%", "11%")
     if compass.back.get_width then
-      compass.back:resize("8%", compass.back:get_width())
+      compass.back:resize("11%", compass.back:get_width())
+    end
+    if compass.back.save then
+      compass.back:save()
+    end
+  end
+
+  if compass.back._dd_gui_adjustable and previous_default_size then
+    compass.back:resize("11%", "11%")
+    if compass.back.get_width then
+      compass.back:resize("11%", compass.back:get_width())
     end
     if compass.back.save then
       compass.back:save()

--- a/src/triggers/DD/LoginBootstrap.lua
+++ b/src/triggers/DD/LoginBootstrap.lua
@@ -19,12 +19,6 @@ local function dd_gui_bootstrap_when_ready()
         end
 
         bootstrap()
-        update_affects()
-        update_vitals()
-        update_inventory()
-        update_equipped()
-        update_enemy()
-        update_travel()
         echo("\nBootstrapping GUI...")
 end
 


### PR DESCRIPTION
Fix package/bootstrap rebuilds so cached GMCP data is replayed into newly created consoles, restore child widget z-order without masking content or tabs, use a darker grey active-tab state with white text, and migrate the shipped compass default to an 11% square while preserving custom sizes.