### PR TITLE
Make compass movement door aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ data. The main panels are:
 - **Affects:** active affects from GMCP, with names left-aligned, modifiers
   centred, and durations aligned at the right edge.
 - **Gauges and compass:** current hits, mana, experience, movement, and the
-  clickable navigation compass.
+  clickable navigation compass. The compass includes `EQ` for equipment and
+  `SCAN` for scanning. Movement buttons briefly highlight their borders while
+  leaving the black cell background unchanged. For mapped rooms, movement
+  checks Mudlet's door status before sending: a locked exit sends `unlock`,
+  `open`, then the movement command; a closed exit sends `open`, then the
+  movement command. If the room or door state is unavailable, it sends the
+  normal movement command.
 
 The GUI refreshes these views from the latest GMCP snapshot after login and
 reconnect. If a manual rebuild is needed, run `lua bootstrap()` in Mudlet.
@@ -116,11 +122,15 @@ The basic GUI workflow is:
 
 - Make some changes to the GUI codebase.
 - Run `.\scripts\build-and-upload.ps1` from the repository root. This invokes muddler, builds `build\DD_GUI.mpackage` and `build\DD_GUI.xml`, and uploads both files to the production GUI directory.
-- Open your Dragons Domain Mudlet test account and install the `DD_GUI.mpackage` package before logging in.
+- In the Dragons Domain Mudlet test account, uninstall the existing `DD_GUI`
+  package before installing the new `DD_GUI.mpackage` package.
 - After logging in you should see the latest version of the GUI with any changes you made.
 
 The upload helper reads FTP credentials from the ignored `.dd-gui-ftp.netrc`
 file. Keep that file local and never commit or print it.
+
+Keep this README synchronized with significant GUI, alias, keybinding, package,
+and workflow changes.
 
 For smaller changes, you may wish to work in Mudlet's built-in text editor so you can quickly view the changes, then copy the code over to your local `dd-gui` repo after you're satisfied with it before building the package.
 

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/GoldBoxTheme.lua
+++ b/src/scripts/DD/GoldBoxTheme.lua
@@ -141,7 +141,7 @@ function Theme:compass_cell_css(hovered, blank)
                         border-color: %s;
                         border-radius: 0px;
                         margin: 1px;
-                ]], self.colors.bright_gold, self.colors.ink, self.colors.bright_frame)
+                ]], self.colors.active_tab, self.colors.white, self.colors.bright_frame)
         end
 
         return string.format([[

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -109,6 +109,14 @@ function build_compass()
       s = "south",
       d = "down",
     },
+    door_directions = {
+      n = "n",
+      u = "up",
+      w = "w",
+      e = "e",
+      s = "s",
+      d = "down",
+    },
     ratio = mw / mh,
     labels = {
       nw = "EQ",
@@ -233,6 +241,41 @@ function build_compass()
 
   local theme = DD_GUI.Theme
 
+  function compass.door_status(name)
+    local direction = compass.door_directions[name]
+    if not direction or type(getDoors) ~= "function" or
+       type(map) ~= "table" or type(map.room_info) ~= "table" then
+      return nil
+    end
+
+    local room_id = tonumber(map.room_info.vnum)
+    if not room_id then
+      return nil
+    end
+
+    local ok, doors = pcall(getDoors, room_id)
+    if not ok or type(doors) ~= "table" then
+      return nil
+    end
+
+    local status = doors[direction]
+    if status == nil then
+      status = doors[compass.commands[name]]
+    end
+    return tonumber(status)
+  end
+
+  function compass.send_movement(name, command)
+    local status = compass.door_status(name)
+    if status == 3 then
+      sendAll("unlock " .. command, "open " .. command, command)
+    elseif status == 2 then
+      sendAll("open " .. command, command)
+    else
+      send(command)
+    end
+  end
+
   function compass.click(name)
     local command = compass.commands[name]
     if not command then
@@ -242,14 +285,18 @@ function build_compass()
     if compass.activate then
       compass.activate(name)
     end
-    send(command)
+    if compass.door_directions[name] then
+      compass.send_movement(name, command)
+    else
+      send(command)
+    end
   end
 
   function compass.onEnter(name)
     compass[name]:setStyleSheet(theme and
       theme:compass_cell_css(true, false) or
-      [[background-color: white; color: black; border: 1px solid grey;]])
-    compass[name]:echo(compass.labels[name], "black", "c")
+      [[background-color: black; color: white; border: 2px solid white;]])
+    compass[name]:echo(compass.labels[name], "white", "c")
   end
 
   function compass.onLeave(name)


### PR DESCRIPTION
## Summary
- highlight compass actions with border-only feedback on a black background
- inspect mapped room door state before movement and send unlock/open/move sequences
- document compass behavior and the uninstall-before-install testing workflow
- build and upload DD_GUI 0.0.30

## Verification
- .\\scripts\\build-and-upload.ps1
- git diff --check