### PR TITLE
Fix GUI rebuild visibility and enemy overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,13 @@ data. The main panels are:
   enemy text, so the red gauge remains visible when the enemy console refreshes.
 
 The GUI refreshes these views from the latest GMCP snapshot after login and
-reconnect. If a manual rebuild is needed, run `lua bootstrap()` in Mudlet.
+reconnect. `bootstrap()` is idempotent for the installed package version, so
+running `lua bootstrap()` after reconnect refreshes the existing widgets
+without stacking another copy of the interface. When a package update really
+does require new widgets, the previous GUI roots are hidden safely before the
+new tree is built and then explicitly shown again after Mudlet reuses any named
+containers. The enemy hitpoint bar is a direct label overlay rather than a
+nested native gauge, which keeps it visible above the enemy console surface.
 
 
 ## Aliases
@@ -96,7 +102,7 @@ These aliases are available from the Mudlet command line:
 | --- | --- |
 | `layoutgui` | Toggle layout editing. |
 | `layoutgui on` / `layoutgui off` | Explicitly enable or disable layout editing. |
-| `ddguiversion` | Display the installed DD_GUI package version. |
+| `ddguiversion` | Display the installed DD_GUI package version, including on Mudlet builds without `getPackageInfo()`. |
 | `resetgui` | Restore all GUI regions to their default positions and sizes. |
 | `gcc` | Refresh and download the latest custom content. |
 | `ddmap on` / `ddmap off` | Enable or disable the Dragons Domain custom mapper. |

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.41",
+  "version": "0.0.44",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/aliases/DD/ddguiversion.lua
+++ b/src/aliases/DD/ddguiversion.lua
@@ -1,5 +1,7 @@
 local version
-if type(getPackageInfo) == "function" then
+if DD_GUI and DD_GUI.package_version then
+        version = DD_GUI.package_version
+elseif type(getPackageInfo) == "function" then
         version = getPackageInfo("DD_GUI", "version")
 end
 

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -40,42 +40,30 @@ function build_enemy_console()
       DD_GUI.Theme:style_console(EnemyTPConsoleTop, 10)
     end
 
+    -- Keep descriptive text outside the native EnemyConsole viewport.
+    -- MiniConsole can repaint its own surface over nested child consoles.
     EnemyInfoConsole = Geyser.MiniConsole:new({
       name="EnemyInfoConsole",
-      x = "0%", y = "72%",
-      width="100%",
+      x = "4%", y = "72%",
+      width="92%",
       height="14%",
       autoWrap = false,
       color = "black",
       scrollBar = false,
       fontSize = 10,
-    }, EnemyConsole)
+    }, DD_GUI.EnemyBox)
     if DD_GUI.Theme then
       DD_GUI.Theme:style_console(EnemyInfoConsole, 10)
     end
 
-    EnemyConsoleHitpointsContainerCSS = CSSMan.new([[
-      background-color: rgb(0,0,0);
-      border-style: solid;
-      border-width: 0px;
-      border-radius: 5px;
-      border-color: red;
-      margin: 0px;
-    ]])
-
-    -- Keep the complete gauge outside both MiniConsole viewports. A console
-    -- can repaint its native surface over child widgets, including the red
-    -- hitpoint fill, so the overlay belongs directly to the enemy box.
-    EnemyConsoleHitpointsContainer = Geyser.Container:new({
+    -- Keep the complete gauge outside both MiniConsole viewports. Native
+    -- console surfaces can repaint over nested gauges, so the bar uses
+    -- direct sibling labels for deterministic stacking.
+    EnemyConsoleHitpointsContainer = Geyser.Label:new({
       name = "EnemyConsoleHitpointsContainer",
       x = "4%", y = "85%",
       width = "92%", height = "10%",
     }, DD_GUI.EnemyBox)
-    EnemyConsoleHitpointsContainer:setStyleSheet(
-      EnemyConsoleHitpointsContainerCSS:getCSS()
-    )
-
-
     local theme = DD_GUI.Theme
     EnemyConsoleHitpointsGaugeBackCSS = CSSMan.new(theme and
       theme:gauge_back_css() or [[background-color: rgb(0,0,0);]])
@@ -83,38 +71,36 @@ function build_enemy_console()
       theme:gauge_front_css(theme.colors.hp) or
       [[background-color: rgb(180,0,0);]])
 
-    EnemyConsoleHitpoints = Geyser.Gauge:new({
-      name = "EnemyConsoleHitpoints",
-      x = "0%", y = "0%",
-      width = "100%", height = "100%",
-    }, EnemyConsoleHitpointsContainer)
-    EnemyConsoleHitpoints.back:setStyleSheet(EnemyConsoleHitpointsGaugeBackCSS:getCSS())
-    EnemyConsoleHitpoints.front:setStyleSheet(EnemyConsoleHitpointsGaugeFrontCSS:getCSS())
+    EnemyConsoleHitpointsContainer:setStyleSheet(
+      EnemyConsoleHitpointsGaugeBackCSS:getCSS()
+    )
 
-    for index = 1, 9 do
-      local separator = Geyser.Label:new({
-        name = "EnemyConsoleHitpoints.Segment." .. index,
-        x = tostring(index * 10) .. "%",
-        y = 0,
-        width = 1,
-        height = "100%",
-      }, EnemyConsoleHitpoints)
-      separator:setStyleSheet([[
-        background-color: rgba(0,0,0,185);
-        border: 0px;
-      ]])
-      if DD_GUI.set_widget_clickthrough then
-        DD_GUI.set_widget_clickthrough(separator, true)
+    EnemyConsoleHitpoints = Geyser.Label:new({
+      name = "EnemyConsoleHitpoints",
+      x = "4%", y = "85%",
+      width = "0%", height = "10%",
+    }, DD_GUI.EnemyBox)
+    EnemyConsoleHitpoints:setStyleSheet(
+      EnemyConsoleHitpointsGaugeFrontCSS:getCSS()
+    )
+
+    function EnemyConsoleHitpoints:setValue(value, maximum)
+      local current = tonumber(value) or 0
+      local limit = tonumber(maximum) or 100
+      local ratio = 0
+      if limit > 0 then
+        ratio = math.max(0, math.min(1, current / limit))
       end
+      self:resize(string.format("%.3f%%", ratio * 100), "100%")
     end
 
     EnemyHitpointsLabel = Geyser.Label:new({
       name = "EnemyHitpointsLabel",
-      x = 0, y = 0,
-      width = "100%", height = "100%",
+      x = "4%", y = "85%",
+      width = "92%", height = "10%",
       fgColor = "black",
       message = [[HITS]]
-    },EnemyConsoleHitpoints )
+    }, DD_GUI.EnemyBox)
     EnemyHitpointsLabel:setColor(0,0,0,0)
     EnemyHitpointsLabel:setFgColor("white")
     EnemyHitpointsLabel:echo("HITS", "white", "c")

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -60,7 +60,85 @@ end
 -- Rebuilds can happen while the server already has a complete GMCP snapshot.
 -- Replay that snapshot after creating the widgets instead of waiting for the
 -- next GMCP event to arrive.
