### PR TITLE
Prevent duplicate comms replay during rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ data. The main panels are:
   speaker and channel, use the channel's default colour, and channel tabs can
   be dragged to change their order. The order is saved per profile, as is the
   comms history, which is restored after a package reinstall or GUI rebuild.
+  Communications are discrete GMCP events and are consumed once; rebuilding
+  the GUI restores the saved history without replaying the last event.
 - **Inventory / Equipped:** inventory is read from `Char.Items`, including
   quantities; visual item effects are stripped to keep rows compact. `Equipped`
   is a paper-doll view of every wear slot from `Char.Worn`, showing `[empty]`

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -52,10 +52,6 @@ function DD_GUI.refresh_data()
                 run_update(update_travel)
         end
 
-        if gmcp.Comm and type(gmcp.Comm.Channel) == "table" then
-                run_update(update_comms)
-        end
-
         if type(char.Channels) == "table" then
                 run_update(update_channel_status)
         end


### PR DESCRIPTION
Consume Comm.Channel.Text only from its event handler. GUI rebuilds now restore saved comms history without replaying the last event, preventing duplicate messages. Package 0.0.37 built and uploaded.