### PR TITLE
Theme native mapper controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ style: narrow black tracks have restrained dark-red edges, while the moving
 thumb is rendered as a small red square joiner against the black track. The
 mapper's native room title uses a transparent background with white text and no
 additional accent line, so rooms at the top edge remain visible beneath it.
+The mapper's native control strip uses the same visual language: black surfaces,
+ivory labels, dark-red edges, and restrained bright-red hover and focus states
+for its zoom controls, area selector, and menu button.
 
 The GUI refreshes these views from the latest GMCP snapshot after login and
 reconnect. `bootstrap()` is idempotent for the installed package version, so

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.107",
+  "version": "0.0.108",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/GoldBoxTheme.lua
+++ b/src/scripts/DD/GoldBoxTheme.lua
@@ -231,7 +231,7 @@ function Theme:profile_style_sheet()
         local joiner = stylesheet_url(
                 DD_GUI.asset_path and DD_GUI.asset_path("frame/node.png"))
 
-        return string.format([[
+        local console_stylesheet = string.format([[
                 TConsole QScrollBar:vertical {
                         background-color: %s;
                         width: 10px;
@@ -307,6 +307,104 @@ function Theme:profile_style_sheet()
                 c.ink, joiner, c.ink, joiner,
                 c.ink
         )
+
+        local mapper_stylesheet = string.format([[
+                QWidget#mapper,
+                QWidget#widget_panel,
+                QWidget#widget_topRow,
+                QWidget#widget_panControls,
+                TMapView {
+                        background-color: %s;
+                        border: 0px;
+                }
+
+                QWidget#mapper QToolButton,
+                QWidget#widget_panel QToolButton,
+                TMapView QToolButton {
+                        background-color: %s;
+                        color: %s;
+                        border: 1px solid %s;
+                        border-radius: 0px;
+                        padding: 0px;
+                        margin: 0px;
+                }
+
+                QWidget#mapper QToolButton:hover,
+                QWidget#mapper QToolButton:focus,
+                QWidget#mapper QToolButton:pressed,
+                QWidget#mapper QToolButton:checked,
+                QWidget#widget_panel QToolButton:hover,
+                QWidget#widget_panel QToolButton:focus,
+                QWidget#widget_panel QToolButton:pressed,
+                QWidget#widget_panel QToolButton:checked,
+                TMapView QToolButton:hover,
+                TMapView QToolButton:focus,
+                TMapView QToolButton:pressed,
+                TMapView QToolButton:checked {
+                        background-color: %s;
+                        color: %s;
+                        border-color: %s;
+                }
+
+                QWidget#mapper QLabel#label_area,
+                QWidget#widget_panel QLabel#label_area,
+                TMapView QLabel {
+                        background-color: %s;
+                        color: %s;
+                        border: 0px;
+                        padding: 0px;
+                }
+
+                QWidget#mapper QComboBox,
+                QWidget#widget_panel QComboBox,
+                TMapView QComboBox {
+                        background-color: %s;
+                        color: %s;
+                        border: 1px solid %s;
+                        border-radius: 0px;
+                        padding: 0px 2px;
+                        selection-background-color: %s;
+                        selection-color: %s;
+                }
+
+                QWidget#mapper QComboBox:hover,
+                QWidget#mapper QComboBox:focus,
+                QWidget#widget_panel QComboBox:hover,
+                QWidget#widget_panel QComboBox:focus,
+                TMapView QComboBox:hover,
+                TMapView QComboBox:focus {
+                        border-color: %s;
+                }
+
+                QWidget#mapper QComboBox::drop-down,
+                QWidget#widget_panel QComboBox::drop-down,
+                TMapView QComboBox::drop-down {
+                        background-color: %s;
+                        border-left: 1px solid %s;
+                        width: 16px;
+                }
+
+                QWidget#mapper QComboBox QAbstractItemView,
+                QWidget#widget_panel QComboBox QAbstractItemView,
+                TMapView QComboBox QAbstractItemView {
+                        background-color: %s;
+                        color: %s;
+                        border: 1px solid %s;
+                        selection-background-color: %s;
+                        selection-color: %s;
+                }
+        ]],
+                c.ink,
+                c.ink, c.ivory, c.frame,
+                c.dark_frame, c.white, c.bright_frame,
+                c.ink, c.ivory,
+                c.ink, c.ivory, c.frame, c.dark_frame, c.white,
+                c.bright_frame,
+                c.ink, c.dark_frame,
+                c.ink, c.ivory, c.frame, c.dark_frame, c.white
+        )
+
+        return console_stylesheet .. mapper_stylesheet
 end
 
 function Theme:apply_profile_style()

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.107"
+DD_GUI.package_version = "0.0.108"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- Theme the native mapper control strip with the DD_GUI black and red palette.
- Cover zoom buttons, area selector, popup, and mapper menu states.
- Bump the package to 0.0.108 and document the mapper toolbar styling.