### PR TITLE
Restore gauge surfaces after rebuild

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -112,6 +112,26 @@ local function dd_gui_show_current_roots()
         }) do
                 dd_gui_show_widget(widget)
         end
+
+        -- Gauge columns are direct children of the bottom root and can retain
+        -- a hidden state when Mudlet reuses named Geyser widgets during a
+        -- reconnect or package rebuild.
+        for _, widget in ipairs({
+                DD_GUI and DD_GUI.FirstColumn,
+                DD_GUI and DD_GUI.SecondColumn,
+                DD_GUI and DD_GUI.ThirdColumn,
+                DD_GUI and DD_GUI.FourthColumn,
+                DD_GUI and DD_GUI.Hitpoints,
+                DD_GUI and DD_GUI.Mana,
+                DD_GUI and DD_GUI.Xp,
+                DD_GUI and DD_GUI.Moves,
+                HitpointsLabel,
+                ManaLabel,
+                XpLabel,
+                MovesLabel,
+        }) do
+                dd_gui_show_widget(widget)
+        end
 end
 
 function bootstrap()

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.45"
+DD_GUI.package_version = "0.0.46"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- explicitly show the four bottom gauge columns and their widgets during bootstrap
- prevent reconnect/package rebuilds from leaving HITS, MANA, XP, and MOVES hidden
- bump DD_GUI to 0.0.46

## Verification
- .\\scripts\\build-and-upload.ps1
- removed/reinstalled the package in Mudlet with profile content preserved
- ran ddguiversion and lua bootstrap()
- visually confirmed the bottom gauge row is present