### PR TITLE
Fix canonical GUI reinstall handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you have any issues with the automated installation and update system for the
 
 To uninstall the GUI, you can simply type:
 
-`lua uninstallPackage("DD_GUI")`, use the built-in `ugui` alias, or use Mudlet's graphical package manager. The GUI copies any legacy downloaded content into the profile-owned `DD_GUI_Content` directory before removal when needed. To safely uninstall and reinstall the latest remote package, use `reinstallgui`; it lets the alias return, waits three seconds between the two operations so Mudlet can finish removing the old package, then reports the installed package version.
+`lua uninstallPackage("DD_GUI")`, use the built-in `ugui` alias, or use Mudlet's graphical package manager. The GUI copies any legacy downloaded content into the profile-owned `DD_GUI_Content` directory before removal when needed. To safely uninstall and reinstall the latest remote package, use `reinstallgui`; it lets the alias return, waits three seconds between the two operations so Mudlet can finish removing the old package, then installs from the canonical `.mpackage` URL and reports the installed package version. The handoff uses profile-level named timers and install/uninstall events so the reinstall callback survives removal of the old package.
 
 ## Layout controls
 
@@ -131,9 +131,8 @@ data. The main panels are:
 The main MUD console and panel consoles use the profile's shared scrollbar
 style: narrow black tracks have restrained dark-red edges, while the moving
 thumb is rendered as a small red square joiner against the black track. The
-mapper's native room title uses
-an opaque black background with white text and no additional accent line, so
-the title takes as little vertical space as possible.
+mapper's native room title uses a transparent background with white text and no
+additional accent line, so rooms at the top edge remain visible beneath it.
 
 The GUI refreshes these views from the latest GMCP snapshot after login and
 reconnect. `bootstrap()` is idempotent for the installed package version, so
@@ -159,7 +158,7 @@ These aliases are available from the Mudlet command line:
 | `ddmap on` / `ddmap off` | Enable or disable the Dragons Domain custom mapper. |
 | `ignores` | Add the Dragons Domain portal message to the mapper's ignore patterns. |
 | `ugui` | Uninstall the `DD_GUI` package. |
-| `reinstallgui` | Defer the uninstall, wait three seconds, reinstall the latest remote package, and report its installed version without removing downloaded custom content. |
+| `reinstallgui` | Defer the uninstall, wait three seconds, reinstall the latest remote package with a profile-level handoff, and report its installed version without removing downloaded custom content. |
 
 
 ## Keyboard controls

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.104",
+  "version": "0.0.107",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/aliases/DD/reinstallgui.lua
+++ b/src/aliases/DD/reinstallgui.lua
@@ -1,17 +1,70 @@
 local package_url = "https://www.dragons-domain.org/main/gui/DD_GUI.mpackage"
-local package_install_url = package_url .. "?v=" .. tostring(os.time())
+local package_install_url = package_url
 local uninstall_delay = 0.1
 local reinstall_delay = 3
 local version_check_delay = 5
 local max_version_checks = 12
+local timer_owner = "DD_GUI.reinstallgui"
+local uninstall_timer_name = "uninstall"
+local install_timer_name = "install"
+local version_timer_name = "version"
+local install_event_name = "installed"
+local uninstall_event_name = "uninstalling"
 
 local state = DD_GUI or {}
 
+local function cancel_schedule(schedule)
+        if not schedule then
+                return
+        end
+
+        if type(schedule) == "table" and schedule.kind == "named" then
+                if type(deleteNamedTimer) == "function" then
+                        pcall(deleteNamedTimer, timer_owner, schedule.name)
+                end
+        elseif type(schedule) == "table" and schedule.kind == "temp" then
+                if schedule.id and type(killTimer) == "function" then
+                        pcall(killTimer, schedule.id)
+                end
+        elseif type(schedule) == "number" and type(killTimer) == "function" then
+                -- Compatibility with the previous tempTimer-based alias.
+                pcall(killTimer, schedule)
+        end
+end
+
+local function schedule_timer(name, delay, callback)
+        -- Named timers live in Mudlet's profile-level ID manager rather than
+        -- in the package tree, so package removal cannot erase the handoff.
+        if type(registerNamedTimer) == "function" and
+           type(deleteNamedTimer) == "function" then
+                pcall(deleteNamedTimer, timer_owner, name)
+                local ok, result = pcall(
+                        registerNamedTimer,
+                        timer_owner,
+                        name,
+                        delay,
+                        callback,
+                        false
+                )
+                if ok and result then
+                        return {kind = "named", name = name}
+                end
+        end
+
+        return {kind = "temp", id = tempTimer(delay, callback)}
+end
+
+local function delete_named_event(name)
+        if type(deleteNamedEventHandler) == "function" then
+                pcall(deleteNamedEventHandler, timer_owner, name)
+        end
+end
+
 local function installed_version()
         local version
