### PR TITLE
Theme native popup menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ additional accent line, so rooms at the top edge remain visible beneath it.
 The mapper's native control strip uses the same visual language: black surfaces,
 ivory labels, dark-red edges, and restrained bright-red hover and focus states
 for its zoom controls, area selector, and menu button.
+Native popup menus use the same profile-wide treatment, including black
+surfaces, ivory text, dark-red separators and borders, red hover states, and
+matching checked-item and submenu indicators. This covers mapper menus,
+dropdown menus, and right-click context menus consistently.
 
 The GUI refreshes these views from the latest GMCP snapshot after login and
 reconnect. `bootstrap()` is idempotent for the installed package version, so

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.108",
+  "version": "0.0.109",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/resources/frame/menu-arrow.svg
+++ b/src/resources/frame/menu-arrow.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8">
+  <path d="M1 1 7 4 1 7Z" fill="#f0ebd5"/>
+</svg>

--- a/src/resources/frame/menu-check.svg
+++ b/src/resources/frame/menu-check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
+  <path d="M2 6.25 4.7 9 10 2.5" fill="none" stroke="#cd303c" stroke-width="1.6" stroke-linecap="square" stroke-linejoin="miter"/>
+</svg>

--- a/src/scripts/DD/GoldBoxTheme.lua
+++ b/src/scripts/DD/GoldBoxTheme.lua
@@ -230,6 +230,10 @@ function Theme:profile_style_sheet()
 
         local joiner = stylesheet_url(
                 DD_GUI.asset_path and DD_GUI.asset_path("frame/node.png"))
+        local menu_check = stylesheet_url(
+                DD_GUI.asset_path and DD_GUI.asset_path("frame/menu-check.svg"))
+        local menu_arrow = stylesheet_url(
+                DD_GUI.asset_path and DD_GUI.asset_path("frame/menu-arrow.svg"))
 
         local console_stylesheet = string.format([[
                 TConsole QScrollBar:vertical {
@@ -404,7 +408,74 @@ function Theme:profile_style_sheet()
                 c.ink, c.ivory, c.frame, c.dark_frame, c.white
         )
 
-        return console_stylesheet .. mapper_stylesheet
+        local popup_stylesheet = string.format([[
+                QMenu {
+                        background-color: %s;
+                        color: %s;
+                        border: 1px solid %s;
+                        padding: 2px;
+                }
+
+                QMenu::item {
+                        background-color: transparent;
+                        color: %s;
+                        border: 1px solid transparent;
+                        padding: 4px 28px 4px 24px;
+                        margin: 1px 2px;
+                }
+
+                QMenu::item:selected,
+                QMenu::item:pressed {
+                        background-color: %s;
+                        color: %s;
+                        border-color: %s;
+                }
+
+                QMenu::item:disabled {
+                        color: %s;
+                }
+
+                QMenu::separator {
+                        height: 1px;
+                        background-color: %s;
+                        margin: 4px 5px;
+                }
+
+                QMenu::indicator {
+                        width: 12px;
+                        height: 12px;
+                        margin-left: 5px;
+                        margin-right: 3px;
+                        background-color: %s;
+                        border: 1px solid %s;
+                }
+
+                QMenu::indicator:checked,
+                QMenu::indicator:non-exclusive:checked,
+                QMenu::indicator:exclusive:checked,
+                QMenu::indicator:indeterminate {
+                        background-color: %s;
+                        border: 0px;
+                        image: %s;
+                }
+
+                QMenu::right-arrow {
+                        width: 8px;
+                        height: 8px;
+                        image: %s;
+                }
+        ]],
+                c.ink, c.ivory, c.frame,
+                c.ivory,
+                c.dark_frame, c.white, c.bright_frame,
+                c.dark_gold,
+                c.frame,
+                c.ink, c.frame,
+                c.ink, menu_check,
+                menu_arrow
+        )
+
+        return console_stylesheet .. mapper_stylesheet .. popup_stylesheet
 end
 
 function Theme:apply_profile_style()

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.108"
+DD_GUI.package_version = "0.0.109"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- Theme native QMenu popups globally with the DD_GUI black and red palette.
- Add custom checked-item and submenu-arrow indicators.
- Document popup styling and bump the package to 0.0.109.