### PR TITLE
Smooth room-entry frame pulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ data. The main panels are:
   coloured underlay feathers toward black across each braid edge, keeping the
   glow softer than a solid rectangular strip.
   pulse while fighting and briefly pulses brighter when entering a new room
-  before returning to its regular colour. When combat ends, the enemy image
+  before returning to its regular colour. The enemy pulse is quicker while
+  the room-entry flash lingers a little longer, and the coloured underlay is
+  inset by one pixel
+  on each exposed side behind the braid. When combat ends, the enemy image
   slowly fades to black, the next enemy or room image is rendered underneath,
   and the replacement fades back in. Shared edges with the map follow the
   combat colour as well, so the pulse remains continuous around the panel.

--- a/README.md
+++ b/README.md
@@ -66,15 +66,13 @@ data. The main panels are:
   shape with a `vnum` identifier; the enemy hitpoint gauge uses either shape.
   Travel mode keeps the room summary visible as `Area` and `Type` on the first
   line, `Room` on the second, and `Room flags` on the third; empty visible flags
-  are shown as `None`. The panel border moves through a slower, smoothly
-  graduated multi-step red pulse with an explicit black-to-red swell. The
-  coloured underlay feathers toward black across each braid edge, keeping the
-  glow softer than a solid rectangular strip.
-  pulse while fighting and briefly pulses brighter when entering a new room
-  before returning to its regular colour. The enemy pulse is quicker while
-  the room-entry flash lingers a little longer, and the coloured underlay is
-  inset by one pixel
-  on each exposed side behind the braid. When combat ends, the enemy image
+  are shown as `None`. The panel border uses a smoothly graduated multi-step
+  red swell and ebb while fighting, and the same soft envelope for the one-shot
+  room-entry flash before returning to its regular colour. The combat pulse
+  completes in two seconds; the room-entry flash uses a 2.42-second cadence.
+  The coloured underlay feathers toward black across each braid edge, keeping
+  the glow softer than a solid rectangular strip. It is inset by one pixel on
+  each exposed side behind the braid. When combat ends, the enemy image
   slowly fades to black, the next enemy or room image is rendered underneath,
   and the replacement fades back in. Shared edges with the map follow the
   combat colour as well, so the pulse remains continuous around the panel.

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.97",
+  "version": "0.0.99",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -56,12 +56,12 @@ function DD_GUI.flash_enemy_panel()
 
   DD_GUI.enemy_panel_flash_active = true
   DD_GUI.set_enemy_panel_border(bright)
