### PR TITLE
Show new enemies immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ data. The main panels are:
   slowly fades to black, the next enemy or room image is rendered underneath,
   and the replacement fades back in. Shared edges with the map follow the
   combat colour as well, so the pulse remains continuous around the panel.
+  If a new enemy arrives during that transition, combat data takes priority
+  and the new image and hitpoint bar appear immediately.
   The braid and square joiners remain visible over that colour instead of
   turning into flat red strips during the pulse; the state colour is painted
   on a separate underlay so the texture cannot suppress it. During normal

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.102",
+  "version": "0.0.103",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -32,21 +32,16 @@ function update_enemy()
 
                 local transition_in_progress = DD_GUI.enemy_defeat_active or
                         DD_GUI.enemy_defeat_phase == "replacement"
-                if transition_in_progress and DD_GUI.enemy_panel_same_room then
-                        local room = gmcp and gmcp.Room and gmcp.Room.Info
-                        if not DD_GUI.enemy_panel_same_room(room) then
-                                if DD_GUI.cancel_enemy_defeat_transition then
-                                        DD_GUI.cancel_enemy_defeat_transition()
-                                end
-                                transition_in_progress = false
-                        end
+                if transition_in_progress and
+                   DD_GUI.cancel_enemy_defeat_transition then
+                        -- A live enemy takes priority over the previous
+                        -- defeat transition. Do not leave the new image and
+                        -- hitpoint bar hidden behind its fade layer.
+                        DD_GUI.cancel_enemy_defeat_transition()
+                        transition_in_progress = false
                 end
 
                 local entering_combat = DD_GUI.enemy_panel_mode ~= "combat"
-                if not transition_in_progress and
-                   DD_GUI.cancel_enemy_defeat_transition then
-                        DD_GUI.cancel_enemy_defeat_transition()
-                end
                 if entering_combat and DD_GUI.cancel_enemy_panel_flash then
                         DD_GUI.cancel_enemy_panel_flash()
                 end

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.102"
+DD_GUI.package_version = "0.0.103"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- cancel stale defeat fades when fresh enemy data arrives
- show the new enemy image and HITS bar immediately
- document the behavior and bump the package to 0.0.103

## Verification
- ran .\\scripts\\build-and-upload.ps1
- refreshed the active profile with reinstallgui
- ran git diff --check