### PR TITLE
Restore enemy hitpoint gauge rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ The GUI is driven by GMCP rather than by scraping ordinary MUD text for panel
 data. The main panels are:
 
 - **Room / enemy:** room details and the current enemy, including custom images
-  fitted to the 56:30 display frame.
+  fitted to the 56:30 display frame. Enemy GMCP payloads support both the
+  legacy `isnpc` identifier and the newer `vnum` identifier.
 - **Map:** the current room and surrounding map data.
 - **Character sheet:** profile image, character details, statistics, and
   resistances.

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -18,11 +18,16 @@ function update_enemy()
                 EnemyInfoConsole:clear()
                 local enemy_image       = asset_path("mobs/20412_the_destroyer.png")
                 local def_enemy_image   = asset_path("mobs/0_default.png")
+                local enemy_vnum = tonumber(enemy.vnum)
+                if enemy_vnum == nil then
+                        enemy_vnum = tonumber(enemy.isnpc) or 0
+                end
 
-                -- 0 if a PC, otherwise the VNUM of the mob
-                if (enemy.isnpc ~= 0) then
+                -- Newer GMCP payloads call this vnum; older ones call it isnpc.
+                -- Zero means the enemy is a player and has no mob portrait.
+                if enemy_vnum ~= 0 then
                         enemy_image = asset_path("mobs/"
-                        ..tonumber(enemy.isnpc)
+                        ..enemy_vnum
                         .."_"
                         ..string.lower(string.gsub(enemy.name, " ", "_"))
                         ..".png")
@@ -59,13 +64,20 @@ function update_enemy()
                         )
                 end
 
-                for i, count in ipairs(enemies) do
-                        --display(i)
-                        --display(count)
-                        if (enemies[1][i].name) ~= nil then
-                                EnemyInfoConsole:cecho("<white>Enemy: <reset>"..string.format("%-22s", firstToUpper(enemy.name)))
-                                EnemyInfoConsole:cecho("\n<white>Lvl: <reset>" ..string.format("%-3s", enemy.level))
-                                EnemyConsoleHitpoints:setValue(((enemy.hp * 1000) / enemy.maxhp),1000)
+                if enemy.name ~= nil then
+                        EnemyInfoConsole:cecho("<white>Enemy: <reset>"..string.format("%-22s", firstToUpper(enemy.name)))
+                        EnemyInfoConsole:cecho("\n<white>Lvl: <reset>" ..string.format("%-3s", enemy.level))
+
+                        local enemy_hp = tonumber(enemy.hp) or 0
+                        local enemy_maxhp = tonumber(enemy.maxhp) or 0
+                        if enemy_maxhp > 0 then
+                                enemy_hp = math.max(0, math.min(enemy_hp, enemy_maxhp))
+                                EnemyConsoleHitpoints:setValue(
+                                        (enemy_hp * 1000) / enemy_maxhp,
+                                        1000
+                                )
+                        else
+                                EnemyConsoleHitpoints:setValue(0, 1000)
                         end
                 end
         end


### PR DESCRIPTION
## Summary
- accept both legacy isnpc and current num enemy identifiers
- avoid aborting enemy panel updates when a field is absent
- clamp and validate enemy HP values before updating the gauge
- document the payload compatibility and bump DD_GUI to 0.0.35

## Verification
- built and uploaded with scripts/build-and-upload.ps1
- installed DD_GUI 0.0.35 in the Abbadon Mudlet profile