### PR TITLE
Restore right-panel frames and custom room images

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.47",
+  "version": "0.0.54",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -138,7 +138,9 @@ local function raise_data_surfaces()
                 InventoryConsole,
                 EquippedConsole,
                 DD_GUI and DD_GUI.Inventory and DD_GUI.Inventory.stats_label,
+                DD_GUI and DD_GUI.InventoryPanelOutline,
                 AffectsConsole,
+                DD_GUI and DD_GUI.AffectPanelOutline,
         }) do
                 raise_widget(widget)
         end
@@ -365,6 +367,93 @@ local function new_info_box(cons, parent)
 
         return Geyser.Label:new(cons, parent)
 end
+
+local function panel_outline_css()
+        if DD_GUI.Theme and DD_GUI.Theme.panel_css then
+                return DD_GUI.Theme:panel_css({
+                        background = "rgba(0,0,0,0)",
+                        margin = 0,
+                })
+        end
+
+        return [[
+                background-color: rgba(0,0,0,0);
+                border-style: solid;
+                border-width: 2px;
+                border-color: rgb(151,27,39);
+                border-radius: 0px;
+                margin: 0px;
+        ]]
+end
+
+local function panel_without_outline_css()
+        return [[
+                background-color: rgba(0,0,0,0);
+                border-style: none;
+                border-width: 0px;
+                border-color: rgba(0,0,0,0);
+                border-radius: 0px;
+                margin: 0px;
+        ]]
+end
+
+local function ensure_panel_outline(panel, name)
+        if not panel then
+                return nil
+        end
+
+        -- Affects' native adjustable frame can be replaced during tab
+        -- rebuilds. Keep a transparent child outline tied to the panel so
+        -- its border survives those repaints and follows user resizing.
+        local outline = panel._dd_gui_panel_outline
+        if outline and outline.container ~= panel then
+                if type(outline.delete) == "function" then
+                        pcall(function() outline:delete() end)
+                end
+                outline = nil
+        end
+        if not outline then
+                local constraints = {
+                        name = name,
+                        x = "0%",
+                        y = "0%",
+                        width = "100%",
+                        height = "100%",
+                }
+
+                -- Adjustable.Container normally redirects children into its
+                -- padded Inside container. Temporarily bypass that redirect
+                -- so this transparent frame sits on the panel's true outer
+                -- bounds and has no inset gap.
+                local go_inside = panel.goInside
+                panel.goInside = false
+                outline = Geyser.Label:new(constraints, panel)
+                panel.goInside = go_inside
+                panel._dd_gui_panel_outline = outline
+        end
+
+        outline:setStyleSheet(panel_outline_css())
+        outline:show()
+        if DD_GUI.set_widget_clickthrough then
+                DD_GUI.set_widget_clickthrough(outline, true)
+        end
+
+        -- The explicit outline is the single visible frame for these two
+        -- panels. Remove the adjustable surface border so a repaint cannot
+        -- create a second line or leave one panel frameless.
+        if panel.adjLabel then
+                panel._dd_gui_base_style = panel_without_outline_css()
+                if DD_GUI.refresh_adjustable_style then
+                        DD_GUI.refresh_adjustable_style(panel)
+                else
+                        panel.adjLabel:setStyleSheet(panel._dd_gui_base_style)
+                end
+        end
+        return outline
+end
+
+DD_GUI.ensure_panel_outline = ensure_panel_outline
+
 function define_boxes()
         local box_css = DD_GUI.Theme and DD_GUI.Theme:panel_css() or [[
           background-color: rgb(0,0,0);
@@ -441,5 +530,14 @@ function define_boxes()
         },DD_GUI.Right)
         DD_GUI.AffectBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.AffectBox:echo("<center>GUI.AffectBox")
+
+        DD_GUI.InventoryPanelOutline = ensure_panel_outline(
+                DD_GUI.InventoryBox,
+                "DD_GUI.InventoryPanelOutline"
+        )
+        DD_GUI.AffectPanelOutline = ensure_panel_outline(
+                DD_GUI.AffectBox,
+                "DD_GUI.AffectPanelOutline"
+        )
         
 end

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -121,6 +121,12 @@ local function dd_gui_show_current_roots()
                 DD_GUI and DD_GUI.SecondColumn,
                 DD_GUI and DD_GUI.ThirdColumn,
                 DD_GUI and DD_GUI.FourthColumn,
+                DD_GUI and DD_GUI.EnemyBox,
+                DD_GUI and DD_GUI.MapBox,
+                DD_GUI and DD_GUI.CharsheetBox,
+                DD_GUI and DD_GUI.ChannelBox,
+                DD_GUI and DD_GUI.InventoryBox,
+                DD_GUI and DD_GUI.AffectBox,
                 DD_GUI and DD_GUI.Hitpoints,
                 DD_GUI and DD_GUI.Mana,
                 DD_GUI and DD_GUI.Xp,
@@ -133,6 +139,8 @@ local function dd_gui_show_current_roots()
                 dd_gui_show_widget(widget)
         end
 end
+
+DD_GUI.show_current_roots = dd_gui_show_current_roots
 
 function bootstrap()
         local package_version = dd_gui_installed_version()

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -101,6 +101,22 @@ local function dd_gui_hide_previous_roots()
         }) do
                 dd_gui_hide_widget(widget)
         end
+
+        -- Remove panel overlays from the previous package tree before a
+        -- versioned rebuild. The replacement tree creates exactly one frame
+        -- for each right-column panel.
+        for _, key in ipairs({
+                "InventoryPanelOutline",
+                "AffectPanelOutline",
+        }) do
+                if DD_GUI and DD_GUI[key] then
+                        local outline = DD_GUI[key]
+                        if type(outline.delete) == "function" then
+                                pcall(function() outline:delete() end)
+                        end
+                        DD_GUI[key] = nil
+                end
+        end
 end
 
 local function dd_gui_show_current_roots()
