### PR TITLE
Fix combat panel feedback transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ data. The main panels are:
   shape with a `vnum` identifier; the enemy hitpoint gauge uses either shape.
   Travel mode keeps the room summary visible as `Area` and `Type` on the first
   line, `Room` on the second, and `Room flags` on the third; empty visible flags
-  are shown as `None`. The panel border is brighter while fighting, briefly
-  pulses brighter when entering a new room, and plays a short shattering-fall
-  transition when combat ends before returning to the room view.
+  are shown as `None`. The panel border pulses brighter while fighting and
+  briefly pulses brighter when entering a new room before returning to its
+  regular colour. When combat ends, the panel plays a short shattering-fall
+  transition before returning to the room view.
 - **Map:** the current room and surrounding map data.
 - **Character sheet:** profile image, character details, statistics, and
   resistances.

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.62",
+  "version": "0.0.65",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -25,10 +25,12 @@ end
 function DD_GUI.cancel_enemy_panel_flash()
   DD_GUI.enemy_panel_flash_token =
     (DD_GUI.enemy_panel_flash_token or 0) + 1
+  DD_GUI.enemy_panel_flash_active = false
 end
 
 function DD_GUI.flash_enemy_panel()
   if not tempTimer then
+    DD_GUI.enemy_panel_flash_active = false
     DD_GUI.set_enemy_panel_border(
       DD_GUI.Theme and DD_GUI.Theme.colors.frame or "rgb(151,27,39)"
     )
@@ -43,17 +45,66 @@ function DD_GUI.flash_enemy_panel()
   local middle = colors.frame_flash or "rgb(181,37,49)"
   local regular = colors.frame or "rgb(151,27,39)"
 
+  DD_GUI.enemy_panel_flash_active = true
   DD_GUI.set_enemy_panel_border(bright)
