### PR TITLE
Fix map title clipping and combat frame seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ data. The main panels are:
   pulse while fighting and briefly pulses brighter when entering a new room
   before returning to its regular colour. When combat ends, the enemy image
   slowly fades to black, the next enemy or room image is rendered underneath,
-  and the replacement fades back in.
-- **Map:** the current room and surrounding map data.
+  and the replacement fades back in. Shared edges with the map follow the
+  combat colour as well, so the pulse remains continuous around the panel.
+- **Map:** the current room and surrounding map data. The embedded mapper has
+  even internal padding, and its title is kept to one compact room/vnum line
+  so northern rooms remain visible even when a room name is long.
 - **Character sheet:** profile image, character details, statistics, and
   resistances.
 - **Comms:** communications received from the GMCP `Comm` structure. The `All`

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.81",
+  "version": "0.0.83",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/FrameGrid.lua
+++ b/src/scripts/DD/FrameGrid.lua
@@ -343,9 +343,42 @@ function FrameGrid:make_axes()
                 return result
         end
 
+        local function merge_nearby_axes(axes_list)
+                local result = {}
+                for _, axis in ipairs(axes_list) do
+                        local match
+                        for _, existing in ipairs(result) do
+                                local overlap = math.min(existing.finish,
+                                        axis.finish) - math.max(existing.start,
+                                        axis.start)
+                                if math.abs(existing.position - axis.position) <= 2 and
+                                   overlap >= 8 then
+                                        match = existing
+                                        break
+                                end
+                        end
+
+                        if match then
+                                match.position = (match.position + axis.position) / 2
+                                match.start = math.min(match.start, axis.start)
+                                match.finish = math.max(match.finish, axis.finish)
+                                for _, entry in ipairs(axis.entries or {}) do
+                                        match.entries[#match.entries + 1] = entry
+                                end
+                        else
+                                result[#result + 1] = axis
+                        end
+                end
+
+                table.sort(result, function(left, right)
+                        return left.position < right.position
+                end)
+                return result
+        end
+
         self.axes = {
-                h = materialize_axis(axes.h),
-                v = materialize_axis(axes.v),
+                h = merge_nearby_axes(materialize_axis(axes.h)),
+                v = merge_nearby_axes(materialize_axis(axes.v)),
         }
 
         -- Independent percentage layouts can land a shared corner a pixel
@@ -383,6 +416,19 @@ end
 
 local function edge_owner_color(self, entries)
         local regular = self:regular_color()
+
+        -- The enemy/map divider is a shared edge. Give combat state an
+        -- explicit priority there so a regular map repaint cannot mask the
+        -- enemy pulse on that one side.
+        local enemy_color = self.region_colors.EnemyBox
+        if enemy_color and enemy_color ~= regular then
+                for _, entry in ipairs(entries or {}) do
+                        if entry.region and entry.region.id == "EnemyBox" then
+                                return enemy_color
+                        end
+                end
+        end
+
         local selected = regular
         for _, entry in ipairs(entries or {}) do
                 local color = self.region_colors[entry.region.id]
@@ -468,6 +514,10 @@ function FrameGrid:refresh_colors()
                         marker._dd_gui_frame_color = color
                 end
         end
+
+        -- Content widgets can repaint a shared divider after a combat colour
+        -- change. Keep the click-through frame layer above those surfaces.
+        self:raise()
 end
 
 function FrameGrid:draw_visuals()

--- a/src/scripts/DD/InitialiseMapper.lua
+++ b/src/scripts/DD/InitialiseMapper.lua
@@ -30,7 +30,33 @@ local function legacy_mapper_save_path()
         return string.gsub(package_path .. "/maps/dragons_domain_mapper.dat", "\\", "/")
 end
 
+local map_info_title_name = "DD_GUI.MapTitle"
 local map_info_accent_name = "DD_GUI.MapTitleAccent"
+
+local function compact_map_title(room_id)
+        local id = tonumber(room_id)
+        if not id or type(roomExists) ~= "function" then
+                return ""
+        end
+
+        local exists_ok, exists = pcall(roomExists, id)
+        if not exists_ok or not exists then
+                return ""
+        end
+
+        local name_ok, name = pcall(getRoomName, id)
+        if not name_ok or not name or tostring(name) == "" then
+                return tostring(id)
+        end
+
+        local title = tostring(name):gsub("[\r\n]+", " ") .. " / " .. tostring(id)
+        -- The native mapper wraps map-info fragments. Keep the title on one
+        -- line so north rooms remain visible in the small embedded viewport.
+        if #title > 40 then
+                title = title:sub(1, 37):gsub("%s+%S*$", "") .. "..."
+        end
+        return title
+end
 
 function DD_GUI.apply_mapper_theme()
         if type(setConfig) == "function" then
@@ -49,10 +75,18 @@ function DD_GUI.apply_mapper_theme()
         local rule = string.rep(string.char(226, 148, 128), 38)
 
         pcall(function()
+                registerMapInfo(map_info_title_name, function(room_id)
+                        local title = compact_map_title(room_id)
+                        if title == "" then
+                                return ""
+                        end
+                        return title, false, false, 255, 255, 255
+                end)
                 registerMapInfo(map_info_accent_name, function()
                         return rule, false, false, frame[1], frame[2], frame[3]
                 end)
-                enableMapInfo("Short")
+                disableMapInfo("Short")
+                enableMapInfo(map_info_title_name)
                 enableMapInfo(map_info_accent_name)
         end)
 end

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.81"
+DD_GUI.package_version = "0.0.83"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- keep the embedded mapper title to one compact room/vnum line so northern rooms remain visible
- merge near-coincident frame axes and prioritize the enemy colour on the shared map divider
- raise the frame layer after colour changes so the combat pulse remains visible on all four sides
- document the behavior and publish DD_GUI 0.0.83

## Verification
- ran scripts/build-and-upload.ps1
- remote XML reports version 0.0.83
- uninstalled/reinstalled through reinstallgui, ran ddguiversion and bootstrap reload
- visually checked the live Mudlet client and pixel-sampled the forced shared-edge pulse