### PR TITLE
Add DD_GUI version alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ These aliases are available from the Mudlet command line:
 | --- | --- |
 | `layoutgui` | Toggle layout editing. |
 | `layoutgui on` / `layoutgui off` | Explicitly enable or disable layout editing. |
+| `ddguiversion` | Display the installed DD_GUI package version. |
 | `resetgui` | Restore all GUI regions to their default positions and sizes. |
 | `gcc` | Refresh and download the latest custom content. |
 | `ddmap on` / `ddmap off` | Enable or disable the Dragons Domain custom mapper. |

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/aliases/DD/aliases.json
+++ b/src/aliases/DD/aliases.json
@@ -8,6 +8,10 @@
                 "regex": "^gcc$"
         },
         {
+                "name": "ddguiversion",
+                "regex": "^ddguiversion$"
+        },
+        {
                 "name": "resetgui",
                 "regex": "^resetgui$"
         },

--- a/src/aliases/DD/ddguiversion.lua
+++ b/src/aliases/DD/ddguiversion.lua
@@ -1,0 +1,10 @@
+local version
+if type(getPackageInfo) == "function" then
+        version = getPackageInfo("DD_GUI", "version")
+end
+
+if version and version ~= "" then
+        echo("\nDD_GUI version: " .. tostring(version) .. "\n")
+else
+        echo("\nDD_GUI package version is unavailable.\n")
+end


### PR DESCRIPTION
Add the ddguiversion Mudlet alias, document it in README, and bump the package to 0.0.36. Verified with git diff check, JSON parsing, and the package build/upload helper.