### PR TITLE
Fix enemy gauge layering and inventory capacity display

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ explicitly.
 When layout editing is enabled, the red-bordered regions can be dragged and
 resized. This includes the room/enemy panel, map, character sheet, comms,
 inventory/equipment, affects, main MUD text, navigation compass, and gauges.
+The adjustment surfaces remain transparent and below the panel data, so
+content stays visible while borders remain available for layout editing.
 The compass keeps a square shape and room/enemy images keep their 56:30 display
 ratio. Leaving layout mode saves the current positions and sizes to the active
 Mudlet profile. Use `resetgui` to restore every region to its default geometry.
@@ -61,7 +63,9 @@ data. The main panels are:
   Communications are discrete GMCP events and are consumed once; rebuilding
   the GUI restores the saved history without replaying the last event.
 - **Inventory / Equipped:** inventory is read from `Char.Items`, including
-  quantities; visual item effects are stripped to keep rows compact. `Equipped`
+  quantities; visual item effects are stripped to keep rows compact. The
+  inventory view also shows current/max item count and current/max carried
+  weight in its lower-right footer. `Equipped`
   is a paper-doll view of every wear slot from `Char.Worn`, showing `[empty]`
   or `[prohibited]` where appropriate for the character's profession, class,
   or current form.
@@ -77,7 +81,8 @@ data. The main panels are:
   sends `open`, then the movement command in sequence. The parsed state is kept per room, with
   Mudlet mapper door data as a fallback when no current Exits line is
   available. If neither source has a state, it sends the normal movement
-  command.
+  command. Enemy hitpoints are rendered in a dedicated overlay below the
+  enemy text, so the red gauge remains visible when the enemy console refreshes.
 
 The GUI refreshes these views from the latest GMCP snapshot after login and
 reconnect. If a manual rebuild is needed, run `lua bootstrap()` in Mudlet.

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.37",
+  "version": "0.0.41",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -137,6 +137,7 @@ local function raise_data_surfaces()
                 CharsheetImageFrame,
                 InventoryConsole,
                 EquippedConsole,
+                DD_GUI and DD_GUI.Inventory and DD_GUI.Inventory.stats_label,
                 AffectsConsole,
         }) do
                 raise_widget(widget)
@@ -225,32 +226,9 @@ function DD_GUI.raise_info_box_contents()
                         end
                 end
 
-                -- Child consoles sit above the adjustable surface during the
-                -- normal z-order pass. Raise the transparent frame surfaces
-                -- again so their red borders remain visible without masking
-                -- the click-through tab and console contents.
-                for _, box in pairs(Adjustable.Container.all) do
-                        if box and box.goInside ~= false and box.adjLabel and
-                           box.adjLabel.raise then
-                                box.adjLabel:raise()
-                        end
-                end
-
-                -- Keep the named information panels reliable across package
-                -- rebuilds, where Adjustable.Container.all can briefly hold
-                -- stale entries while the new children are being attached.
-                for _, box in ipairs({
-                        DD_GUI.EnemyBox,
-                        DD_GUI.MapBox,
-                        DD_GUI.CharsheetBox,
-                        DD_GUI.ChannelBox,
-                        DD_GUI.InventoryBox,
-                        DD_GUI.AffectBox,
-                }) do
-                        if box and box.adjLabel and box.adjLabel.raise then
-                                box.adjLabel:raise()
-                        end
-                end
+                -- Keep data surfaces above the full-size transparent frame
+                -- labels. Their inset geometry leaves the red border visible,
+                -- while raising the frames last can hide all panel content.
                 raise_tab_rails()
                 raise_data_surfaces()
                 raise_tab_controls()

--- a/src/scripts/DD/DD_GUI.InventoryBox.lua
+++ b/src/scripts/DD/DD_GUI.InventoryBox.lua
@@ -111,6 +111,15 @@ function DD_GUI.Inventory:switch_tab(key)
                 end
         end
 
+        if self.stats_label then
+                if key == "inventory" then
+                        self.stats_label:show()
+                        raiseWindow(self.stats_label.name)
+                else
+                        self.stats_label:hide()
+                end
+        end
+
         self:style_tabs()
 
         if key == "inventory" and type(update_inventory) == "function" then

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -44,7 +44,7 @@ function build_enemy_console()
       name="EnemyInfoConsole",
       x = "0%", y = "72%",
       width="100%",
-      height="30%",
+      height="14%",
       autoWrap = false,
       color = "black",
       scrollBar = false,
@@ -63,11 +63,17 @@ function build_enemy_console()
       margin: 0px;
     ]])
 
-    EnemyConsoleHitpointsContainer = Geyser.VBox:new({
+    -- Keep the complete gauge outside both MiniConsole viewports. A console
+    -- can repaint its native surface over child widgets, including the red
+    -- hitpoint fill, so the overlay belongs directly to the enemy box.
+    EnemyConsoleHitpointsContainer = Geyser.Container:new({
       name = "EnemyConsoleHitpointsContainer",
-      x = "0%", y = "50%",
-      width = "100%", height = "35%",
-    },EnemyInfoConsole)
+      x = "4%", y = "85%",
+      width = "92%", height = "10%",
+    }, DD_GUI.EnemyBox)
+    EnemyConsoleHitpointsContainer:setStyleSheet(
+      EnemyConsoleHitpointsContainerCSS:getCSS()
+    )
 
 
     local theme = DD_GUI.Theme
@@ -77,7 +83,11 @@ function build_enemy_console()
       theme:gauge_front_css(theme.colors.hp) or
       [[background-color: rgb(180,0,0);]])
 
