### PR TITLE
Balance character panel content padding

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/CharsheetConsole.lua
+++ b/src/scripts/DD/CharsheetConsole.lua
@@ -2,8 +2,8 @@ function build_charsheet_console()
 
     CharsheetConsole = Geyser.MiniConsole:new({
       name="CharsheetConsole",
-      x = "4%", y = "0%",
-      width="94%",
+      x = "2%", y = "0%",
+      width="96%",
       height="100%",
       autoWrap = false,
       color = "black",


### PR DESCRIPTION
## Summary
- equalize the character console's horizontal inset to 2% on both sides
- keep the portrait and stat text group centred within the existing character panel

## Verification
- .\\scripts\\build-and-upload.ps1 completed successfully for DD_GUI 0.0.27
- git diff --check passed