### PR TITLE
Remove mapper title accent rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ data. The main panels are:
   mode, including after a package rebuild.
 - **Map:** the current room and surrounding map data. The embedded mapper has
   even internal padding, and its title is kept to one compact room/vnum line
-  so northern rooms remain visible even when a room name is long.
+  with no extra rule beneath it, so northern rooms remain visible even when a
+  room name is long.
 - **Character sheet:** profile image, character details, statistics, and
   resistances.
 - **Comms:** communications received from the GMCP `Comm` structure. The `All`
@@ -131,8 +132,8 @@ The main MUD console and panel consoles use the profile's shared scrollbar
 style: narrow black tracks have restrained dark-red edges, while the moving
 thumb is rendered as a small red square joiner against the black track. The
 mapper's native room title uses
-an opaque black background with white text and a short red rule underneath, so
-it belongs visually with the rest of the interface.
+an opaque black background with white text and no additional accent line, so
+the title takes as little vertical space as possible.
 
 The GUI refreshes these views from the latest GMCP snapshot after login and
 reconnect. `bootstrap()` is idempotent for the installed package version, so

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.103",
+  "version": "0.0.104",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/InitialiseMapper.lua
+++ b/src/scripts/DD/InitialiseMapper.lua
@@ -70,10 +70,6 @@ function DD_GUI.apply_mapper_theme()
                 return
         end
 
-        local frame = DD_GUI.Theme and DD_GUI.Theme.map_info_frame or
-                {151, 27, 39}
-        local rule = string.rep(string.char(226, 148, 128), 38)
-
         pcall(function()
                 registerMapInfo(map_info_title_name, function(room_id)
                         local title = compact_map_title(room_id)
@@ -82,12 +78,12 @@ function DD_GUI.apply_mapper_theme()
                         end
                         return title, false, false, 255, 255, 255
                 end)
-                registerMapInfo(map_info_accent_name, function()
-                        return rule, false, false, frame[1], frame[2], frame[3]
-                end)
                 disableMapInfo("Short")
+                -- Older builds registered a red rule beneath the title. Hide
+                -- that persisted map-info entry so it cannot cover northern
+                -- rooms after an upgrade.
+                disableMapInfo(map_info_accent_name)
                 enableMapInfo(map_info_title_name)
-                enableMapInfo(map_info_accent_name)
         end)
 end
 

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.103"
+DD_GUI.package_version = "0.0.104"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- remove the extra red rule beneath the embedded mapper title
- explicitly disable the legacy map-info accent during upgrades
- document the compact title behavior and bump the package to 0.0.104

## Verification
- ran .\\scripts\\build-and-upload.ps1
- refreshed the active profile with reinstallgui
- visually checked the live Mudlet window
- ran git diff --check