-  tempTimer(0.12, function()
+  tempTimer(0.20, function()
     if DD_GUI.enemy_panel_flash_token == token then
       DD_GUI.set_enemy_panel_border(middle)
     end
   end)
-  tempTimer(0.42, function()
+  tempTimer(0.76, function()
     if DD_GUI.enemy_panel_flash_token == token then
       DD_GUI.enemy_panel_flash_active = false
       DD_GUI.set_enemy_panel_border(regular)
@@ -124,26 +124,26 @@ function DD_GUI.start_enemy_combat_pulse()
     0.18
   )
   local pulse_stages = {
-    {color = black, duration = 0.26},
-    {color = ember, duration = 0.12},
-    {color = glow, duration = 0.14},
-    {color = dim, duration = 0.16},
-    {color = base, duration = 0.16},
-    {color = low, duration = 0.16},
-    {color = soft, duration = 0.16},
-    {color = middle, duration = 0.18},
-    {color = high, duration = 0.18},
-    {color = very_high, duration = 0.16},
-    {color = peak, duration = 0.22},
-    {color = very_high, duration = 0.16},
-    {color = high, duration = 0.18},
-    {color = middle, duration = 0.18},
-    {color = soft, duration = 0.16},
-    {color = low, duration = 0.16},
-    {color = base, duration = 0.16},
-    {color = dim, duration = 0.16},
-    {color = glow, duration = 0.14},
-    {color = ember, duration = 0.12},
+    {color = black, duration = 0.20},
+    {color = ember, duration = 0.09},
+    {color = glow, duration = 0.11},
+    {color = dim, duration = 0.12},
+    {color = base, duration = 0.12},
+    {color = low, duration = 0.12},
+    {color = soft, duration = 0.12},
+    {color = middle, duration = 0.14},
+    {color = high, duration = 0.14},
+    {color = very_high, duration = 0.12},
+    {color = peak, duration = 0.18},
+    {color = very_high, duration = 0.12},
+    {color = high, duration = 0.14},
+    {color = middle, duration = 0.14},
+    {color = soft, duration = 0.12},
+    {color = low, duration = 0.12},
+    {color = base, duration = 0.12},
+    {color = dim, duration = 0.12},
+    {color = glow, duration = 0.11},
+    {color = ember, duration = 0.09},
   }
 
   DD_GUI.enemy_combat_pulse_active = true

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -11,6 +11,72 @@ function DD_GUI.set_enemy_panel_border(border)
   end
 end
 
+local function rgb_channels(color)
+  local red, green, blue = tostring(color):match(
+    "^rgb%s*%(%s*(%d+)%s*,%s*(%d+)%s*,%s*(%d+)%s*%)$"
+  )
+  return tonumber(red), tonumber(green), tonumber(blue)
+end
+
+local function blend_rgb(from, to, amount)
+  local from_red, from_green, from_blue = rgb_channels(from)
+  local to_red, to_green, to_blue = rgb_channels(to)
+  if not from_red or not to_red then
+    return to
+  end
+
+  return string.format(
+    "rgb(%d,%d,%d)",
+    math.floor(from_red + (to_red - from_red) * amount + 0.5),
+    math.floor(from_green + (to_green - from_green) * amount + 0.5),
+    math.floor(from_blue + (to_blue - from_blue) * amount + 0.5)
+  )
+end
+
+local function panel_pulse_palette(colors)
+  local bright = colors.bright_frame or "rgb(205,48,60)"
+  local regular = colors.frame or "rgb(151,27,39)"
+  local middle = colors.frame_flash or "rgb(181,37,49)"
+  local black = "rgb(0,0,0)"
+
+  return {
+    black = black,
+    ember = blend_rgb(black, regular, 0.18),
+    glow = blend_rgb(black, regular, 0.38),
+    dim = blend_rgb(black, regular, 0.62),
+    base = blend_rgb(black, regular, 0.82),
+    low = blend_rgb(regular, middle, 0.25),
+    soft = blend_rgb(regular, middle, 0.5),
+    middle = middle,
+    high = blend_rgb(middle, bright, 0.5),
+    very_high = blend_rgb(bright, colors.white or "rgb(255,255,255)", 0.08),
+    peak = blend_rgb(
+      bright,
+      colors.white or "rgb(255,255,255)",
+      0.18
+    ),
+    regular = regular,
+  }
+end
+
+local pulse_stage_names = {
+  "black", "ember", "glow", "dim", "base", "low", "soft", "middle",
+  "high", "very_high", "peak", "very_high", "high", "middle", "soft",
+  "low", "base", "dim", "glow", "ember",
+}
+
+local function build_panel_pulse_stages(colors, durations)
+  local palette = panel_pulse_palette(colors)
+  local stages = {}
+  for index, name in ipairs(pulse_stage_names) do
+    stages[index] = {
+      color = palette[name],
+      duration = durations[index],
+    }
+  end
+  return stages, palette.regular
+end
+
 local function enemy_hitpoint_widgets()
   return {
     EnemyConsoleHitpointsContainer,
@@ -50,51 +116,42 @@ function DD_GUI.flash_enemy_panel()
   local token = DD_GUI.enemy_panel_flash_token
   local theme = DD_GUI.Theme
   local colors = theme and theme.colors or {}
-  local bright = colors.bright_frame or "rgb(205,48,60)"
-  local middle = colors.frame_flash or "rgb(181,37,49)"
-  local regular = colors.frame or "rgb(151,27,39)"
+  local room_stages, regular = build_panel_pulse_stages(colors, {
+    0.18, 0.08, 0.10, 0.12, 0.12, 0.12, 0.12, 0.14, 0.14, 0.12,
+    0.18, 0.12, 0.14, 0.14, 0.12, 0.12, 0.12, 0.10, 0.08, 0.06,
+  })
 
   DD_GUI.enemy_panel_flash_active = true
-  DD_GUI.set_enemy_panel_border(bright)
-  tempTimer(0.20, function()
-    if DD_GUI.enemy_panel_flash_token == token then
-      DD_GUI.set_enemy_panel_border(middle)
+  local stage = 1
+  local function pulse()
+    if DD_GUI.enemy_panel_flash_token ~= token then
+      return
     end
-  end)
-  tempTimer(0.76, function()
-    if DD_GUI.enemy_panel_flash_token == token then
-      DD_GUI.enemy_panel_flash_active = false
-      DD_GUI.set_enemy_panel_border(regular)
-    end
-  end)
+
+    local current = room_stages[stage]
+    DD_GUI.set_enemy_panel_border(current.color)
+    stage = stage + 1
+    tempTimer(current.duration, function()
+      if DD_GUI.enemy_panel_flash_token ~= token then
+        return
+      end
+
+      if stage > #room_stages then
+        DD_GUI.enemy_panel_flash_active = false
+        DD_GUI.set_enemy_panel_border(regular)
+      else
+        pulse()
+      end
+    end)
+  end
+
+  pulse()
 end
 
 function DD_GUI.cancel_enemy_combat_pulse()
   DD_GUI.enemy_combat_pulse_token =
     (DD_GUI.enemy_combat_pulse_token or 0) + 1
   DD_GUI.enemy_combat_pulse_active = false
-end
-
-local function rgb_channels(color)
-  local red, green, blue = tostring(color):match(
-    "^rgb%s*%(%s*(%d+)%s*,%s*(%d+)%s*,%s*(%d+)%s*%)$"
-  )
-  return tonumber(red), tonumber(green), tonumber(blue)
-end
-
-local function blend_rgb(from, to, amount)
-  local from_red, from_green, from_blue = rgb_channels(from)
-  local to_red, to_green, to_blue = rgb_channels(to)
-  if not from_red or not to_red then
-    return to
-  end
-
-  return string.format(
-    "rgb(%d,%d,%d)",
-    math.floor(from_red + (to_red - from_red) * amount + 0.5),
-    math.floor(from_green + (to_green - from_green) * amount + 0.5),
-    math.floor(from_blue + (to_blue - from_blue) * amount + 0.5)
-  )
 end
 
 function DD_GUI.start_enemy_combat_pulse()
@@ -106,49 +163,16 @@ function DD_GUI.start_enemy_combat_pulse()
   local token = DD_GUI.enemy_combat_pulse_token
   local theme = DD_GUI.Theme
   local colors = theme and theme.colors or {}
-  local bright = colors.bright_frame or "rgb(205,48,60)"
-  local regular = colors.frame or "rgb(151,27,39)"
-  local middle = colors.frame_flash or "rgb(181,37,49)"
-  local black = "rgb(0,0,0)"
-  local ember = blend_rgb(black, regular, 0.18)
-  local glow = blend_rgb(black, regular, 0.38)
-  local dim = blend_rgb(black, regular, 0.62)
-  local base = blend_rgb(black, regular, 0.82)
-  local low = blend_rgb(regular, middle, 0.25)
-  local soft = blend_rgb(regular, middle, 0.5)
-  local high = blend_rgb(middle, bright, 0.5)
-  local very_high = blend_rgb(bright, colors.white or "rgb(255,255,255)", 0.08)
-  local peak = blend_rgb(
-    bright,
-    colors.white or "rgb(255,255,255)",
-    0.18
-  )
-  local pulse_stages = {
-    {color = black, duration = 0.20},
-    {color = ember, duration = 0.09},
-    {color = glow, duration = 0.11},
-    {color = dim, duration = 0.12},
-    {color = base, duration = 0.12},
-    {color = low, duration = 0.12},
-    {color = soft, duration = 0.12},
-    {color = middle, duration = 0.14},
-    {color = high, duration = 0.14},
-    {color = very_high, duration = 0.12},
-    {color = peak, duration = 0.18},
-    {color = very_high, duration = 0.12},
-    {color = high, duration = 0.14},
-    {color = middle, duration = 0.14},
-    {color = soft, duration = 0.12},
-    {color = low, duration = 0.12},
-    {color = base, duration = 0.12},
-    {color = dim, duration = 0.12},
-    {color = glow, duration = 0.11},
-    {color = ember, duration = 0.09},
-  }
+  local pulse_stages = build_panel_pulse_stages(colors, {
+    0.14, 0.07, 0.08, 0.10, 0.10, 0.10, 0.10, 0.12, 0.12, 0.10,
+    0.15, 0.10, 0.12, 0.12, 0.10, 0.10, 0.10, 0.07, 0.07, 0.04,
+  })
 
   DD_GUI.enemy_combat_pulse_active = true
   if not tempTimer then
-    DD_GUI.set_enemy_panel_border(bright)
+    DD_GUI.set_enemy_panel_border(
+      DD_GUI.Theme and DD_GUI.Theme.colors.bright_frame or "rgb(205,48,60)"
+    )
     return
   end
 

--- a/src/scripts/DD/FrameGrid.lua
+++ b/src/scripts/DD/FrameGrid.lua
@@ -539,12 +539,44 @@ function FrameGrid:underlay_css(color, orientation, node)
         ]], x2, y2, color, color)
 end
 
