### PR TITLE
Fix enemy hitpoint bar height

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -91,7 +91,7 @@ function build_enemy_console()
       if limit > 0 then
         ratio = math.max(0, math.min(1, current / limit))
       end
-      self:resize(string.format("%.3f%%", ratio * 100), "100%")
+      self:resize(string.format("%.3f%%", ratio * 100), "10%")
     end
 
     EnemyHitpointsLabel = Geyser.Label:new({

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.44"
+DD_GUI.package_version = "0.0.45"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- keep the enemy hitpoint fill at the intended 10% panel height
- bump DD_GUI to 0.0.45

## Verification
- .\\scripts\\build-and-upload.ps1
- removed/reinstalled the package in Mudlet while preserving profile content
- ran ddguiversion and lua bootstrap()
- rendered a temporary 500/1000 HP enemy payload and visually confirmed a short horizontal bar