### PR TITLE
Persist downloaded GUI content across reinstalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the codebase for the [Mudlet](https://www.mudlet.org/)-based GUI used by
 
 To install and use the GUI, connect to the MUD through Mudlet at **dragons-domain.org** on port **8888**. The GUI should automatically install when you connect, and the extra custom content should automatically download after you log in.
 
-You should expect a short delay while content downloads the first time you connect, but subsequent connections for the same character will only download new assets. GUI settings, maps, comms history, and comms tab order are kept with the active Mudlet profile rather than inside the package.
+You should expect a short delay while content downloads the first time you connect. Downloaded sounds, images, layouts, and other custom content are stored in the profile-owned `DD_GUI_Content` directory, separate from the installable package, so uninstalling and reinstalling the GUI does not remove them. Later connections and package updates reuse the existing content and only download new or changed assets. GUI settings, maps, comms history, and comms tab order are kept with the active Mudlet profile rather than inside the package.
 
 If you have any issues with the automated installation and update system for the GUI, you can type the following at your Mudlet command prompt to install it manually:
 
@@ -20,7 +20,7 @@ If you have any issues with the automated installation and update system for the
 
 To uninstall the GUI, you can simply type:
 
-`lua uninstallPackage("DD_GUI")`, use the built-in `ugui` alias, or use Mudlet's graphical package manager.
+`lua uninstallPackage("DD_GUI")`, use the built-in `ugui` alias, or use Mudlet's graphical package manager. The GUI copies any legacy downloaded content into the profile-owned `DD_GUI_Content` directory before removal when needed.
 
 ## Layout controls
 
@@ -69,8 +69,8 @@ data. The main panels are:
   leaving the black cell background unchanged. For mapped rooms, movement
   parses the current MUD `[Exits: ...]` line before sending: plain exits are
   open, `(direction)` is closed, and `[direction]` is locked. A locked exit
-  sends `unlock`, `open`, then the movement command; a closed exit sends
-  `open`, then the movement command. The parsed state is kept per room, with
+  sends `unlock`, `open`, then the movement command in sequence; a closed exit
+  sends `open`, then the movement command in sequence. The parsed state is kept per room, with
   Mudlet mapper door data as a fallback when no current Exits line is
   available. If neither source has a state, it sends the normal movement
   command.
@@ -126,7 +126,8 @@ The basic GUI workflow is:
 - Make some changes to the GUI codebase.
 - Run `.\scripts\build-and-upload.ps1` from the repository root. This invokes muddler, builds `build\DD_GUI.mpackage` and `build\DD_GUI.xml`, and uploads both files to the production GUI directory.
 - In the Dragons Domain Mudlet test account, uninstall the existing `DD_GUI`
-  package before installing the new `DD_GUI.mpackage` package.
+  package before installing the new `DD_GUI.mpackage` package. The downloaded
+  content cache is profile-owned and is retained across this replacement.
 - After logging in you should see the latest version of the GUI with any changes you made.
 
 The upload helper reads FTP credentials from the ignored `.dd-gui-ftp.netrc`
@@ -143,26 +144,32 @@ For smaller changes, you may wish to work in Mudlet's built-in text editor so yo
 Currently assets have this storage structure under your Mudlet Profile (which should have a path on Windows like `C:\Users\myusername\.config\mudlet\profiles\TestMudletGuy\`):
 
 ```
-assets\
+DD_GUI_Content\
+|-- audio\
 |-- avatars\
 |-- compass\
 |-- custom_rooms\
 |-- environments\
 |-- mobs\
-`-- maps\
+|-- maps\
+`-- layout\
 ```
 
 Profile pictures for avatars are 160x200 pngs that have the following naming structure (all lowercase):
 `race_class_sex_number.png` e.g. the first image option for a female human mage would be named `human_mage_female_1.png`.
 
-If you want a custom avatar (as a player), put it in the `avatars\` directory under your local profile and change the relevant code in `Scripts->DD->UpdateFunctions->update_vitals`.
+Custom profile avatars are selected automatically when a matching file exists in
+the `DD_GUI_Content\avatars\` directory under the local Mudlet profile. Name the file
+after the character in lowercase, such as `abbadon.png`; the GUI uses it before
+falling back to the race and sex portrait. Form-specific portraits still take
+precedence while shapeshifted.
 
 Compass images you can figure out yourself if you want to change them.  The relevant Lua file is `dd-gui\src\scripts\compass.resize.lua`.
 
 Custom room images use the 56:30 display ratio; 560x300 pngs are recommended and have the naming structure (all lowercase):
 `vnum_name_of_room.png`, e.g. `3054_by_the_temple_altar.png`.
 
-Default sector-type based images use the same 56:30 ratio, are stored in `assets\environments\`, and have the naming structure (all lowercase):
+Default sector-type based images use the same 56:30 ratio, are stored in `DD_GUI_Content\environments\`, and have the naming structure (all lowercase):
 `sectornumber_sect_nameofsectortype.png`, e.g. `9_sect_air.png`.
 
 Custom mobile/enemy images use the 56:30 display ratio; 560x300 pngs are recommended and have the naming structure (all lowercase):

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.31",
+  "version": "0.0.34",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/aliases/DD/ugui.lua
+++ b/src/aliases/DD/ugui.lua
@@ -1,2 +1,6 @@
+if DD_GUI and DD_GUI.migrate_legacy_content then
+        DD_GUI.migrate_legacy_content()
+end
+
 echo("Uninstalling package 'DD_GUI'...\n")
 uninstallPackage("DD_GUI")

--- a/src/scripts/DD/Avatar.lua
+++ b/src/scripts/DD/Avatar.lua
@@ -1,0 +1,24 @@
+DD_GUI = DD_GUI or {}
+
+function DD_GUI.profile_avatar_filename()
+        if not gmcp or not gmcp.Char or type(gmcp.Char.Base) ~= "table" then
+                return nil
+        end
+
+        local character_name = tostring(gmcp.Char.Base.name or ""):lower()
+        character_name = character_name:gsub("[^%w]+", "_")
+        character_name = character_name:gsub("^_+", ""):gsub("_+$", "")
+        if character_name == "" then
+                return nil
+        end
+
+        local filename = character_name .. ".png"
+        local avatar_path = DD_GUI.asset_path and
+                DD_GUI.asset_path("avatars/" .. filename) or
+                ms_path .. "/avatars/" .. filename
+        if file_exists(avatar_path) then
+                return filename
+        end
+
+        return nil
+end

--- a/src/scripts/DD/CharsheetConsole.lua
+++ b/src/scripts/DD/CharsheetConsole.lua
@@ -40,25 +40,30 @@ function build_charsheet_console()
       DD_GUI.Theme:style_console(CharsheetPFPConsole, 10)
     end
 
-    local chsex_string = 'male'
+    local pfp_filename = DD_GUI.profile_avatar_filename and
+      DD_GUI.profile_avatar_filename()
+    if not pfp_filename then
+      local chsex_string = 'male'
 
-    if (gmcp.Char.Base.sex == 0) then
-      chsex_string = 'neutral'
-    elseif (gmcp.Char.Base.sex == 2) then
-      chsex_string = 'female'
+      if (gmcp.Char.Base.sex == 0) then
+        chsex_string = 'neutral'
+      elseif (gmcp.Char.Base.sex == 2) then
+        chsex_string = 'female'
+      end
+
+      pfp_filename = firstToLower(gmcp.Char.Base.race) .. '_'
+                         ..firstToLower(gmcp.Char.Base.class) .. '_'
+                         ..chsex_string .. '_1.png'
     end
-
-    local pfp_filename = firstToLower(gmcp.Char.Base.race) .. '_'
-                       ..firstToLower(gmcp.Char.Base.class) .. '_'
-                       ..chsex_string .. '_1.png'
     --display(pfp_filename)
 
-    -- Replace the below with your avatar filename and uncomment the below line if you want a custom avatar. Should
-    -- be a 160 x 200 px .png in the ms_path + /avatars/ directory
-    -- pfp_filename = mycustomavatar.png'
+    -- A character-named avatar is selected automatically when it exists.
 
-    local pfp_path = ms_path .. '/avatars/' .. pfp_filename
-    local default_path = ms_path .. '/avatars/default_char.png'
+    local asset_path = DD_GUI.asset_path or function(relative_path)
+      return ms_path .. '/' .. relative_path
+    end
+    local pfp_path = asset_path('avatars/' .. pfp_filename)
+    local default_path = asset_path('avatars/default_char.png')
     if not file_exists(pfp_path) then
       pfp_path = default_path
     end

--- a/src/scripts/DD/GetCustomContent.lua
+++ b/src/scripts/DD/GetCustomContent.lua
@@ -10,7 +10,7 @@ downloadQueue = downloadQueue or {}
 isDownloadingFileList = false
 
 -- Make the file list path/URL visible to all handlers
-FILELIST_LOCAL = getMudletHomeDir() .. "/DD_GUI/custom_filelist.txt"
+FILELIST_LOCAL = ms_path .. "/custom_filelist.txt"
 FILELIST_URL   = "https://www.dragons-domain.org/main/gui/custom/files.php"
 CONTENT_BASE   = "https://www.dragons-domain.org/main/gui/custom/"
 
@@ -71,11 +71,13 @@ function process_file_list()
 
     -- NEW: ignore blank lines and *directory* entries
     if relPath ~= "" and looks_like_file(relPath) then
-      local saveto   = getMudletHomeDir() .. "/DD_GUI/" .. relPath
+      local saveto   = ms_path .. "/" .. relPath
       local url      = CONTENT_BASE .. relPath
-      local existing = lfs.attributes(saveto, "size")
+      local existing_path = DD_GUI.asset_path and
+        DD_GUI.asset_path(relPath) or saveto
+      local existing = lfs.attributes(existing_path, "size")
 
-      if (file_exists(saveto) and tonumber(sizeStr) ~= tonumber(existing)) or (existing == nil) then
+      if existing == nil or tonumber(sizeStr) ~= tonumber(existing) then
         table.insert(downloadQueue, { url = url, saveto = saveto })
       end
     -- else: it's a directory or bad line — skip it
@@ -91,7 +93,7 @@ function start_next_download()
     return
   end
   local nextDownload = table.remove(downloadQueue, 1)
-  ensure_dir_for(nextDownload.saveto)           -- <-- create DD_GUI/audio/ etc.
+  ensure_dir_for(nextDownload.saveto)
   downloadFile(nextDownload.saveto, nextDownload.url)
 end
 

--- a/src/scripts/DD/InitialiseMapper.lua
+++ b/src/scripts/DD/InitialiseMapper.lua
@@ -8,13 +8,26 @@ local function file_exists(path)
         return true
 end
 
+local function asset_path(relative_path)
+        if DD_GUI and DD_GUI.asset_path then
+                return DD_GUI.asset_path(relative_path)
+        end
+
+        return string.gsub(
+                getMudletHomeDir() .. "/DD_GUI/" .. relative_path,
+                "\\", "/"
+        )
+end
+
 function dd_mapper_save_path()
         -- Keep player map data outside the package resource folder so reinstalls preserve it.
         return string.gsub(getMudletHomeDir() .. "/dragons_domain_mapper.dat", "\\", "/")
 end
 
 local function legacy_mapper_save_path()
-        return string.gsub(getMudletHomeDir() .. "/DD_GUI/maps/dragons_domain_mapper.dat", "\\", "/")
+        local package_path = DD_GUI and DD_GUI.package_path or
+                getMudletHomeDir() .. "/DD_GUI"
+        return string.gsub(package_path .. "/maps/dragons_domain_mapper.dat", "\\", "/")
 end
 
 function save_dd_mapper()
@@ -29,7 +42,7 @@ end
 function initialise_mapper()
         expandAlias("ignores")
 
-        local bundled_map = string.gsub(getMudletHomeDir() .. "/DD_GUI/maps/mud_school.dat", "\\", "/")
+        local bundled_map = asset_path("maps/mud_school.dat")
         local persistent_map = dd_mapper_save_path()
         local legacy_map = legacy_mapper_save_path()
         local map_to_load = bundled_map

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -1,4 +1,8 @@
 function update_enemy()
+        local asset_path = DD_GUI.asset_path or function(relative_path)
+                return ms_path .. "/" .. relative_path
+        end
+
         local enemies = gmcp and gmcp.Char and gmcp.Char.Enemies
         local enemy = type(enemies) == "table" and type(enemies[1]) == "table" and
                 enemies[1][1]
@@ -12,17 +16,16 @@ function update_enemy()
                 EnemyHitpointsLabel:show()
                 EnemyConsole:clear()
                 EnemyInfoConsole:clear()
-                local enemy_image       = ms_path .. "/mobs/20412_the_destroyer.png"
-                local def_enemy_image   = ms_path .. "/mobs/0_default.png"
+                local enemy_image       = asset_path("mobs/20412_the_destroyer.png")
+                local def_enemy_image   = asset_path("mobs/0_default.png")
 
                 -- 0 if a PC, otherwise the VNUM of the mob
                 if (enemy.isnpc ~= 0) then
-                        enemy_image = ms_path
-                        .."/mobs/"
+                        enemy_image = asset_path("mobs/"
                         ..tonumber(enemy.isnpc)
                         .."_"
                         ..string.lower(string.gsub(enemy.name, " ", "_"))
-                        ..".png"
+                        ..".png")
                 end
 
                 enemy_image = string.gsub(enemy_image, "'", "_")

--- a/src/scripts/DD/UpdateFunctions/update_travel.lua
+++ b/src/scripts/DD/UpdateFunctions/update_travel.lua
@@ -1,5 +1,9 @@
 function update_travel()
 
+    local asset_path = DD_GUI.asset_path or function(relative_path)
+            return ms_path .. "/" .. relative_path
+    end
+
     local vitals = gmcp and gmcp.Char and gmcp.Char.Vitals
     local room = gmcp and gmcp.Room and gmcp.Room.Info
     if type(vitals) ~= "table" or type(room) ~= "table" then
@@ -14,48 +18,48 @@ function update_travel()
             EnemyConsoleHitpointsContainer:hide()
             EnemyConsoleHitpoints:hide()
             EnemyHitpointsLabel:hide()
-            local room_image = ms_path .. "/avatars/default_char.png"
+            local room_image = asset_path("avatars/default_char.png")
             local sector_name = "Unknown"
 
             --Room images based on sector types
             if (tonumber(gmcp.Room.Info.sector) == 0) then
-            room_image = ms_path .. "/environments/0_sect_inside.png"
+            room_image = asset_path("environments/0_sect_inside.png")
             sector_name = "Inside"
             elseif (tonumber(gmcp.Room.Info.sector) == 1) then
-            room_image = ms_path .. "/environments/1_sect_city.png"
+            room_image = asset_path("environments/1_sect_city.png")
             sector_name = "City"
             elseif (tonumber(gmcp.Room.Info.sector) == 2) then
-            room_image = ms_path .. "/environments/2_sect_field.png"
+            room_image = asset_path("environments/2_sect_field.png")
             sector_name = "Field"
             elseif (tonumber(gmcp.Room.Info.sector) == 3) then
-            room_image = ms_path .. "/environments/3_sect_forest.png"
+            room_image = asset_path("environments/3_sect_forest.png")
             sector_name = "Forest"
             elseif (tonumber(gmcp.Room.Info.sector) == 4) then
-            room_image = ms_path .. "/environments/4_sect_hills.png"
+            room_image = asset_path("environments/4_sect_hills.png")
             sector_name = "Hills"
             elseif (tonumber(gmcp.Room.Info.sector) == 5) then
-            room_image = ms_path .. "/environments/5_sect_mountain.png"
+            room_image = asset_path("environments/5_sect_mountain.png")
             sector_name = "Mountain"
             elseif (tonumber(gmcp.Room.Info.sector) == 6) then
-            room_image = ms_path .. "/environments/6_sect_water_swim.png"
+            room_image = asset_path("environments/6_sect_water_swim.png")
             sector_name = "Water (Swimmable)"
             elseif (tonumber(gmcp.Room.Info.sector) == 7) then
-            room_image = ms_path .. "/environments/7_sect_water_noswim.png"
+            room_image = asset_path("environments/7_sect_water_noswim.png")
             sector_name = "Water (Unswimmable)"
             elseif (tonumber(gmcp.Room.Info.sector) == 8) then
-            room_image = ms_path .. "/environments/8_sect_underwater.png"
+            room_image = asset_path("environments/8_sect_underwater.png")
             sector_name = "Underwater"
             elseif (tonumber(gmcp.Room.Info.sector) == 9) then
-            room_image = ms_path .. "/environments/9_sect_air.png"
+            room_image = asset_path("environments/9_sect_air.png")
             sector_name = "Air"
             elseif (tonumber(gmcp.Room.Info.sector) == 10) then
-            room_image = ms_path .. "/environments/10_sect_desert.png"
+            room_image = asset_path("environments/10_sect_desert.png")
             sector_name = "Desert"
             elseif (tonumber(gmcp.Room.Info.sector) == 11) then
-            room_image = ms_path .. "/environments/11_sect_swamp.png"
+            room_image = asset_path("environments/11_sect_swamp.png")
             sector_name = "Swamp"
             elseif (tonumber(gmcp.Room.Info.sector) == 12) then
-            room_image = ms_path .. "/environments/12_sect_underwater_ground.png"
+            room_image = asset_path("environments/12_sect_underwater_ground.png")
             sector_name = "Underwater (Ground)"
             end
 
@@ -66,20 +70,21 @@ function update_travel()
             ri_fn_dotver = string.lower(string.gsub(ri_fn_dotver, " ", "_"))
 
             if (tonumber(gmcp.Room.Info.vnum) ~= 0) then
-                    ri_filename = ms_path
-                    .."/custom_rooms/"
+                    ri_filename = asset_path("custom_rooms/"
                     ..tonumber(gmcp.Room.Info.vnum)
                     .."_"
                     ..ri_fn_dotver
-                    ..".png"
+                    ..".png")
             end
 
-            ri_filename = string.gsub(ri_filename, "'", "_")
-            ri_filename = string.gsub(ri_filename, "<", "_")
-            ri_filename = string.gsub(ri_filename, ">", "_")
-            ri_filename = string.gsub(ri_filename, "{", "_")
+            if ri_filename then
+                    ri_filename = string.gsub(ri_filename, "'", "_")
+                    ri_filename = string.gsub(ri_filename, "<", "_")
+                    ri_filename = string.gsub(ri_filename, ">", "_")
+                    ri_filename = string.gsub(ri_filename, "{", "_")
+            end
 
-            if (file_exists(ri_filename)) then
+            if (ri_filename and file_exists(ri_filename)) then
                     room_image = ri_filename
             end
 

--- a/src/scripts/DD/UpdateFunctions/update_vitals.lua
+++ b/src/scripts/DD/UpdateFunctions/update_vitals.lua
@@ -91,6 +91,12 @@ function update_vitals()
   local pfp_filename = gmcp.Char.Base.race:lower():gsub("-", "_") .. '_'
   ..chsex_string .. '_1.png'
 
+  local profile_avatar = DD_GUI.profile_avatar_filename and
+    DD_GUI.profile_avatar_filename()
+  if profile_avatar then
+    pfp_filename = profile_avatar
+  end
+
   --[[
         Right now all pfp filenames end in _1; at some point make it so a random default number for them
         can be chosen based on how many exist, and that this will persist across sessions for the profile.
@@ -98,10 +104,6 @@ function update_vitals()
 
   -- display(gmcp.Char.Base.race:lower():gsub("-", "_"))
   -- display(pfp_filename)
-  -- Replace the below with your avatar filename and uncomment the below line if you want a custom avatar. Should
-  -- be a 160 x 200 px .png in the ms_path + /avatars/ directory
-  -- pfp_filename = 'abbadon.png'
-
   -- Shifter stuff
   if (gmcp.Char.Base.class == "Shape Shifter") and (gmcp.Char.Vitals.form == "hawk") then
     pfp_filename = 'hawk_form.png'
@@ -163,8 +165,11 @@ function update_vitals()
     pfp_filename = 'mist_form.png'
   end
 
-  local char_image = ms_path .. '/avatars/' .. pfp_filename
-  local def_image = ms_path .. '/avatars/' .. 'default_char.png'
+  local asset_path = DD_GUI.asset_path or function(relative_path)
+    return ms_path .. '/' .. relative_path
+  end
+  local char_image = asset_path('avatars/' .. pfp_filename)
+  local def_image = asset_path('avatars/default_char.png')
 
   if file_exists(char_image) then
         DD_GUI.ImageFit:set(

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -278,9 +278,9 @@ function build_compass()
   function compass.send_movement(name, command)
     local status = compass.door_status(name)
     if status == 3 then
-      sendAll("unlock " .. command, "open " .. command, command)
+      sendAll(0.2, "unlock " .. command, "open " .. command, command)
     elseif status == 2 then
-      sendAll("open " .. command, command)
+      sendAll(0.2, "open " .. command, command)
     else
       send(command)
     end

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -1,14 +1,123 @@
 DD_GUI = DD_GUI or {}
 mudlet = mudlet or {}
 
-ms_path = string.gsub(getMudletHomeDir().."/DD_GUI","\\","/")
+local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
+local package_path = profile_path .. "/DD_GUI"
+local content_path = profile_path .. "/DD_GUI_Content"
+local lfs = require "lfs"
+
+local function ensure_directory(path)
+        if lfs.attributes(path, "mode") ~= "directory" then
+                pcall(lfs.mkdir, path)
+        end
+end
+
+local function copy_file(source, destination)
+        local source_size = lfs.attributes(source, "size")
+        if not source_size then
+                return false
+        end
+
+        if lfs.attributes(destination, "size") == source_size then
+                return true
+        end
+
+        local input = io.open(source, "rb")
+        if not input then
+                return false
+        end
+
+        local output = io.open(destination, "wb")
+        if not output then
+                input:close()
+                return false
+        end
+
+        while true do
+                local chunk = input:read(1024 * 1024)
+                if not chunk then
+                        break
+                end
+                output:write(chunk)
+        end
+
+        input:close()
+        output:close()
+        return true
+end
+
+local function copy_tree(source, destination)
+        if lfs.attributes(source, "mode") ~= "directory" then
+                return
+        end
+
+        ensure_directory(destination)
+        for name in lfs.dir(source) do
+                if name ~= "." and name ~= ".." then
+                        local source_item = source .. "/" .. name
+                        local destination_item = destination .. "/" .. name
+                        local mode = lfs.attributes(source_item, "mode")
+                        if mode == "directory" then
+                                copy_tree(source_item, destination_item)
+                        elseif mode == "file" then
+                                copy_file(source_item, destination_item)
+                        end
+                end
+        end
+end
+
+ms_path = content_path
+DD_GUI.package_path = package_path
+DD_GUI.content_path = content_path
+ensure_directory(content_path)
+
+function DD_GUI.asset_path(relative_path)
+        local relative = tostring(relative_path or ""):gsub("\\", "/")
+        local persistent_path = content_path .. "/" .. relative
+        if lfs.attributes(persistent_path, "mode") == "file" then
+                return persistent_path
+        end
+        return package_path .. "/" .. relative
+end
+
+function DD_GUI.migrate_legacy_content()
+        ensure_directory(content_path)
+        for _, directory in ipairs({
+                "audio",
+                "avatars",
+                "compass",
+                "custom_rooms",
+                "environments",
+                "layout",
+                "maps",
+                "mobs",
+        }) do
+                copy_tree(
+                        package_path .. "/" .. directory,
+                        content_path .. "/" .. directory
+                )
+        end
+        copy_file(
+                package_path .. "/custom_filelist.txt",
+                content_path .. "/custom_filelist.txt"
+        )
+end
 
 mudlet.mapper_script = true
 
 function myScriptInstalled(_, name)
-    -- stop if what got installed isn't my thing
-    if name ~= "DD_GUI" then return end
-    bootstrap()
+        if name ~= "DD_GUI" then
+                return
+        end
+        DD_GUI.migrate_legacy_content()
+        bootstrap()
+end
+
+function myScriptUninstalled(_, name)
+        if name == "DD_GUI" then
+                DD_GUI.migrate_legacy_content()
+        end
 end
 
 registerAnonymousEventHandler("sysInstallPackage", "myScriptInstalled")
+registerAnonymousEventHandler("sysUninstallPackage", "myScriptUninstalled")

--- a/src/scripts/DD/scripts.json
+++ b/src/scripts/DD/scripts.json
@@ -3,6 +3,9 @@
         "name": "folder"
   },
   {
+        "name": "Avatar"
+  },
+  {
         "name": "AffectsConsole"
   },
   {

--- a/src/triggers/DD/Mapping/triggers.json
+++ b/src/triggers/DD/Mapping/triggers.json
@@ -32,7 +32,7 @@
                 "name": "UpdateExitStatus",
                 "patterns": [
                         {
-                                "pattern": "^\\[Exits: (.*)\\]$",
+                                "pattern": "\\[Exits:\\s*(.*)\\]",
                                 "type": "regex"
                         }
                 ]


### PR DESCRIPTION
## Summary
- store downloaded GUI media and layouts in profile-owned DD_GUI_Content
- preserve legacy package content during uninstall and reuse package defaults as fallback
- keep avatar and mapped asset lookups working across package updates
- document the persistent cache and bump the package to 0.0.34

## Verification
- built and uploaded with scripts/build-and-upload.ps1
- installed DD_GUI 0.0.34 in the Abbadon Mudlet profile
- verified all 6,474 listed custom files are present with matching sizes