-    EnemyConsoleHitpoints = Geyser.Gauge:new({ name = "EnemyConsoleHitpoints", }, EnemyConsoleHitpointsContainer)
+    EnemyConsoleHitpoints = Geyser.Gauge:new({
+      name = "EnemyConsoleHitpoints",
+      x = "0%", y = "0%",
+      width = "100%", height = "100%",
+    }, EnemyConsoleHitpointsContainer)
     EnemyConsoleHitpoints.back:setStyleSheet(EnemyConsoleHitpointsGaugeBackCSS:getCSS())
     EnemyConsoleHitpoints.front:setStyleSheet(EnemyConsoleHitpointsGaugeFrontCSS:getCSS())
 

--- a/src/scripts/DD/InventoryConsole.lua
+++ b/src/scripts/DD/InventoryConsole.lua
@@ -7,13 +7,17 @@ function build_inventory_console()
       EquippedConsole:hide()
     end
 
+    if InventoryStatsLabel and InventoryStatsLabel.hide then
+      InventoryStatsLabel:hide()
+    end
+
     DD_GUI.Inventory.consoles = {}
 
     InventoryConsole = Geyser.MiniConsole:new({
       name="InventoryConsole",
       x = "0%", y = "0%",
       width="100%",
-      height="100%",
+      height="86%",
       autoWrap = true,
       color = "black",
       scrollBar = true,
@@ -40,7 +44,27 @@ function build_inventory_console()
       DD_GUI.Theme:style_console(EquippedConsole, 10)
     end
 
+    InventoryStatsLabel = Geyser.Label:new({
+      name = "InventoryStatsLabel",
+      x = "45%", y = "86%",
+      width = "52%", height = "11%",
+    }, DD_GUI.InventoryBox)
+    InventoryStatsLabel:setStyleSheet([[
+      background-color: rgb(0,0,0);
+      border: 0px;
+      padding: 0px;
+      margin: 0px;
+    ]])
+    InventoryStatsLabel:setFgColor("white")
+    if DD_GUI.Theme then
+      DD_GUI.Theme:style_label(InventoryStatsLabel, 9, false)
+    else
+      InventoryStatsLabel:setFontSize(9)
+    end
+    InventoryStatsLabel:hide()
+
     DD_GUI.Inventory.consoles.inventory = InventoryConsole
     DD_GUI.Inventory.consoles.equipped = EquippedConsole
+    DD_GUI.Inventory.stats_label = InventoryStatsLabel
     DD_GUI.Inventory:switch_tab(DD_GUI.Inventory.current_tab or "inventory")
 end

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -97,6 +97,18 @@ function update_enemy()
                         else
                                 EnemyConsoleHitpoints:setValue(0, 1000)
                         end
+
+                        -- The gauge is a sibling of the text console; keep it
+                        -- above the image and text surfaces after each update.
+                        if EnemyConsoleHitpointsContainer.raise then
+                                EnemyConsoleHitpointsContainer:raise()
+                        end
+                        if EnemyConsoleHitpoints.raise then
+                                EnemyConsoleHitpoints:raise()
+                        end
+                        if EnemyHitpointsLabel.raise then
+                                EnemyHitpointsLabel:raise()
+                        end
                 end
         end
 end

--- a/src/scripts/DD/UpdateFunctions/update_inventory.lua
+++ b/src/scripts/DD/UpdateFunctions/update_inventory.lua
@@ -44,6 +44,59 @@ local function compact_inventory_name(value)
   return name
 end
 
+local function display_stat(value)
+  local number = tonumber(value)
+  if number then
+    return tostring(math.floor(number))
+  end
+
+  if value == nil or tostring(value) == "" then
+    return "?"
+  end
+
+  return tostring(value)
+end
+
+local function update_inventory_stats()
+  if not InventoryStatsLabel then
+    return
+  end
+
+  local char = gmcp and gmcp.Char
+  local stats = char and char.Stats
+  if type(stats) ~= "table" then
+    stats = char and char.Items and char.Items.Stats
+  end
+  if type(stats) ~= "table" then
+    InventoryStatsLabel:hide()
+    return
+  end
+
+  local current_number = stats.carry_num
+  local maximum_number = stats.maxcarry_num
+  local current_weight = stats.carry_wt
+  local maximum_weight = stats.maxcarry_wt
+
+  if current_number == nil and maximum_number == nil and
+     current_weight == nil and maximum_weight == nil then
+    InventoryStatsLabel:hide()
+    return
+  end
+
+  local message = string.format(
+    "Items: %s / %s<br/>Weight: %s / %s",
+    display_stat(current_number),
+    display_stat(maximum_number),
+    display_stat(current_weight),
+    display_stat(maximum_weight)
+  )
+  InventoryStatsLabel:show()
+  InventoryStatsLabel:echo(message, "white", "r9")
+  if InventoryStatsLabel.raise then
+    InventoryStatsLabel:raise()
+  end
+end
+
 function update_inventory()
   if not InventoryConsole then
     return
@@ -62,6 +115,7 @@ function update_inventory()
 
   InventoryConsole:clear()
   InventoryConsole:resetAutoWrap()
+  update_inventory_stats()
 
   if #entries == 0 then
     InventoryConsole:cecho("Nothing.<reset>")


### PR DESCRIPTION
Fix enemy hitpoint gauge visibility by placing the gauge directly on the enemy box and preserving data-widget z-order after rebuilds. Add GMCP Char.Stats inventory count/weight capacity footer, update README, and publish package 0.0.41.