@@ -137,6 +153,32 @@ local function dd_gui_show_current_roots()
                 MovesLabel,
         }) do
                 dd_gui_show_widget(widget)
+        end
+
+        if DD_GUI.ensure_panel_outline then
+                DD_GUI.InventoryPanelOutline = DD_GUI.ensure_panel_outline(
+                        DD_GUI.InventoryBox,
+                        "DD_GUI.InventoryPanelOutline"
+                )
+                DD_GUI.AffectPanelOutline = DD_GUI.ensure_panel_outline(
+                        DD_GUI.AffectBox,
+                        "DD_GUI.AffectPanelOutline"
+                )
+        end
+
+        local panel_css = DD_GUI and DD_GUI.BoxCSS
+        if panel_css and type(panel_css.getCSS) == "function" then
+                local css = panel_css:getCSS()
+                for _, panel in ipairs({
+                        DD_GUI and DD_GUI.EnemyBox,
+                        DD_GUI and DD_GUI.MapBox,
+                        DD_GUI and DD_GUI.CharsheetBox,
+                        DD_GUI and DD_GUI.ChannelBox,
+                }) do
+                        if panel and type(panel.setStyleSheet) == "function" then
+                                pcall(function() panel:setStyleSheet(css) end)
+                        end
+                end
         end
 end
 

--- a/src/scripts/DD/UpdateFunctions/update_travel.lua
+++ b/src/scripts/DD/UpdateFunctions/update_travel.lua
@@ -65,27 +65,28 @@ function update_travel()
 
             -- Custom room images.  If a custom room image exists, use it.
 
-            local ri_filename
-            local ri_fn_dotver = string.lower(string.gsub(gmcp.Room.Info.name, "/", "_"))
-            ri_fn_dotver = string.lower(string.gsub(ri_fn_dotver, " ", "_"))
+            local custom_room_path
+            local room_name = string.lower(tostring(gmcp.Room.Info.name or ""))
+            room_name = string.gsub(room_name, "/", "_")
+            room_name = string.gsub(room_name, " ", "_")
+            -- Sanitize the relative filename before asset_path() checks the
+            -- profile-owned content directory. Sanitizing the resolved path
+            -- afterward makes asset_path() fall back to the package folder.
+            room_name = string.gsub(room_name, "'", "_")
+            room_name = string.gsub(room_name, "<", "_")
+            room_name = string.gsub(room_name, ">", "_")
+            room_name = string.gsub(room_name, "{", "_")
 
             if (tonumber(gmcp.Room.Info.vnum) ~= 0) then
-                    ri_filename = asset_path("custom_rooms/"
+                    custom_room_path = asset_path("custom_rooms/"
                     ..tonumber(gmcp.Room.Info.vnum)
                     .."_"
-                    ..ri_fn_dotver
+                    ..room_name
                     ..".png")
             end
 
-            if ri_filename then
-                    ri_filename = string.gsub(ri_filename, "'", "_")
-                    ri_filename = string.gsub(ri_filename, "<", "_")
-                    ri_filename = string.gsub(ri_filename, ">", "_")
-                    ri_filename = string.gsub(ri_filename, "{", "_")
-            end
-
-            if (ri_filename and file_exists(ri_filename)) then
-                    room_image = ri_filename
+            if (custom_room_path and file_exists(custom_room_path)) then
+                    room_image = custom_room_path
             end
 
             --display(ri_filename)

--- a/src/scripts/DD/UpdateFunctions/update_vitals.lua
+++ b/src/scripts/DD/UpdateFunctions/update_vitals.lua
@@ -21,35 +21,17 @@ function update_vitals()
         lost_focus = true
       end
 
-    if lost_focus == true then
-    if hasFocus() then
-        set_borders()
-        ui_container()
-        create_background()
-        define_boxes()
-        build_gauges()
-        build_affects_box()
-        build_affects_console()
-        build_inventory_box()
-        build_inventory_console()
-        build_channel_box()
-        build_channel_console()
-        build_charsheet_box()
-        build_charsheet_console()
-        build_enemy_box()
-        build_enemy_console()
-        build_compass()
-        if DD_GUI.migrate_layout_defaults then
-                DD_GUI.migrate_layout_defaults()
-        end
-
-        if DD_GUI.raise_info_box_contents then
-                DD_GUI.raise_info_box_contents()
-        end
-
+    if lost_focus == true and hasFocus() then
+        -- Focus recovery used to duplicate bootstrap's widget construction.
+        -- That path could leave named adjustable panels hidden while their
+        -- child consoles remained visible. Reuse the idempotent bootstrap so
+        -- all roots, borders, and gauge columns are restored together.
         lost_focus = false
+        if type(bootstrap) == "function" then
+                bootstrap()
+                return
+        end
     end
-  end
 
   local hp      = gmcp.Char.Vitals.hp
   local maxhp   = gmcp.Char.Vitals.maxhp

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.47"
+DD_GUI.package_version = "0.0.54"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.46"
+DD_GUI.package_version = "0.0.47"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
Fixes right-column panel outlines so inventory and affects retain exactly one visible frame after bootstrap and content refreshes. Also sanitizes room image filenames before profile-content lookup, restoring custom room images such as 27347_sekolah_s_supplies.png. Verified in Mudlet with package 0.0.54 after uninstalling and reinstalling DD_GUI without removing profile-owned content.