-  tempTimer(0.08, function()
+  tempTimer(0.12, function()
     if DD_GUI.enemy_panel_flash_token == token then
       DD_GUI.set_enemy_panel_border(middle)
     end
   end)
-  tempTimer(0.16, function()
+  tempTimer(0.42, function()
     if DD_GUI.enemy_panel_flash_token == token then
+      DD_GUI.enemy_panel_flash_active = false
       DD_GUI.set_enemy_panel_border(regular)
     end
   end)
+end
+
+function DD_GUI.cancel_enemy_combat_pulse()
+  DD_GUI.enemy_combat_pulse_token =
+    (DD_GUI.enemy_combat_pulse_token or 0) + 1
+  DD_GUI.enemy_combat_pulse_active = false
+end
+
+function DD_GUI.start_enemy_combat_pulse()
+  if DD_GUI.enemy_combat_pulse_active then
+    return
+  end
+
+  DD_GUI.cancel_enemy_combat_pulse()
+  local token = DD_GUI.enemy_combat_pulse_token
+  local theme = DD_GUI.Theme
+  local colors = theme and theme.colors or {}
+  local bright = colors.bright_frame or "rgb(205,48,60)"
+  local regular = colors.frame or "rgb(151,27,39)"
+
+  DD_GUI.enemy_combat_pulse_active = true
+  if not tempTimer then
+    DD_GUI.set_enemy_panel_border(bright)
+    return
+  end
+
+  local function pulse()
+    if DD_GUI.enemy_combat_pulse_token ~= token or
+       DD_GUI.enemy_panel_mode ~= "combat" then
+      DD_GUI.enemy_combat_pulse_active = false
+      return
+    end
+
+    DD_GUI.set_enemy_panel_border(bright)
+    tempTimer(0.18, function()
+      if DD_GUI.enemy_combat_pulse_token ~= token or
+         DD_GUI.enemy_panel_mode ~= "combat" then
+        DD_GUI.enemy_combat_pulse_active = false
+        return
+      end
+
+      DD_GUI.set_enemy_panel_border(regular)
+      tempTimer(0.82, pulse)
+    end)
+  end
+
+  pulse()
 end
 
 function DD_GUI.enemy_panel_room_changed(vnum)
@@ -71,6 +122,31 @@ function DD_GUI.enemy_panel_same_room(room)
 
   return DD_GUI.enemy_panel_room_vnum ~= nil and
     tostring(room.vnum) == tostring(DD_GUI.enemy_panel_room_vnum)
+end
+
+function DD_GUI.maybe_start_enemy_defeat_transition()
+  local room = gmcp and gmcp.Room and gmcp.Room.Info
+  local same_room = DD_GUI.enemy_panel_same_room and
+    DD_GUI.enemy_panel_same_room(room)
+
+  if DD_GUI.enemy_defeat_active then
+    if not same_room and DD_GUI.cancel_enemy_defeat_transition then
+      DD_GUI.cancel_enemy_defeat_transition()
+      return false
+    end
+    return true
+  end
+
+  if DD_GUI.enemy_panel_mode ~= "combat" or not same_room or
+     not DD_GUI.start_enemy_defeat_transition then
+    return false
+  end
+
+  return DD_GUI.start_enemy_defeat_transition(function()
+    if type(update_travel) == "function" then
+      pcall(update_travel)
+    end
+  end) == true
 end
 
 local function shatter_css(alpha)
@@ -124,13 +200,16 @@ function DD_GUI.start_enemy_defeat_transition(on_complete)
   local layer = EnemyShatterLayer
   local layer_width = math.max(1, tonumber(layer:get_width()) or 0)
   local layer_height = math.max(1, tonumber(layer:get_height()) or 0)
-  local columns = 5
-  local rows = 3
+  local columns = 6
+  local rows = 4
   local cell_width = layer_width / columns
   local cell_height = layer_height / rows
   local symbols = {"/", "\\", "+", "-", "*"}
 
   DD_GUI.cancel_enemy_panel_flash()
+  if DD_GUI.cancel_enemy_combat_pulse then
+    DD_GUI.cancel_enemy_combat_pulse()
+  end
   DD_GUI.set_enemy_panel_border(
     DD_GUI.Theme and DD_GUI.Theme.colors.bright_frame or
       "rgb(205,48,60)"
@@ -178,7 +257,7 @@ function DD_GUI.start_enemy_defeat_transition(on_complete)
 
   layer:raiseAll()
   local frame = 0
-  local frame_count = 8
+  local frame_count = 12
 
   local function finish()
     if DD_GUI.enemy_defeat_token ~= token then
@@ -186,6 +265,7 @@ function DD_GUI.start_enemy_defeat_transition(on_complete)
     end
 
     DD_GUI.enemy_defeat_active = false
+    DD_GUI.enemy_panel_mode = "travel"
     remove_enemy_shatter_shards()
     layer:hide()
     if type(on_complete) == "function" then
@@ -217,9 +297,9 @@ function DD_GUI.start_enemy_defeat_transition(on_complete)
     end
 
     if frame >= frame_count then
-      tempTimer(0.05, finish)
+      tempTimer(0.08, finish)
     else
-      tempTimer(0.06, animate)
+      tempTimer(0.07, animate)
     end
   end
 
@@ -230,6 +310,9 @@ end
 function build_enemy_console()
   if DD_GUI.cancel_enemy_defeat_transition then
     DD_GUI.cancel_enemy_defeat_transition()
+  end
+  if DD_GUI.cancel_enemy_combat_pulse then
+    DD_GUI.cancel_enemy_combat_pulse()
   end
   if EnemyShatterLayer and EnemyShatterLayer.delete then
     pcall(function() EnemyShatterLayer:delete() end)
@@ -350,13 +433,16 @@ function build_enemy_console()
       DD_GUI.set_widget_clickthrough(EnemyHitpointsLabel, true)
     end
 
+    -- This must be a sibling of the native MiniConsole rather than its
+    -- child. MiniConsole can repaint over child widgets during a refresh,
+    -- making the defeat animation appear to skip straight to travel mode.
     EnemyShatterLayer = Geyser.Container:new({
       name = "DD_GUI.EnemyShatterLayer",
-      x = "0%",
-      y = "0%",
-      width = "100%",
-      height = "69%",
-    }, EnemyConsole)
+      x = "4%",
+      y = "6%",
+      width = "92%",
+      height = "63%",
+    }, DD_GUI.EnemyBox)
     if DD_GUI.set_widget_clickthrough then
       DD_GUI.set_widget_clickthrough(EnemyShatterLayer, true)
     end

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -49,29 +49,7 @@ function DD_GUI.refresh_data()
         if position == 6 and has_enemy then
                 run_update(update_enemy)
         elseif type(room) == "table" and type(vitals) == "table" then
-                local same_room = DD_GUI.enemy_panel_same_room and
-                        DD_GUI.enemy_panel_same_room(room)
-                local transition_started = false
-
-                if DD_GUI.enemy_defeat_active then
-                        if not same_room and DD_GUI.cancel_enemy_defeat_transition then
-                                DD_GUI.cancel_enemy_defeat_transition()
-                        else
-                                transition_started = true
-                        end
-                elseif position ~= 6 and
-                       DD_GUI.enemy_panel_mode == "combat" and same_room and
-                       DD_GUI.start_enemy_defeat_transition then
-                        transition_started = DD_GUI.start_enemy_defeat_transition(
-                                function()
-                                        run_update(update_travel)
-                                end
-                        ) == true
-                end
-
-                if not transition_started then
-                        run_update(update_travel)
-                end
+                run_update(update_travel)
         end
 
         if type(char.Channels) == "table" then

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -24,22 +24,30 @@ function update_enemy()
 
         local enemies = gmcp and gmcp.Char and gmcp.Char.Enemies
         local enemy = first_enemy(enemies)
+        local position = gmcp and gmcp.Char and gmcp.Char.Vitals and
+                tonumber(gmcp.Char.Vitals.position)
 
         if type(enemy) == "table" and
-           (tonumber(gmcp.Char.Vitals.position) == 6) then
+           position == 6 then
 
+                local entering_combat = DD_GUI.enemy_panel_mode ~= "combat"
                 if DD_GUI.cancel_enemy_defeat_transition then
                         DD_GUI.cancel_enemy_defeat_transition()
                 end
-                if DD_GUI.cancel_enemy_panel_flash then
+                if entering_combat and DD_GUI.cancel_enemy_panel_flash then
                         DD_GUI.cancel_enemy_panel_flash()
+                end
+                if entering_combat and DD_GUI.cancel_enemy_combat_pulse then
+                        DD_GUI.cancel_enemy_combat_pulse()
                 end
                 DD_GUI.enemy_panel_mode = "combat"
                 local room = gmcp.Room and gmcp.Room.Info
                 if type(room) == "table" and room.vnum ~= nil then
                         DD_GUI.enemy_panel_room_vnum = tostring(room.vnum)
                 end
-                if DD_GUI.set_enemy_panel_border then
+                if DD_GUI.start_enemy_combat_pulse then
+                        DD_GUI.start_enemy_combat_pulse()
+                elseif DD_GUI.set_enemy_panel_border then
                         DD_GUI.set_enemy_panel_border(
                                 DD_GUI.Theme and DD_GUI.Theme.colors.bright_frame or
                                         "rgb(205,48,60)"
@@ -129,5 +137,8 @@ function update_enemy()
                                 EnemyHitpointsLabel:raise()
                         end
                 end
+        elseif DD_GUI.maybe_start_enemy_defeat_transition and
+               DD_GUI.maybe_start_enemy_defeat_transition() then
+                return
         end
 end

--- a/src/scripts/DD/UpdateFunctions/update_travel.lua
+++ b/src/scripts/DD/UpdateFunctions/update_travel.lua
@@ -12,6 +12,12 @@ function update_travel()
 
     if (tonumber(vitals.position) ~= 6) then
 
+            if DD_GUI.maybe_start_enemy_defeat_transition and
+               DD_GUI.maybe_start_enemy_defeat_transition() then
+                    return
+            end
+
+            local previous_mode = DD_GUI.enemy_panel_mode
             local room_changed = false
             if DD_GUI.enemy_panel_room_changed then
                     room_changed = DD_GUI.enemy_panel_room_changed(
@@ -19,17 +25,22 @@ function update_travel()
                     )
             end
             DD_GUI.enemy_panel_mode = "travel"
-            if DD_GUI.cancel_enemy_panel_flash then
-                    DD_GUI.cancel_enemy_panel_flash()
+            if previous_mode == "combat" then
+                    if DD_GUI.cancel_enemy_combat_pulse then
+                            DD_GUI.cancel_enemy_combat_pulse()
+                    end
+                    if DD_GUI.cancel_enemy_panel_flash then
+                            DD_GUI.cancel_enemy_panel_flash()
+                    end
             end
-            if DD_GUI.set_enemy_panel_border then
+            if room_changed and DD_GUI.flash_enemy_panel then
+                    DD_GUI.flash_enemy_panel()
+            elseif not DD_GUI.enemy_panel_flash_active and
+                   DD_GUI.set_enemy_panel_border then
                     DD_GUI.set_enemy_panel_border(
                             DD_GUI.Theme and DD_GUI.Theme.colors.frame or
                                     "rgb(151,27,39)"
                     )
-            end
-            if room_changed and DD_GUI.flash_enemy_panel then
-                    DD_GUI.flash_enemy_panel()
             end
 
             -- Travel mode has three lines of room metadata. The info console
@@ -40,7 +51,8 @@ function update_travel()
             end
 
             EnemyConsole:clear()
-            if DD_GUI.set_enemy_panel_border then
+            if not DD_GUI.enemy_panel_flash_active and
+               DD_GUI.set_enemy_panel_border then
                     DD_GUI.set_enemy_panel_border(
                             DD_GUI.Theme and DD_GUI.Theme.colors.frame or
                                     "rgb(151,27,39)"

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.62"
+DD_GUI.package_version = "0.0.65"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
Make room-entry feedback visible, pulse the enemy border during combat, and render the defeat shatter transition above the native console surface. Built and uploaded with scripts/build-and-upload.ps1; installed in Mudlet 0.0.65 with reinstallgui and bootstrap(); visually verified room flash, combat pulse, natural defeat transition, and clean post-transition state.