+local function dd_gui_installed_version()
+        if DD_GUI and DD_GUI.package_version then
+                return tostring(DD_GUI.package_version)
+        end
+
+        if type(getPackageInfo) ~= "function" then
+                return ""
+        end
+
+        local ok, version = pcall(getPackageInfo, "DD_GUI", "version")
+        if not ok then
+                return ""
+        end
+
+        return tostring(version or "")
+end
+
+local function dd_gui_hide_widget(widget)
+        if widget and type(widget.hide) == "function" then
+                pcall(function() widget:hide() end)
+        end
+end
+
+local function dd_gui_show_widget(widget)
+        if widget and type(widget.show) == "function" then
+                pcall(function() widget:show() end)
+        end
+end
+
+local function dd_gui_hide_previous_roots()
+        -- Deleting a live Adjustable.Container tree can crash some Mudlet
+        -- builds while child QWidgets are still being repainted. Hide the
+        -- old roots before constructing the replacement tree instead.
+        for _, widget in ipairs({
+                ui and ui.mainconsole_container,
+                DD_GUI and DD_GUI.Top,
+                DD_GUI and DD_GUI.Right,
+                DD_GUI and DD_GUI.Bottom,
+        }) do
+                dd_gui_hide_widget(widget)
+        end
+end
+
+local function dd_gui_show_current_roots()
+        for _, widget in ipairs({
+                ui and ui.mainconsole_container,
+                DD_GUI and DD_GUI.Top,
+                DD_GUI and DD_GUI.Right,
+                DD_GUI and DD_GUI.Bottom,
+        }) do
+                dd_gui_show_widget(widget)
+        end
+end
+
 function bootstrap()
+        local package_version = dd_gui_installed_version()
+
+        if DD_GUI.bootstrap_ready and
+           DD_GUI.bootstrap_version == package_version then
+                if DD_GUI.bootstrap_refresh_timer then
+                        killTimer(DD_GUI.bootstrap_refresh_timer)
+                        DD_GUI.bootstrap_refresh_timer = nil
+                end
+
+                dd_gui_show_current_roots()
+                DD_GUI.refresh_data()
+                if DD_GUI.raise_info_box_contents then
+                        DD_GUI.raise_info_box_contents()
+                end
+                if DD_GUI.Layout then
+                        DD_GUI.Layout:apply(false)
+                end
+                return
+        end
+
+        if DD_GUI.bootstrap_ready then
+                dd_gui_hide_previous_roots()
+        end
+
         set_borders()
         ui_container()
         create_background()
@@ -99,6 +177,14 @@ function bootstrap()
         if DD_GUI.raise_info_box_contents then
                 DD_GUI.raise_info_box_contents()
         end
+
+        -- Named adjustable containers can be reused by Mudlet during a live
+        -- package replacement. Ensure a root hidden during that handoff is
+        -- visible before the first data refresh and paint pass.
+        dd_gui_show_current_roots()
+
+        DD_GUI.bootstrap_ready = true
+        DD_GUI.bootstrap_version = package_version
 
         -- Geyser completes its initial geometry and stacking pass after
         -- bootstrap. Refresh once more so package updates also repaint the

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -1,6 +1,10 @@
 DD_GUI = DD_GUI or {}
 mudlet = mudlet or {}
 
+-- Mudlet builds without getPackageInfo() still need a reliable way to show
+-- the installed GUI version and decide whether bootstrap() may be reused.
+DD_GUI.package_version = "0.0.44"
+
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"
 local content_path = profile_path .. "/DD_GUI_Content"


### PR DESCRIPTION
## Summary
- make bootstrap idempotent and restore named GUI roots after package replacement
- move enemy descriptive text and hitpoint bar above native console repainting
- add package-embedded version reporting for Mudlet builds without getPackageInfo()
- update README and publish DD_GUI 0.0.44

## Verification
- .\\scripts\\build-and-upload.ps1
- Mudlet 4.21.0-dev: uninstall/reinstall, ddguiversion, lua bootstrap()
- verified travel, character, comms, inventory, affects, gauges, compass, and main text remain visible