-function FrameGrid:ensure_underlay(widget)
+function FrameGrid:underlay_bounds(bounds, orientation, node)
+        local inset_x = 0
+        local inset_y = 0
+        if node then
+                inset_x = 1
+                inset_y = 1
+        elseif orientation == "h" then
+                inset_y = 1
+        elseif orientation == "v" then
+                inset_x = 1
+        end
+
+        return {
+                x = bounds.x + inset_x,
+                y = bounds.y + inset_y,
+                width = math.max(1, bounds.width - inset_x * 2),
+                height = math.max(1, bounds.height - inset_y * 2),
+        }
+end
+
+function FrameGrid:position_underlay(underlay, bounds, orientation, node)
+        local positioned = self:underlay_bounds(bounds, orientation, node)
+        if underlay.move then
+                pcall(function()
+                        underlay:move(positioned.x, positioned.y)
+                end)
+        end
+        if underlay.resize then
+                pcall(function()
+                        underlay:resize(positioned.width, positioned.height)
+                end)
+        end
+        return positioned
+end
+
+function FrameGrid:ensure_underlay(widget, orientation, node)
         if not widget then
                 return nil
-        end
-        if widget._dd_gui_frame_underlay then
-                return widget._dd_gui_frame_underlay
         end
 
         local bounds = widget_bounds(widget)
