### PR TITLE
Support compass actions with Num Lock off

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ These aliases are available from the Mudlet command line:
 While the GUI is in its normal locked state:
 
 - `Ctrl+Shift+Alt+C` clears the main MUD text window.
-- Numeric keypad `7`, `8`, and `9` send equipment, north, and up.
+- Numeric keypad `7`, `8`, and `9` send equipment, north, and up. The `7`
+  and `1` actions also work with Num Lock off, where the keys are reported as
+  keypad `Home` and `End`.
 - Numeric keypad `4`, `5`, and `6` send west, look, and east.
 - Numeric keypad `1`, `2`, and `3` send scan, south, and down. Each action
   briefly highlights its corresponding compass button.

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.101",
+  "version": "0.0.102",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/keys/DD_GUI/Numpad1End.lua
+++ b/src/keys/DD_GUI/Numpad1End.lua
@@ -1,0 +1,5 @@
+if DD_GUI and DD_GUI.compass_press then
+  DD_GUI.compass_press("sw")
+else
+  send("scan")
+end

--- a/src/keys/DD_GUI/Numpad7Home.lua
+++ b/src/keys/DD_GUI/Numpad7Home.lua
@@ -1,0 +1,5 @@
+if DD_GUI and DD_GUI.compass_press then
+  DD_GUI.compass_press("nw")
+else
+  send("equipment")
+end

--- a/src/keys/DD_GUI/keys.json
+++ b/src/keys/DD_GUI/keys.json
@@ -40,6 +40,10 @@
                 "keys": "keypad+7"
         },
         {
+                "name": "Numpad7Home",
+                "keys": "keypad+Home"
+        },
+        {
                 "name": "Numpad8",
                 "keys": "keypad+8"
         },
@@ -62,6 +66,10 @@
         {
                 "name": "Numpad1",
                 "keys": "keypad+1"
+        },
+        {
+                "name": "Numpad1End",
+                "keys": "keypad+End"
         },
         {
                 "name": "Numpad2",

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.101"
+DD_GUI.package_version = "0.0.102"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- bind keypad Home and End to the EQ and SCAN compass actions
- keep the existing Num Lock-on bindings
- document the dual keypad behavior and bump the package version to 0.0.102

## Verification
- ran .\\scripts\\build-and-upload.ps1
- refreshed the active profile with reinstallgui
- confirmed reinstallgui, Numpad7Home, and Numpad1End are installed
- sent real Num Lock-off keypad 7 and 1 events and verified equipment and scan
- ran git diff --check