-        if DD_GUI and DD_GUI.package_version then
-                version = DD_GUI.package_version
-        elseif type(getPackageInfo) == "function" then
+        -- Prefer Mudlet's package metadata because DD_GUI.package_version can
+        -- remain in memory briefly while a replacement package is loading.
+        if type(getPackageInfo) == "function" then
                 local ok, package_version = pcall(
                         getPackageInfo,
                         "DD_GUI",
@@ -20,6 +73,10 @@ local function installed_version()
                 if ok then
                         version = package_version
                 end
+        end
+        if (not version or version == "") and
+           DD_GUI and DD_GUI.package_version then
+                version = DD_GUI.package_version
         end
         return version
 end
@@ -40,10 +97,23 @@ local version_check_attempts = 0
 local function check_installed_version()
         state.reinstall_version_timer = nil
         if not state.reinstall_install_finished then
-                state.reinstall_version_timer = tempTimer(
-                        1,
-                        check_installed_version
-                )
+                local version = installed_version()
+                if state.reinstall_install_requested and
+                   previous_version and version and
+                   tostring(version) ~= tostring(previous_version) then
+                        state.reinstall_install_succeeded = true
+                        state.reinstall_install_finished = true
+                        state.reinstall_install_requested = false
+                else
+                        state.reinstall_version_timer = schedule_timer(
+                                version_timer_name, 1, check_installed_version)
+                        return
+                end
+        end
+
+        if not state.reinstall_install_finished then
+                state.reinstall_version_timer = schedule_timer(
+                        version_timer_name, 1, check_installed_version)
                 return
         end
 
@@ -58,10 +128,15 @@ local function check_installed_version()
            (not version or version == "" or
             (previous_version and
              tostring(version) == tostring(previous_version))) then
-                state.reinstall_version_timer = tempTimer(
-                        1,
-                        check_installed_version
-                )
+                state.reinstall_version_timer = schedule_timer(
+                        version_timer_name, 1, check_installed_version)
+                return
+        end
+
+        if previous_version and version and
+           tostring(version) == tostring(previous_version) then
+                echo("\nDD_GUI version check timed out; installed version is " ..
+                        tostring(version) .. ".\n")
                 return
         end
 
@@ -72,16 +147,94 @@ if DD_GUI and DD_GUI.migrate_legacy_content then
         DD_GUI.migrate_legacy_content()
 end
 
-if state.reinstall_timer and killTimer then
-        killTimer(state.reinstall_timer)
-        state.reinstall_timer = nil
-end
-if state.reinstall_version_timer and killTimer then
-        killTimer(state.reinstall_version_timer)
-        state.reinstall_version_timer = nil
-end
+cancel_schedule(state.reinstall_timer)
+cancel_schedule(state.reinstall_install_timer)
+cancel_schedule(state.reinstall_version_timer)
+state.reinstall_timer = nil
+state.reinstall_install_timer = nil
+state.reinstall_version_timer = nil
+delete_named_event(install_event_name)
+delete_named_event(uninstall_event_name)
 state.reinstall_install_succeeded = false
 state.reinstall_install_finished = false
+state.reinstall_install_requested = false
+state.reinstall_pending = true
+
+local install_scheduled = false
+
+local function install_latest_package()
+        state.reinstall_install_timer = nil
+        state.reinstall_install_requested = true
+        echo("\nInstalling the latest DD_GUI package...\n")
+
+        local call_ok, result, error_message = pcall(
+                installPackage,
+                package_install_url
+        )
+        if (not call_ok or result == false or
+            (result == nil and error_message ~= nil)) and
+           not state.reinstall_install_succeeded then
+                state.reinstall_install_finished = true
+                state.reinstall_install_requested = false
+                echo("DD_GUI install failed: " ..
+                        tostring(error_message or result or "unknown error") ..
+                        "\n")
+                delete_named_event(install_event_name)
+                return
+        end
+
+        -- installPackage() can return before the package's install event and
+        -- new folder.lua have run. Leave the request pending until either
+        -- that event or the version poll observes the new metadata.
+end
+
+local function schedule_install()
+        if install_scheduled then
+                return
+        end
+
+        install_scheduled = true
+        state.reinstall_pending = false
+        state.reinstall_install_timer = schedule_timer(
+                install_timer_name,
+                reinstall_delay,
+                install_latest_package
+        )
+end
+
+-- These handlers are profile-level objects, not package objects. The
+-- uninstall event fires before Mudlet removes this package, giving us a
+-- reliable place to arm the surviving install timer.
+if type(registerNamedEventHandler) == "function" then
+        pcall(
+                registerNamedEventHandler,
+                timer_owner,
+                uninstall_event_name,
+                "sysUninstallPackage",
+                function(_, name)
+                        if name == "DD_GUI" and state.reinstall_pending then
+                                schedule_install()
+                        end
+                end,
+                true
+        )
+
+        pcall(
+                registerNamedEventHandler,
+                timer_owner,
+                install_event_name,
+                "sysInstallPackage",
+                function(_, name)
+                        if name == "DD_GUI" and
+                           state.reinstall_install_requested then
+                                state.reinstall_install_succeeded = true
+                                state.reinstall_install_finished = true
+                                state.reinstall_install_requested = false
+                        end
+                end,
+                true
+        )
+end
 
 echo("\nDD_GUI will uninstall shortly, then reinstall in " ..
         reinstall_delay .. " seconds...\n")
@@ -89,30 +242,24 @@ echo("\nDD_GUI will uninstall shortly, then reinstall in " ..
 -- Create this timer before removing the package so it survives the package
 -- replacement. The install request itself is asynchronous, so wait beyond
 -- the uninstall and reinstall delays before reading the new metadata.
-state.reinstall_version_timer = tempTimer(
+state.reinstall_version_timer = schedule_timer(
+        version_timer_name,
         uninstall_delay + reinstall_delay + version_check_delay,
         check_installed_version
 )
 
 -- Let this alias return before removing the package that owns it. Mudlet can
 -- terminate when uninstallPackage() mutates the active package mid-alias.
-state.reinstall_timer = tempTimer(uninstall_delay, function()
+state.reinstall_timer = schedule_timer(uninstall_timer_name, uninstall_delay, function()
         state.reinstall_timer = nil
         local ok, err = pcall(uninstallPackage, "DD_GUI")
         if not ok then
                 echo("DD_GUI uninstall failed: " .. tostring(err) .. "\n")
+                state.reinstall_pending = false
+                delete_named_event(uninstall_event_name)
                 return
         end
-
-        tempTimer(reinstall_delay, function()
-                echo("\nInstalling the latest DD_GUI package...\n")
-                local install_ok, install_err = pcall(installPackage, package_install_url)
-                if not install_ok then
-                        echo("DD_GUI install failed: " .. tostring(install_err) .. "\n")
-                        state.reinstall_install_finished = true
-                        return
-                end
-                state.reinstall_install_succeeded = true
-                state.reinstall_install_finished = true
-        end)
+        -- The named uninstall event normally schedules this. The fallback
+        -- covers Mudlet builds that do not expose named event handlers.
+        schedule_install()
 end)

--- a/src/scripts/DD/InitialiseMapper.lua
+++ b/src/scripts/DD/InitialiseMapper.lua
@@ -61,7 +61,9 @@ end
 function DD_GUI.apply_mapper_theme()
         if type(setConfig) == "function" then
                 pcall(function()
-                        setConfig("mapInfoColor", {0, 0, 0, 255})
+                        -- Keep northern room symbols visible if the native
+                        -- title reaches into the top of the map.
+                        setConfig("mapInfoColor", {0, 0, 0, 0})
                 end)
         end
 

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.104"
+DD_GUI.package_version = "0.0.107"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- keep the mapper title background transparent so northern rooms remain visible
- make reinstallgui use profile-level named timers and package lifecycle events that survive uninstall
- install from the canonical .mpackage URL and verify real installed metadata
- document the behavior and bump the package to 0.0.107

## Verification
- ran .\\scripts\\build-and-upload.ps1
- safely installed the canonical URL in the live Mudlet profile
- ran reinstallgui end-to-end and verified the package returned at 0.0.107
- ran git diff --check