### PR TITLE
Add combat panel flashes and defeat transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you have any issues with the automated installation and update system for the
 
 To uninstall the GUI, you can simply type:
 
-`lua uninstallPackage("DD_GUI")`, use the built-in `ugui` alias, or use Mudlet's graphical package manager. The GUI copies any legacy downloaded content into the profile-owned `DD_GUI_Content` directory before removal when needed.
+`lua uninstallPackage("DD_GUI")`, use the built-in `ugui` alias, or use Mudlet's graphical package manager. The GUI copies any legacy downloaded content into the profile-owned `DD_GUI_Content` directory before removal when needed. To safely uninstall and reinstall the latest remote package, use `reinstallgui`; it lets the alias return, then waits three seconds between the two operations so Mudlet can finish removing the old package.
 
 ## Layout controls
 
@@ -53,7 +53,9 @@ data. The main panels are:
   shape with a `vnum` identifier; the enemy hitpoint gauge uses either shape.
   Travel mode keeps the room summary visible as `Area` and `Type` on the first
   line, `Room` on the second, and `Room flags` on the third; empty visible flags
-  are shown as `None`.
+  are shown as `None`. The panel border is brighter while fighting, briefly
+  pulses brighter when entering a new room, and plays a short shattering-fall
+  transition when combat ends before returning to the room view.
 - **Map:** the current room and surrounding map data.
 - **Character sheet:** profile image, character details, statistics, and
   resistances.
@@ -118,6 +120,7 @@ These aliases are available from the Mudlet command line:
 | `ddmap on` / `ddmap off` | Enable or disable the Dragons Domain custom mapper. |
 | `ignores` | Add the Dragons Domain portal message to the mapper's ignore patterns. |
 | `ugui` | Uninstall the `DD_GUI` package. |
+| `reinstallgui` | Defer the uninstall, wait three seconds, and reinstall the latest remote package without removing downloaded custom content. |
 
 
 ## Keyboard controls

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.57",
+  "version": "0.0.62",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/aliases/DD/aliases.json
+++ b/src/aliases/DD/aliases.json
@@ -4,6 +4,10 @@
                 "regex": "^ugui$"
         },
         {
+                "name": "reinstallgui",
+                "regex": "^reinstallgui$"
+        },
+        {
                 "name": "gcc",
                 "regex": "^gcc$"
         },

