### PR TITLE
Refine console and mapper styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ data. The main panels are:
   in a dedicated overlay below the enemy text, so the red gauge remains visible
   when the enemy console refreshes.
 
+The main MUD console and panel consoles use the profile's shared dark scrollbar
+style: narrow black tracks, dark-red edges, and red handles. The mapper's native
+room title uses an opaque black background with white text and a short red rule
+underneath, so it belongs visually with the rest of the interface.
+
 The GUI refreshes these views from the latest GMCP snapshot after login and
 reconnect. `bootstrap()` is idempotent for the installed package version, so
 running `lua bootstrap()` after reconnect refreshes the existing widgets

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/GoldBoxTheme.lua
+++ b/src/scripts/DD/GoldBoxTheme.lua
@@ -26,6 +26,8 @@ Theme.colors = {
         moves = "rgb(38,139,126)",
 }
 
+Theme.map_info_frame = {151, 27, 39}
+
 function Theme:panel_css(options)
         options = options or {}
         local background = options.background or self.colors.ink
@@ -212,6 +214,84 @@ function Theme:style_console(console, size)
         if type(console.setColor) == "function" then
                 pcall(function() console:setColor(0, 0, 0) end)
         end
+end
+
+function Theme:profile_style_sheet()
+        local c = self.colors
+
+        return string.format([[
+                TConsole QScrollBar:vertical {
+                        background: %s;
+                        width: 8px;
+                        margin: 0px;
+                        border-left: 1px solid %s;
+                }
+                TConsole QScrollBar::handle:vertical {
+                        background: %s;
+                        min-height: 18px;
+                        border: 1px solid %s;
+                }
+                TConsole QScrollBar::handle:vertical:hover {
+                        background: %s;
+                }
+                TConsole QScrollBar::add-line:vertical,
+                TConsole QScrollBar::sub-line:vertical {
+                        background: %s;
+                        height: 0px;
+                        border: none;
+                }
+                TConsole QScrollBar::add-page:vertical,
+                TConsole QScrollBar::sub-page:vertical {
+                        background: %s;
+                }
+
+                TConsole QScrollBar:horizontal {
+                        background: %s;
+                        height: 8px;
+                        margin: 0px;
+                        border-top: 1px solid %s;
+                }
+                TConsole QScrollBar::handle:horizontal {
+                        background: %s;
+                        min-width: 18px;
+                        border: 1px solid %s;
+                }
+                TConsole QScrollBar::handle:horizontal:hover {
+                        background: %s;
+                }
+                TConsole QScrollBar::add-line:horizontal,
+                TConsole QScrollBar::sub-line:horizontal {
+                        background: %s;
+                        width: 0px;
+                        border: none;
+                }
+                TConsole QScrollBar::add-page:horizontal,
+                TConsole QScrollBar::sub-page:horizontal {
+                        background: %s;
+                }
+        ]],
+                c.ink, c.dark_frame, c.frame, c.bright_frame, c.bright_frame,
+                c.ink, c.ink,
+                c.ink, c.dark_frame, c.frame, c.bright_frame, c.bright_frame,
+                c.ink, c.ink
+        )
+end
+
+function Theme:apply_profile_style()
+        if type(setProfileStyleSheet) ~= "function" then
+                return false
+        end
+
+        local ok, err = pcall(function()
+                setProfileStyleSheet(self:profile_style_sheet())
+        end)
+        if not ok then
+                DD_GUI.profile_style_error = tostring(err)
+                return false
+        end
+
+        DD_GUI.profile_style_error = nil
+        return true
 end
 
 local function set_clickthrough(widget, enabled)

--- a/src/scripts/DD/InitialiseMapper.lua
+++ b/src/scripts/DD/InitialiseMapper.lua
@@ -30,6 +30,33 @@ local function legacy_mapper_save_path()
         return string.gsub(package_path .. "/maps/dragons_domain_mapper.dat", "\\", "/")
 end
 
+local map_info_accent_name = "DD_GUI.MapTitleAccent"
+
+function DD_GUI.apply_mapper_theme()
+        if type(setConfig) == "function" then
+                pcall(function()
+                        setConfig("mapInfoColor", {0, 0, 0, 255})
+                end)
+        end
+
+        if type(registerMapInfo) ~= "function" or
+           type(enableMapInfo) ~= "function" then
+                return
+        end
+
+        local frame = DD_GUI.Theme and DD_GUI.Theme.map_info_frame or
+                {151, 27, 39}
+        local rule = string.rep(string.char(226, 148, 128), 38)
+
+        pcall(function()
+                registerMapInfo(map_info_accent_name, function()
+                        return rule, false, false, frame[1], frame[2], frame[3]
+                end)
+                enableMapInfo("Short")
+                enableMapInfo(map_info_accent_name)
+        end)
+end
+
 function save_dd_mapper()
         local saved, error_message = saveMap(dd_mapper_save_path())
         if not saved then

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -187,6 +187,10 @@ DD_GUI.show_current_roots = dd_gui_show_current_roots
 function bootstrap()
         local package_version = dd_gui_installed_version()
 
+        if DD_GUI.Theme and DD_GUI.Theme.apply_profile_style then
+                DD_GUI.Theme:apply_profile_style()
+        end
+
         if DD_GUI.bootstrap_ready and
            DD_GUI.bootstrap_version == package_version then
                 if DD_GUI.bootstrap_refresh_timer then
@@ -198,6 +202,9 @@ function bootstrap()
                 DD_GUI.refresh_data()
                 if DD_GUI.raise_info_box_contents then
                         DD_GUI.raise_info_box_contents()
+                end
+                if DD_GUI.apply_mapper_theme then
+                        DD_GUI.apply_mapper_theme()
                 end
                 if DD_GUI.Layout then
                         DD_GUI.Layout:apply(false)
@@ -230,6 +237,9 @@ function bootstrap()
         end
         initialise_mapper()
         load_dd_mapper()
+        if DD_GUI.apply_mapper_theme then
+                DD_GUI.apply_mapper_theme()
+        end
         get_custom_content()
         if DD_GUI.Mapper and DD_GUI.Mapper.setColor then
                 DD_GUI.Mapper:setColor(0, 0, 0, 255)

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.56"
+DD_GUI.package_version = "0.0.57"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- Apply a narrow dark scrollbar stylesheet to main and panel consoles.
- Set the native mapper room title to an opaque black strip with a red lower rule.
- Document the visual changes and publish package 0.0.57.

## Verification
- Ran .\\scripts\\build-and-upload.ps1.
- Replaced the live DD_GUI package, checked ddguiversion, and ran lua bootstrap().
- Visually verified the live Mudlet profile.