@@ -552,13 +584,24 @@ function FrameGrid:ensure_underlay(widget)
                 return nil
         end
 
+        if widget._dd_gui_frame_underlay then
+                self:position_underlay(
+                        widget._dd_gui_frame_underlay,
+                        bounds,
+                        orientation,
+                        node
+                )
+                return widget._dd_gui_frame_underlay
+        end
+
         self.underlay_index = (self.underlay_index or 0) + 1
+        local positioned = self:underlay_bounds(bounds, orientation, node)
         local underlay = Geyser.Label:new({
                 name = "DD_GUI.FrameGrid.Underlay." .. self.underlay_index,
-                x = bounds.x,
-                y = bounds.y,
-                width = bounds.width,
-                height = bounds.height,
+                x = positioned.x,
+                y = positioned.y,
+                width = positioned.width,
+                height = positioned.height,
         }, main)
         underlay:setStyleSheet(self:transparent_css())
         set_clickthrough(underlay, true)
@@ -575,7 +618,7 @@ function FrameGrid:line_style(widget, orientation, color)
                 margin: 0px;
         ]], regular and self:base_color() or color)
 
-        local underlay = self:ensure_underlay(widget)
+        local underlay = self:ensure_underlay(widget, orientation, false)
         if underlay then
                 underlay:setStyleSheet(self:underlay_css(
                         regular and self:base_color() or color,
@@ -615,7 +658,7 @@ function FrameGrid:node_style(widget, color)
                 margin: 0px;
         ]], regular and self:base_color() or color)
 
-        local underlay = self:ensure_underlay(widget)
+        local underlay = self:ensure_underlay(widget, nil, true)
         if underlay then
                 underlay:setStyleSheet(self:underlay_css(
                         regular and self:base_color() or color,

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.99"
+DD_GUI.package_version = "0.0.100"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.97"
+DD_GUI.package_version = "0.0.99"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- make the room-entry frame effect a smooth staged swell and ebb
- keep the room pulse at 2.42 seconds and the combat cycle at exactly 2.00 seconds
- share the pulse colour palette and document the updated behavior

## Verification
- ran .\\scripts\\build-and-upload.ps1
- refreshed the active Mudlet profile with reinstallgui
- verified pulse stage totals and ran git diff --check