--- a/src/aliases/DD/reinstallgui.lua
+++ b/src/aliases/DD/reinstallgui.lua
@@ -1,0 +1,36 @@
+local package_url = "https://www.dragons-domain.org/main/gui/DD_GUI.mpackage"
+local uninstall_delay = 0.1
+local reinstall_delay = 3
+
+local state = DD_GUI or {}
+
+if DD_GUI and DD_GUI.migrate_legacy_content then
+        DD_GUI.migrate_legacy_content()
+end
+
+if state.reinstall_timer and killTimer then
+        killTimer(state.reinstall_timer)
+        state.reinstall_timer = nil
+end
+
+echo("\nDD_GUI will uninstall shortly, then reinstall in " ..
+        reinstall_delay .. " seconds...\n")
+
+-- Let this alias return before removing the package that owns it. Mudlet can
+-- terminate when uninstallPackage() mutates the active package mid-alias.
+state.reinstall_timer = tempTimer(uninstall_delay, function()
+        state.reinstall_timer = nil
+        local ok, err = pcall(uninstallPackage, "DD_GUI")
+        if not ok then
+                echo("DD_GUI uninstall failed: " .. tostring(err) .. "\n")
+                return
+        end
+
+        tempTimer(reinstall_delay, function()
+                echo("\nInstalling the latest DD_GUI package...\n")
+                local install_ok, install_err = pcall(installPackage, package_url)
+                if not install_ok then
+                        echo("DD_GUI install failed: " .. tostring(install_err) .. "\n")
+                end
+        end)
+end)

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -1,4 +1,241 @@
+local function enemy_panel_css(border)
+  if DD_GUI.Theme and DD_GUI.Theme.panel_css then
+    return DD_GUI.Theme:panel_css({border = border})
+  end
+
+  return string.format([[
+    background-color: rgba(0,0,0,0);
+    border-style: solid;
+    border-width: 2px;
+    border-color: %s;
+    border-radius: 0px;
+    margin: 1px;
+  ]], border)
+end
+
+function DD_GUI.set_enemy_panel_border(border)
+  if not DD_GUI.EnemyBox or not border then
+    return
+  end
+
+  DD_GUI.EnemyBox:setStyleSheet(enemy_panel_css(border))
+  DD_GUI.enemy_panel_border = border
+end
+
+function DD_GUI.cancel_enemy_panel_flash()
+  DD_GUI.enemy_panel_flash_token =
+    (DD_GUI.enemy_panel_flash_token or 0) + 1
+end
+
+function DD_GUI.flash_enemy_panel()
+  if not tempTimer then
+    DD_GUI.set_enemy_panel_border(
+      DD_GUI.Theme and DD_GUI.Theme.colors.frame or "rgb(151,27,39)"
+    )
+    return
+  end
+
+  DD_GUI.cancel_enemy_panel_flash()
+  local token = DD_GUI.enemy_panel_flash_token
+  local theme = DD_GUI.Theme
+  local colors = theme and theme.colors or {}
+  local bright = colors.bright_frame or "rgb(205,48,60)"
+  local middle = colors.frame_flash or "rgb(181,37,49)"
+  local regular = colors.frame or "rgb(151,27,39)"
+
+  DD_GUI.set_enemy_panel_border(bright)
+  tempTimer(0.08, function()
+    if DD_GUI.enemy_panel_flash_token == token then
+      DD_GUI.set_enemy_panel_border(middle)
+    end
+  end)
+  tempTimer(0.16, function()
+    if DD_GUI.enemy_panel_flash_token == token then
+      DD_GUI.set_enemy_panel_border(regular)
+    end
+  end)
+end
+
+function DD_GUI.enemy_panel_room_changed(vnum)
+  local current = vnum == nil and "" or tostring(vnum)
+  local previous = DD_GUI.enemy_panel_room_vnum
+  DD_GUI.enemy_panel_room_vnum = current
+  return previous ~= nil and previous ~= "" and
+    current ~= "" and previous ~= current
+end
+
+function DD_GUI.enemy_panel_same_room(room)
+  if type(room) ~= "table" or room.vnum == nil then
+    return false
+  end
+
+  return DD_GUI.enemy_panel_room_vnum ~= nil and
+    tostring(room.vnum) == tostring(DD_GUI.enemy_panel_room_vnum)
+end
+
+local function shatter_css(alpha)
+  local theme = DD_GUI.Theme
+  local colors = theme and theme.colors or {}
+  local edge = colors.bright_frame or "rgb(205,48,60)"
+
+  return string.format([[
+    background-color: rgba(151,27,39,%d);
+    border-style: solid;
+    border-width: 1px;
+    border-color: %s;
+    border-radius: 0px;
+    margin: 0px;
+  ]], alpha, edge)
+end
+
+local function remove_enemy_shatter_shards()
+  for _, shard in ipairs(DD_GUI.EnemyShatterShards or {}) do
+    if shard and shard.delete then
+      pcall(function() shard:delete() end)
+    end
+  end
+  DD_GUI.EnemyShatterShards = {}
+end
+
+function DD_GUI.cancel_enemy_defeat_transition()
+  DD_GUI.enemy_defeat_token = (DD_GUI.enemy_defeat_token or 0) + 1
+  DD_GUI.enemy_defeat_active = false
+  remove_enemy_shatter_shards()
+  if EnemyShatterLayer and EnemyShatterLayer.hide then
+    EnemyShatterLayer:hide()
+  end
+end
+
+function DD_GUI.start_enemy_defeat_transition(on_complete)
+  if DD_GUI.enemy_defeat_active then
+    return true
+  end
+
+  if not EnemyShatterLayer or not Geyser or not Geyser.Label then
+    if type(on_complete) == "function" then
+      on_complete()
+    end
+    return false
+  end
+
+  DD_GUI.enemy_defeat_active = true
+  DD_GUI.enemy_defeat_token = (DD_GUI.enemy_defeat_token or 0) + 1
+  local token = DD_GUI.enemy_defeat_token
+  local layer = EnemyShatterLayer
+  local layer_width = math.max(1, tonumber(layer:get_width()) or 0)
+  local layer_height = math.max(1, tonumber(layer:get_height()) or 0)
+  local columns = 5
+  local rows = 3
+  local cell_width = layer_width / columns
+  local cell_height = layer_height / rows
+  local symbols = {"/", "\\", "+", "-", "*"}
+
+  DD_GUI.cancel_enemy_panel_flash()
+  DD_GUI.set_enemy_panel_border(
+    DD_GUI.Theme and DD_GUI.Theme.colors.bright_frame or
+      "rgb(205,48,60)"
+  )
+  remove_enemy_shatter_shards()
+  layer:show()
+
+  for row = 0, rows - 1 do
+    for column = 0, columns - 1 do
+      local x = math.floor(column * cell_width + 2)
+      local y = math.floor(row * cell_height + 2)
+      local width = math.max(8, math.floor(cell_width - 4))
+      local height = math.max(8, math.floor(cell_height - 4))
+      local shard = Geyser.Label:new({
+        name = string.format("DD_GUI.EnemyShatter.%d.%d", row, column),
+        x = x,
+        y = y,
+        width = width,
+        height = height,
+        color = "black",
+      }, layer)
+      shard:setStyleSheet(shatter_css(90))
+      shard:echo(symbols[(row + column) % #symbols + 1], "white", "cb9")
+      if DD_GUI.set_widget_clickthrough then
+        DD_GUI.set_widget_clickthrough(shard, true)
+      end
+      local desired_drift_x = (column - (columns - 1) / 2) * 34 +
+        (row % 2 == 0 and -8 or 8)
+      local desired_drift_y =
+        28 + row * 18 + math.abs(column - (columns - 1) / 2) * 12
+      local min_drift_x = 2 - x
+      local max_drift_x = layer_width - x - width - 2
+      local max_drift_y = layer_height - y - height - 2
+      table.insert(DD_GUI.EnemyShatterShards, {
+        widget = shard,
+        x = x,
+        y = y,
+        width = width,
+        height = height,
+        drift_x = math.max(min_drift_x, math.min(max_drift_x, desired_drift_x)),
+        drift_y = math.max(0, math.min(max_drift_y, desired_drift_y)),
+      })
+    end
+  end
+
+  layer:raiseAll()
+  local frame = 0
+  local frame_count = 8
+
+  local function finish()
+    if DD_GUI.enemy_defeat_token ~= token then
+      return
+    end
+
+    DD_GUI.enemy_defeat_active = false
+    remove_enemy_shatter_shards()
+    layer:hide()
+    if type(on_complete) == "function" then
+      pcall(on_complete)
+    end
+  end
+
+  local function animate()
+    if DD_GUI.enemy_defeat_token ~= token then
+      return
+    end
+
+    frame = frame + 1
+    local progress = math.min(1, frame / frame_count)
+    local alpha = math.floor(90 + 130 * progress)
+    for _, state in ipairs(DD_GUI.EnemyShatterShards) do
+      local shard = state.widget
+      local scale = 1 - progress * 0.45
+      local width = math.max(3, math.floor(state.width * scale))
+      local height = math.max(3, math.floor(state.height * scale))
+      local x = state.x + state.drift_x * progress +
+        (state.width - width) / 2
+      local y = state.y + state.drift_y * progress +
+        (state.height - height) / 2
+
+      shard:move(math.floor(x), math.floor(y))
+      shard:resize(width, height)
+      shard:setStyleSheet(shatter_css(alpha))
+    end
+
+    if frame >= frame_count then
+      tempTimer(0.05, finish)
+    else
+      tempTimer(0.06, animate)
+    end
+  end
+
+  animate()
+  return true
+end
+
 function build_enemy_console()
+  if DD_GUI.cancel_enemy_defeat_transition then
+    DD_GUI.cancel_enemy_defeat_transition()
+  end
+  if EnemyShatterLayer and EnemyShatterLayer.delete then
+    pcall(function() EnemyShatterLayer:delete() end)
+  end
+  EnemyShatterLayer = nil
+
 
     EnemyConsole = Geyser.MiniConsole:new({
       name="EnemyConsole",
@@ -112,5 +349,17 @@ function build_enemy_console()
     if DD_GUI.set_widget_clickthrough then
       DD_GUI.set_widget_clickthrough(EnemyHitpointsLabel, true)
     end
+
+    EnemyShatterLayer = Geyser.Container:new({
+      name = "DD_GUI.EnemyShatterLayer",
+      x = "0%",
+      y = "0%",
+      width = "100%",
+      height = "69%",
+    }, EnemyConsole)
+    if DD_GUI.set_widget_clickthrough then
+      DD_GUI.set_widget_clickthrough(EnemyShatterLayer, true)
+    end
+    EnemyShatterLayer:hide()
 
   end

--- a/src/scripts/DD/GoldBoxTheme.lua
+++ b/src/scripts/DD/GoldBoxTheme.lua
@@ -11,6 +11,7 @@ Theme.colors = {
         panel_alt = "rgb(0,0,0)",
         frame = "rgb(151,27,39)",
         bright_frame = "rgb(205,48,60)",
+        frame_flash = "rgb(181,37,49)",
         dark_frame = "rgb(72,10,18)",
         gold = "rgb(196,161,78)",
         bright_gold = "rgb(239,210,118)",

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -49,7 +49,29 @@ function DD_GUI.refresh_data()
         if position == 6 and has_enemy then
                 run_update(update_enemy)
         elseif type(room) == "table" and type(vitals) == "table" then
-                run_update(update_travel)
+                local same_room = DD_GUI.enemy_panel_same_room and
+                        DD_GUI.enemy_panel_same_room(room)
+                local transition_started = false
+
+                if DD_GUI.enemy_defeat_active then
+                        if not same_room and DD_GUI.cancel_enemy_defeat_transition then
+                                DD_GUI.cancel_enemy_defeat_transition()
+                        else
+                                transition_started = true
+                        end
+                elseif position ~= 6 and
+                       DD_GUI.enemy_panel_mode == "combat" and same_room and
+                       DD_GUI.start_enemy_defeat_transition then
+                        transition_started = DD_GUI.start_enemy_defeat_transition(
+                                function()
+                                        run_update(update_travel)
+                                end
+                        ) == true
+                end
+
+                if not transition_started then
+                        run_update(update_travel)
+                end
         end
 
         if type(char.Channels) == "table" then

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -28,7 +28,23 @@ function update_enemy()
         if type(enemy) == "table" and
            (tonumber(gmcp.Char.Vitals.position) == 6) then
 
-                DD_GUI.EnemyBox:setStyleSheet(DD_GUI.EnemyBoxCSS:getCSS())
+                if DD_GUI.cancel_enemy_defeat_transition then
+                        DD_GUI.cancel_enemy_defeat_transition()
+                end
+                if DD_GUI.cancel_enemy_panel_flash then
+                        DD_GUI.cancel_enemy_panel_flash()
+                end
+                DD_GUI.enemy_panel_mode = "combat"
+                local room = gmcp.Room and gmcp.Room.Info
+                if type(room) == "table" and room.vnum ~= nil then
+                        DD_GUI.enemy_panel_room_vnum = tostring(room.vnum)
+                end
+                if DD_GUI.set_enemy_panel_border then
+                        DD_GUI.set_enemy_panel_border(
+                                DD_GUI.Theme and DD_GUI.Theme.colors.bright_frame or
+                                        "rgb(205,48,60)"
+                        )
+                end
                 if EnemyInfoConsole and EnemyInfoConsole.resize then
                         EnemyInfoConsole:resize("92%", "14%")
                 end

--- a/src/scripts/DD/UpdateFunctions/update_travel.lua
+++ b/src/scripts/DD/UpdateFunctions/update_travel.lua
@@ -12,6 +12,26 @@ function update_travel()
 
     if (tonumber(vitals.position) ~= 6) then
 
+            local room_changed = false
+            if DD_GUI.enemy_panel_room_changed then
+                    room_changed = DD_GUI.enemy_panel_room_changed(
+                            gmcp.Room.Info.vnum
+                    )
+            end
+            DD_GUI.enemy_panel_mode = "travel"
+            if DD_GUI.cancel_enemy_panel_flash then
+                    DD_GUI.cancel_enemy_panel_flash()
+            end
+            if DD_GUI.set_enemy_panel_border then
+                    DD_GUI.set_enemy_panel_border(
+                            DD_GUI.Theme and DD_GUI.Theme.colors.frame or
+                                    "rgb(151,27,39)"
+                    )
+            end
+            if room_changed and DD_GUI.flash_enemy_panel then
+                    DD_GUI.flash_enemy_panel()
+            end
+
             -- Travel mode has three lines of room metadata. The info console
             -- shares the panel with the combat summary, so give it the
             -- unused lower space while the enemy gauge is hidden.
@@ -20,7 +40,12 @@ function update_travel()
             end
 
             EnemyConsole:clear()
-            DD_GUI.EnemyBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
+            if DD_GUI.set_enemy_panel_border then
+                    DD_GUI.set_enemy_panel_border(
+                            DD_GUI.Theme and DD_GUI.Theme.colors.frame or
+                                    "rgb(151,27,39)"
+                    )
+            end
             EnemyInfoConsole:clear()
             EnemyConsoleHitpointsContainer:hide()
             EnemyConsoleHitpoints:hide()

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.57"
+DD_GUI.package_version = "0.0.62"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- brighten the room/enemy frame during combat and pulse it on room changes
- add a bounded shatter transition when combat ends
- add and document the delayed reinstallgui alias

## Verification
- built and uploaded DD_GUI 0.0.62
- tested the pulse and shatter in the live Mudlet client
- tested reinstallgui through uninstall, delay, reinstall, version check, and bootstrap