### PR TITLE
Track live exit door states and remove image borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,13 @@ data. The main panels are:
   clickable navigation compass. The compass includes `EQ` for equipment and
   `SCAN` for scanning. Movement buttons briefly highlight their borders while
   leaving the black cell background unchanged. For mapped rooms, movement
-  checks Mudlet's door status before sending: a locked exit sends `unlock`,
-  `open`, then the movement command; a closed exit sends `open`, then the
-  movement command. If the room or door state is unavailable, it sends the
-  normal movement command.
+  parses the current MUD `[Exits: ...]` line before sending: plain exits are
+  open, `(direction)` is closed, and `[direction]` is locked. A locked exit
+  sends `unlock`, `open`, then the movement command; a closed exit sends
+  `open`, then the movement command. The parsed state is kept per room, with
+  Mudlet mapper door data as a fallback when no current Exits line is
+  available. If neither source has a state, it sends the normal movement
+  command.
 
 The GUI refreshes these views from the latest GMCP snapshot after login and
 reconnect. If a manual rebuild is needed, run `lua bootstrap()` in Mudlet.

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/CharsheetConsole.lua
+++ b/src/scripts/DD/CharsheetConsole.lua
@@ -21,7 +21,7 @@ function build_charsheet_console()
       height="130px",
     }, CharsheetConsole)
     CharsheetImageFrame:setStyleSheet(DD_GUI.Theme and
-      DD_GUI.Theme:image_frame_css() or [[border: 1px solid grey;]])
+      DD_GUI.Theme:image_frame_css() or [[border: 0px;]])
     if DD_GUI.set_widget_clickthrough then
       DD_GUI.set_widget_clickthrough(CharsheetImageFrame, true)
     end

--- a/src/scripts/DD/CompassExits.lua
+++ b/src/scripts/DD/CompassExits.lua
@@ -1,0 +1,76 @@
+DD_GUI = DD_GUI or {}
+
+DD_GUI.exit_status_by_room = DD_GUI.exit_status_by_room or {}
+
+local compass_exit_aliases = {
+        n = "n",
+        north = "n",
+        u = "u",
+        up = "u",
+        w = "w",
+        west = "w",
+        e = "e",
+        east = "e",
+        s = "s",
+        south = "s",
+        d = "d",
+        down = "d",
+}
+
+local function compass_current_room_id()
+        if type(map) == "table" and type(map.room_info) == "table" then
+                return tonumber(map.room_info.vnum)
+        end
+
+        if gmcp and gmcp.Room and type(gmcp.Room.Info) == "table" then
+                return tonumber(gmcp.Room.Info.vnum)
+        end
+
+        return nil
+end
+
+function DD_GUI.update_exit_status(exit_text)
+        local statuses = {}
+        local text = tostring(exit_text or "")
+        text = text:gsub("\27%[[0-9;]*m", "")
+
+        for token in text:gmatch("%S+") do
+                local first = token:sub(1, 1)
+                local last = token:sub(-1)
+                local status = 1
+
+                if first == "(" and last == ")" then
+                        status = 2
+                elseif first == "[" and last == "]" then
+                        status = 3
+                end
+
+                local direction = token
+                if first == "(" or first == "[" then
+                        direction = direction:sub(2)
+                end
+                if last == ")" or last == "]" then
+                        direction = direction:sub(1, -2)
+                end
+                direction = direction:lower()
+                local compass_direction = compass_exit_aliases[direction]
+                if compass_direction then
+                        statuses[compass_direction] = status
+                end
+        end
+
+        local room_id = compass_current_room_id()
+        if room_id then
+                DD_GUI.exit_status_by_room[room_id] = statuses
+                DD_GUI.exit_status_room = room_id
+        end
+end
+
+if not DD_GUI.exit_status_event_handler then
+        DD_GUI.exit_status_event_handler = registerAnonymousEventHandler(
+                "gmcp.Room.Info",
+                function()
+                        DD_GUI.exit_status_room = nil
+                end
+        )
+end

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -21,7 +21,7 @@ function build_enemy_console()
       height="69%",
     }, EnemyConsole)
     EnemyImageFrame:setStyleSheet(DD_GUI.Theme and
-      DD_GUI.Theme:image_frame_css() or [[border: 1px solid grey;]])
+      DD_GUI.Theme:image_frame_css() or [[border: 0px;]])
     if DD_GUI.set_widget_clickthrough then
       DD_GUI.set_widget_clickthrough(EnemyImageFrame, true)
     end

--- a/src/scripts/DD/GoldBoxTheme.lua
+++ b/src/scripts/DD/GoldBoxTheme.lua
@@ -112,12 +112,11 @@ end
 function Theme:image_frame_css()
         return string.format([[
                 background-color: rgba(0,0,0,0);
-                border-style: solid;
-                border-width: 2px;
-                border-color: %s;
+                border-style: none;
+                border-width: 0px;
                 border-radius: 0px;
                 margin: 0px;
-        ]], self.colors.frame)
+        ]])
 end
 
 function Theme:compass_cell_css(hovered, blank)

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -243,13 +243,23 @@ function build_compass()
 
   function compass.door_status(name)
     local direction = compass.door_directions[name]
-    if not direction or type(getDoors) ~= "function" or
-       type(map) ~= "table" or type(map.room_info) ~= "table" then
+    if not direction or type(map) ~= "table" or
+       type(map.room_info) ~= "table" then
       return nil
     end
 
     local room_id = tonumber(map.room_info.vnum)
     if not room_id then
+      return nil
+    end
+
+    local parsed_status = DD_GUI.exit_status_by_room and
+      DD_GUI.exit_status_by_room[room_id]
+    if parsed_status then
+      return tonumber(parsed_status[name]) or 0
+    end
+
+    if type(getDoors) ~= "function" then
       return nil
     end
 

--- a/src/scripts/DD/scripts.json
+++ b/src/scripts/DD/scripts.json
@@ -9,6 +9,9 @@
         "name": "GoldBoxTheme"
   },
   {
+        "name": "CompassExits"
+  },
+  {
         "name": "BoxesDefinitions"
   },
   {

--- a/src/triggers/DD/Mapping/UpdateExitStatus.lua
+++ b/src/triggers/DD/Mapping/UpdateExitStatus.lua
@@ -1,0 +1,3 @@
+if DD_GUI and DD_GUI.update_exit_status then
+        DD_GUI.update_exit_status(matches[2])
+end

--- a/src/triggers/DD/Mapping/triggers.json
+++ b/src/triggers/DD/Mapping/triggers.json
@@ -27,6 +27,14 @@
                                 "type": "regex"
                         }
                 ]
-        
+        },
+        {
+                "name": "UpdateExitStatus",
+                "patterns": [
+                        {
+                                "pattern": "^\\[Exits: (.*)\\]$",
+                                "type": "regex"
+                        }
+                ]
         }
 ]


### PR DESCRIPTION
## Summary
- parse each MUD [Exits: ...] line and retain open, closed, and locked exit states per room
- make compass movement unlock/open closed doors before moving
- remove red image-frame borders from room, enemy, and character profile images
- update README and publish DD_GUI 0.0.31

## Verification
- ./scripts/build-and-upload.ps1
- Mudlet package reinstall and visual check