### PR TITLE
Improve reinstall version check and combat pulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you have any issues with the automated installation and update system for the
 
 To uninstall the GUI, you can simply type:
 
-`lua uninstallPackage("DD_GUI")`, use the built-in `ugui` alias, or use Mudlet's graphical package manager. The GUI copies any legacy downloaded content into the profile-owned `DD_GUI_Content` directory before removal when needed. To safely uninstall and reinstall the latest remote package, use `reinstallgui`; it lets the alias return, then waits three seconds between the two operations so Mudlet can finish removing the old package.
+`lua uninstallPackage("DD_GUI")`, use the built-in `ugui` alias, or use Mudlet's graphical package manager. The GUI copies any legacy downloaded content into the profile-owned `DD_GUI_Content` directory before removal when needed. To safely uninstall and reinstall the latest remote package, use `reinstallgui`; it lets the alias return, waits three seconds between the two operations so Mudlet can finish removing the old package, then reports the installed package version.
 
 ## Layout controls
 
@@ -121,7 +121,7 @@ These aliases are available from the Mudlet command line:
 | `ddmap on` / `ddmap off` | Enable or disable the Dragons Domain custom mapper. |
 | `ignores` | Add the Dragons Domain portal message to the mapper's ignore patterns. |
 | `ugui` | Uninstall the `DD_GUI` package. |
-| `reinstallgui` | Defer the uninstall, wait three seconds, and reinstall the latest remote package without removing downloaded custom content. |
+| `reinstallgui` | Defer the uninstall, wait three seconds, reinstall the latest remote package, and report its installed version without removing downloaded custom content. |
 
 
 ## Keyboard controls

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.67",
+  "version": "0.0.72",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/aliases/DD/reinstallgui.lua
+++ b/src/aliases/DD/reinstallgui.lua
@@ -1,8 +1,71 @@
 local package_url = "https://www.dragons-domain.org/main/gui/DD_GUI.mpackage"
 local uninstall_delay = 0.1
 local reinstall_delay = 3
+local version_check_delay = 5
+local max_version_checks = 12
 
 local state = DD_GUI or {}
+
+local function installed_version()
+        local version
+        if DD_GUI and DD_GUI.package_version then
+                version = DD_GUI.package_version
+        elseif type(getPackageInfo) == "function" then
+                local ok, package_version = pcall(
+                        getPackageInfo,
+                        "DD_GUI",
+                        "version"
+                )
+                if ok then
+                        version = package_version
+                end
+        end
+        return version
+end
+
+local function report_installed_version()
+        local version = installed_version()
+
+        if version and version ~= "" then
+                echo("\nDD_GUI version: " .. tostring(version) .. "\n")
+        else
+                echo("\nDD_GUI package version is unavailable.\n")
+        end
+end
+
+local previous_version = installed_version()
+local version_check_attempts = 0
+
+local function check_installed_version()
+        state.reinstall_version_timer = nil
+        if not state.reinstall_install_finished then
+                state.reinstall_version_timer = tempTimer(
+                        1,
+                        check_installed_version
+                )
+                return
+        end
+
+        if not state.reinstall_install_succeeded then
+                echo("\nDD_GUI version check skipped because installation failed.\n")
+                return
+        end
+
+        version_check_attempts = version_check_attempts + 1
+        local version = installed_version()
+        if version_check_attempts < max_version_checks and
+           (not version or version == "" or
+            (previous_version and
+             tostring(version) == tostring(previous_version))) then
+                state.reinstall_version_timer = tempTimer(
+                        1,
+                        check_installed_version
+                )
+                return
+        end
+
+        report_installed_version()
+end
 
 if DD_GUI and DD_GUI.migrate_legacy_content then
         DD_GUI.migrate_legacy_content()
@@ -12,9 +75,23 @@ if state.reinstall_timer and killTimer then
         killTimer(state.reinstall_timer)
         state.reinstall_timer = nil
 end
+if state.reinstall_version_timer and killTimer then
+        killTimer(state.reinstall_version_timer)
+        state.reinstall_version_timer = nil
+end
+state.reinstall_install_succeeded = false
+state.reinstall_install_finished = false
 
 echo("\nDD_GUI will uninstall shortly, then reinstall in " ..
         reinstall_delay .. " seconds...\n")
+
+-- Create this timer before removing the package so it survives the package
+-- replacement. The install request itself is asynchronous, so wait beyond
+-- the uninstall and reinstall delays before reading the new metadata.
+state.reinstall_version_timer = tempTimer(
+        uninstall_delay + reinstall_delay + version_check_delay,
+        check_installed_version
+)
 
 -- Let this alias return before removing the package that owns it. Mudlet can
 -- terminate when uninstallPackage() mutates the active package mid-alias.
@@ -31,6 +108,10 @@ state.reinstall_timer = tempTimer(uninstall_delay, function()
                 local install_ok, install_err = pcall(installPackage, package_url)
                 if not install_ok then
                         echo("DD_GUI install failed: " .. tostring(install_err) .. "\n")
+                        state.reinstall_install_finished = true
+                        return
                 end
+                state.reinstall_install_succeeded = true
+                state.reinstall_install_finished = true
         end)
 end)

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -102,15 +102,20 @@ function DD_GUI.start_enemy_combat_pulse()
   local middle = colors.frame_flash or "rgb(181,37,49)"
   local soft = blend_rgb(regular, middle, 0.5)
   local high = blend_rgb(middle, bright, 0.5)
+  local peak = blend_rgb(
+    bright,
+    colors.white or "rgb(255,255,255)",
+    0.18
+  )
   local pulse_stages = {
-    {color = regular, duration = 0.70},
-    {color = soft, duration = 0.20},
-    {color = middle, duration = 0.25},
-    {color = high, duration = 0.25},
-    {color = bright, duration = 0.32},
-    {color = high, duration = 0.25},
-    {color = middle, duration = 0.25},
-    {color = soft, duration = 0.20},
+    {color = regular, duration = 0.64},
+    {color = soft, duration = 0.19},
+    {color = middle, duration = 0.23},
+    {color = high, duration = 0.23},
+    {color = peak, duration = 0.30},
+    {color = high, duration = 0.23},
+    {color = middle, duration = 0.23},
+    {color = soft, duration = 0.19},
   }
 
   DD_GUI.enemy_combat_pulse_active = true

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.67"
+DD_GUI.package_version = "0.0.72"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- wait for asynchronous DD_GUI replacement and retry the installed version check
- document reinstallgui's version report
- make the combat border pulse slightly faster with a brighter peak

## Verification
- build-and-upload.ps1 completed for DD_GUI 0.0.72
- live Mudlet reinstall reported DD_GUI 0.0.72
- live pulse trace reached rgb(214,85,95) and returned to the regular frame
- bootstrap() and ddguiversion verified in Mudlet