### PR TITLE
Restore compass action button clicks

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.100",
+  "version": "0.0.101",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -7,6 +7,11 @@ local function compass_surface_css()
   ]]
 end
 
+local compass_action_commands = {
+  nw = "equipment",
+  sw = "scan",
+}
+
 function dd_gui_compass_handle_click(event)
   if not DD_GUI.Layout or not DD_GUI.Layout.enabled or
      not event or event.button ~= "LeftButton" or
@@ -96,13 +101,13 @@ function build_compass()
   compass = {
     buttons = {"nw", "n", "u", "w", "look", "e", "sw", "s", "d"},
     commands = {
-      nw = "equipment",
+      nw = compass_action_commands.nw,
       n = "north",
       u = "up",
       w = "west",
       look = "look",
       e = "east",
-      sw = "scan",
+      sw = compass_action_commands.sw,
       s = "south",
       d = "down",
     },
@@ -341,6 +346,12 @@ function build_compass()
   function DD_GUI.compass_press(name)
     if compass and compass.click then
       compass.click(name)
+      return
+    end
+
+    local command = compass_action_commands[name]
+    if command then
+      send(command)
     end
   end
 
@@ -353,7 +364,12 @@ function build_compass()
       cell:setFontSize(8)
       cell:setBold(1)
     end
-    cell:setClickCallback("compass.click", direction)
+    -- Route clicks through the stable public callback. This survives a live
+    -- compass rebuild and keeps action cells interactive above frame layers.
+    cell:setClickCallback("DD_GUI.compass_press", direction)
+    if DD_GUI.set_widget_clickthrough then
+      DD_GUI.set_widget_clickthrough(cell, false)
+    end
     setLabelOnEnter("compass." .. direction, "compass.onEnter", direction)
     setLabelOnLeave("compass." .. direction, "compass.onLeave", direction)
   end

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.100"
+DD_GUI.package_version = "0.0.101"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- route compass cells through the stable public compass callback
- keep EQ and SCAN interactive through rebuilds and frame overlays
- retain direct equipment and scan fallbacks

## Verification
- ran .\\scripts\\build-and-upload.ps1
- refreshed the active Mudlet profile with reinstallgui
- clicked EQ and SCAN in Mudlet and verified the equipment response and scan command
- ran git diff --check