### PR TITLE
Support current enemy GMCP payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ data. The main panels are:
 
 - **Room / enemy:** room details and the current enemy, including custom images
   fitted to the 56:30 display frame. Enemy GMCP payloads support both the
-  legacy `isnpc` identifier and the newer `vnum` identifier.
+  legacy nested-array shape with an `isnpc` identifier and the newer flat-array
+  shape with a `vnum` identifier; the enemy hitpoint gauge uses either shape.
 - **Map:** the current room and surrounding map data.
 - **Character sheet:** profile image, character details, statistics, and
   resistances.

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -41,9 +41,10 @@ function DD_GUI.refresh_data()
         local room = gmcp.Room and gmcp.Room.Info
         local position = type(vitals) == "table" and tonumber(vitals.position)
         local enemy_rows = char.Enemies
-        local has_enemy = type(enemy_rows) == "table" and
-                type(enemy_rows[1]) == "table" and
-                type(enemy_rows[1][1]) == "table"
+        local first_enemy_row = type(enemy_rows) == "table" and enemy_rows[1]
+        local has_enemy = type(first_enemy_row) == "table" and
+                (first_enemy_row.name ~= nil or first_enemy_row.hp ~= nil or
+                 first_enemy_row.maxhp ~= nil or type(first_enemy_row[1]) == "table")
 
         if position == 6 and has_enemy then
                 run_update(update_enemy)

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -1,11 +1,29 @@
+local function first_enemy(enemies)
+        if type(enemies) ~= "table" or type(enemies[1]) ~= "table" then
+                return nil
+        end
+
+        -- Older GMCP payloads wrapped the enemy rows one level deeper;
+        -- the current web-gate payload sends a flat array of enemy objects.
+        if enemies[1].name ~= nil or enemies[1].hp ~= nil or
+           enemies[1].maxhp ~= nil then
+                return enemies[1]
+        end
+
+        if type(enemies[1][1]) == "table" then
+                return enemies[1][1]
+        end
+
+        return nil
+end
+
 function update_enemy()
         local asset_path = DD_GUI.asset_path or function(relative_path)
                 return ms_path .. "/" .. relative_path
         end
 
         local enemies = gmcp and gmcp.Char and gmcp.Char.Enemies
-        local enemy = type(enemies) == "table" and type(enemies[1]) == "table" and
-                enemies[1][1]
+        local enemy = first_enemy(enemies)
 
         if type(enemy) == "table" and
            (tonumber(gmcp.Char.Vitals.position) == 6) then


### PR DESCRIPTION
Fix enemy GMCP payload compatibility and populate the hitpoint gauge for current payloads. README updated; package 0.0.36 built and uploaded.