### PR TITLE
Add GMCP quest status tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,15 @@ data. The main panels are:
   is a paper-doll view of every wear slot from `Char.Worn`, showing `[empty]`
   or `[prohibited]` where appropriate for the character's profession, class,
   or current form.
-- **Affects:** active affects from GMCP, with names left-aligned, modifiers
-  centred, and durations aligned at the right edge.
+- **Affects / Quest Status:** a two-tab panel beneath Inventory / Equipped.
+  `Affects` shows active effects from GMCP, with names left-aligned, modifiers
+  centred, and durations aligned at the right edge. `Quest Status` reads
+  `Char.Quest` and adapts to available, cooldown, active, and ready-to-return
+  states. It shows the objective, target, questgiver, area and room names with
+  their vnums, completion and time remaining, current and lifetime quest
+  points, and level-gate requirements. The Inventory / Equipped and Affects /
+  Quest Status panels share the remaining right-column height equally by
+  default.
 - **Gauges and compass:** current hits, mana, experience, movement, and the
   clickable navigation compass. The compass includes `EQ` for equipment and
   `SCAN` for scanning. Movement buttons briefly highlight their borders while

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.109",
+  "version": "0.0.110",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/AffectsConsole.lua
+++ b/src/scripts/DD/AffectsConsole.lua
@@ -1,16 +1,44 @@
 function build_affects_console()
+    if AffectsConsole and AffectsConsole.hide then
+      AffectsConsole:hide()
+    end
+    if QuestStatusConsole and QuestStatusConsole.hide then
+      QuestStatusConsole:hide()
+    end
+
+    DD_GUI.Affects.consoles = {}
+
     AffectsConsole = Geyser.MiniConsole:new({
-      name="AffectsConsole",
-      x = "2%", y = "14%",
-      width="96%",
-      height="82%",
+      name = "AffectsConsole",
+      x = "0%", y = "0%",
+      width = "100%",
+      height = "100%",
       autoWrap = true,
       color = "black",
       scrollBar = true,
       horizontalScrollBar = false,
       fontSize = 10,
-    }, DD_GUI.AffectBox)
+    }, DD_GUI.Affects.content_stack)
     if DD_GUI.Theme then
       DD_GUI.Theme:style_console(AffectsConsole, 10)
     end
+
+    QuestStatusConsole = Geyser.MiniConsole:new({
+      name = "QuestStatusConsole",
+      x = "0%", y = "0%",
+      width = "100%",
+      height = "100%",
+      autoWrap = true,
+      color = "black",
+      scrollBar = true,
+      horizontalScrollBar = false,
+      fontSize = 10,
+    }, DD_GUI.Affects.content_stack)
+    if DD_GUI.Theme then
+      DD_GUI.Theme:style_console(QuestStatusConsole, 10)
+    end
+
+    DD_GUI.Affects.consoles.affects = AffectsConsole
+    DD_GUI.Affects.consoles.quest = QuestStatusConsole
+    DD_GUI.Affects:switch_tab(DD_GUI.Affects.current_tab or "affects")
 end

--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -144,6 +144,7 @@ local function raise_data_surfaces()
                 DD_GUI and DD_GUI.Inventory and DD_GUI.Inventory.stats_label,
                 DD_GUI and DD_GUI.InventoryPanelOutline,
                 AffectsConsole,
+                QuestStatusConsole,
                 DD_GUI and DD_GUI.AffectPanelOutline,
         }) do
                 raise_widget(widget)
@@ -192,8 +193,10 @@ local function raise_tab_controls()
                 end
         end
 
-        if DD_GUI and DD_GUI.Affects and DD_GUI.Affects.tab_button then
-                raise_widget(DD_GUI.Affects.tab_button)
+        if DD_GUI and DD_GUI.Affects and DD_GUI.Affects.tab_buttons then
+                for _, button in pairs(DD_GUI.Affects.tab_buttons) do
+                        raise_widget(button)
+                end
         end
 end
 
@@ -529,16 +532,16 @@ function define_boxes()
           name = "DD_GUI.InventoryBox",
           x = "0%", y = "35.11%",
           width = "89.29%",
-          height = "36.17%",
+          height = "32.445%",
         },DD_GUI.Right)
         DD_GUI.InventoryBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.InventoryBox:echo("<center>GUI.InventoryBox")
         
         DD_GUI.AffectBox = new_info_box({
           name = "DD_GUI.AffectBox",
-          x = "0%", y = "71.28%",
+          x = "0%", y = "67.555%",
           width = "89.29%",
-          height = "28.72%",
+          height = "32.445%",
         },DD_GUI.Right)
         DD_GUI.AffectBox:setStyleSheet(DD_GUI.BoxCSS:getCSS())
         --GUI.AffectBox:echo("<center>GUI.AffectBox")

--- a/src/scripts/DD/DD_GUI.AffectsBox.lua
+++ b/src/scripts/DD/DD_GUI.AffectsBox.lua
@@ -1,23 +1,47 @@
 DD_GUI = DD_GUI or {}
 DD_GUI.Affects = DD_GUI.Affects or {}
 
-function DD_GUI.Affects:tab_css()
+DD_GUI.Affects.tab_definitions = {
+        { key = "affects", label = "Affects" },
+        { key = "quest",   label = "Quest Status" },
+}
+
+function DD_GUI.Affects:tab_css(key)
         if DD_GUI.Theme then
-                return DD_GUI.Theme:tab_css(true)
+                return DD_GUI.Theme:tab_css(key == self.current_tab)
         end
 
         return [[
-                background-color: rgba(0,120,135,190);
+                background-color: rgba(0,0,0,170);
                 border-style: solid;
                 border-width: 1px;
-                border-color: cyan;
+                border-color: rgb(45,45,45);
                 margin: 1px;
         ]]
+end
+
+function DD_GUI.Affects:style_tab(key)
+        local tab = self.tab_buttons and self.tab_buttons[key]
+        if not tab then
+                return
+        end
+
+        tab:setStyleSheet(self:tab_css(key))
+        tab:echo(self.tab_labels[key], "white", "c")
+end
+
+function DD_GUI.Affects:style_tabs()
+        for _, definition in ipairs(self.tab_definitions) do
+                self:style_tab(definition.key)
+        end
 end
 
 function DD_GUI.Affects:build_tabs()
         if self.tab_rail and self.tab_rail.hide then
                 self.tab_rail:hide()
+        end
+        if self.content_stack and self.content_stack.hide then
+                self.content_stack:hide()
         end
 
         -- Older package versions added a second full-size frame. Remove it
@@ -29,6 +53,9 @@ function DD_GUI.Affects:build_tabs()
                 pcall(deleteLabel, "DD_GUI.Affects.Frame")
         end
         self.frame = nil
+        self.tab_button = nil
+        self.tab_buttons = {}
+        self.tab_labels = {}
 
         self.tab_rail = Geyser.Label:new({
                 name = "DD_GUI.Affects.TabRail",
@@ -39,21 +66,75 @@ function DD_GUI.Affects:build_tabs()
         }, DD_GUI.AffectBox)
         self.tab_rail:setColor(0, 0, 0, 0)
 
-        self.tab_button = Geyser.Label:new({
-                name = "DD_GUI.Affects.Tab",
-                x = "0%",
-                y = "0%",
-                width = "100%",
-                height = "100%",
-        }, self.tab_rail)
-        if DD_GUI.Theme then
-                DD_GUI.Theme:style_label(self.tab_button, 8, true)
-        else
-                self.tab_button:setFontSize(8)
-                self.tab_button:setBold(1)
+        self.content_stack = Geyser.Label:new({
+                name = "DD_GUI.Affects.ContentStack",
+                x = "2%",
+                y = "14%",
+                width = "96%",
+                height = "82%",
+        }, DD_GUI.AffectBox)
+        self.content_stack:setColor(0, 0, 0, 255)
+
+        local tab_width = 100 / #self.tab_definitions
+        for index, definition in ipairs(self.tab_definitions) do
+                local tab = Geyser.Label:new({
+                        name = "DD_GUI.Affects.Tab." .. definition.key,
+                        x = tostring((index - 1) * tab_width) .. "%",
+                        y = "0%",
+                        width = tostring(tab_width) .. "%",
+                        height = "100%",
+                }, self.tab_rail)
+
+                if DD_GUI.Theme then
+                        DD_GUI.Theme:style_label(tab, 8, true)
+                else
+                        tab:setFontSize(8)
+                        tab:setBold(1)
+                end
+                tab:setClickCallback("dd_affects_tab_click", definition.key)
+
+                self.tab_buttons[definition.key] = tab
+                self.tab_labels[definition.key] = definition.label
         end
-        self.tab_button:setStyleSheet(self:tab_css())
-        self.tab_button:echo("Affects", "white", "c")
+
+        if self.current_tab ~= "affects" and self.current_tab ~= "quest" then
+                self.current_tab = "affects"
+        end
+        self:style_tabs()
+end
+
+function DD_GUI.Affects:switch_tab(key)
+        if not self.consoles or not self.consoles[key] then
+                key = "affects"
+        end
+
+        self.current_tab = key
+        for tab_key, console in pairs(self.consoles or {}) do
+                if tab_key == key then
+                        console:show()
+                        raiseWindow(console.name)
+                else
+                        console:hide()
+                end
+        end
+
+        self:style_tabs()
+
+        if key == "affects" and type(update_affects) == "function" then
+                update_affects()
+        elseif key == "quest" and type(update_quest_status) == "function" then
+                update_quest_status()
+        end
+end
+
+function dd_affects_tab_click(key, event)
+        if event and event.button and event.button ~= "LeftButton" then
+                return
+        end
+
+        if DD_GUI and DD_GUI.Affects then
+                DD_GUI.Affects:switch_tab(key)
+        end
 end
 
 function build_affects_box()

--- a/src/scripts/DD/ResetLayout.lua
+++ b/src/scripts/DD/ResetLayout.lua
@@ -66,8 +66,12 @@ function DD_GUI.migrate_layout_defaults()
         local changed = false
         local inventory_width = DD_GUI.InventoryBox and DD_GUI.InventoryBox.get_width and
                 tonumber(DD_GUI.InventoryBox:get_width()) or nil
+        local inventory_height = DD_GUI.InventoryBox and DD_GUI.InventoryBox.get_height and
+                tonumber(DD_GUI.InventoryBox:get_height()) or nil
         local affect_width = DD_GUI.AffectBox and DD_GUI.AffectBox.get_width and
                 tonumber(DD_GUI.AffectBox:get_width()) or nil
+        local affect_height = DD_GUI.AffectBox and DD_GUI.AffectBox.get_height and
+                tonumber(DD_GUI.AffectBox:get_height()) or nil
 
         local map_x = DD_GUI.MapBox and DD_GUI.MapBox.get_x and
                 tonumber(DD_GUI.MapBox:get_x()) or nil
@@ -234,15 +238,19 @@ function DD_GUI.migrate_layout_defaults()
                 changed = true
         end
 
-        if approximately(inventory_width, right_width * 0.91, 8) and
-           approximately(affect_width, right_width * 0.91, 8) then
+        local previous_right_panel_layout = right_height and
+                approximately(inventory_width, right_width * 0.8929, 8) and
+                approximately(affect_width, right_width * 0.8929, 8) and
+                approximately(inventory_height, right_height * 0.3617, 8) and
+                approximately(affect_height, right_height * 0.2872, 8)
+        if previous_right_panel_layout then
                 reset_adjustable_box(
                         DD_GUI.InventoryBox,
-                        "0%", "35.11%", "89.29%", "36.17%"
+                        "0%", "35.11%", "89.29%", "32.445%"
                 )
                 reset_adjustable_box(
                         DD_GUI.AffectBox,
-                        "0%", "71.28%", "89.29%", "28.72%"
+                        "0%", "67.555%", "89.29%", "32.445%"
                 )
                 changed = true
         end
@@ -310,8 +318,8 @@ function DD_GUI.migrate_layout_defaults()
                 { DD_GUI.MapBox, "27%", "0%", "27%", "100%" },
                 { DD_GUI.CharsheetBox, "54%", "0%", "18%", "100%" },
                 { DD_GUI.ChannelBox, "72%", "0%", "25%", "100%" },
-                { DD_GUI.InventoryBox, "0%", "35.11%", "89.29%", "36.17%" },
-                { DD_GUI.AffectBox, "0%", "71.28%", "89.29%", "28.72%" },
+                { DD_GUI.InventoryBox, "0%", "35.11%", "89.29%", "32.445%" },
+                { DD_GUI.AffectBox, "0%", "67.555%", "89.29%", "32.445%" },
         }
 
         for _, default_box in ipairs(defaults) do
@@ -355,8 +363,8 @@ function DD_GUI.reset_layout()
                 { DD_GUI.MapBox, "27%", "0%", "27%", "100%" },
                 { DD_GUI.CharsheetBox, "54%", "0%", "18%", "100%" },
                 { DD_GUI.ChannelBox, "72%", "0%", "25%", "100%" },
-                { DD_GUI.InventoryBox, "0%", "35.11%", "89.29%", "36.17%" },
-                { DD_GUI.AffectBox, "0%", "71.28%", "89.29%", "28.72%" },
+                { DD_GUI.InventoryBox, "0%", "35.11%", "89.29%", "32.445%" },
+                { DD_GUI.AffectBox, "0%", "67.555%", "89.29%", "32.445%" },
         }
 
         for _, default_box in ipairs(defaults) do

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -30,6 +30,10 @@ function DD_GUI.refresh_data()
                 run_update(update_affects)
         end
 
+        if type(char.Quest) == "table" then
+                run_update(update_quest_status)
+        end
+
         if type(char.Items) == "table" then
                 run_update(update_inventory)
         end

--- a/src/scripts/DD/UpdateFunctions/scripts.json
+++ b/src/scripts/DD/UpdateFunctions/scripts.json
@@ -13,6 +13,12 @@
                 ]
         },
         {
+                "name": "update_quest_status",
+                "eventHandlerList": [
+                        "gmcp.Char.Quest"
+                ]
+        },
+        {
                 "name": "update_inventory",
                 "eventHandlerList": [
                         "gmcp.Char.Items"

--- a/src/scripts/DD/UpdateFunctions/update_quest_status.lua
+++ b/src/scripts/DD/UpdateFunctions/update_quest_status.lua
@@ -1,0 +1,195 @@
+local function clean_quest_text(value)
+  local text = tostring(value or "")
+  if type(ansi2string) == "function" then
+    local ok, plain = pcall(ansi2string, text)
+    if ok and plain then
+      text = plain
+    end
+  end
+
+  text = string.gsub(text, "\27%[[0-9;]*m", "")
+  text = string.gsub(text, "{%a", "")
+  text = string.gsub(text, "<[^>]+>", "")
+  text = string.gsub(text, "[\r\n]+", " ")
+  text = string.gsub(text, "%s+", " ")
+  text = string.gsub(text, "^%s+", "")
+  text = string.gsub(text, "%s+$", "")
+  return text
+end
+
+local function quest_number(value)
+  local number = tonumber(value)
+  if not number then
+    return 0
+  end
+  return math.floor(number)
+end
+
+local function quest_flag(value)
+  return value == true or tostring(value or "") == "1" or
+         string.lower(tostring(value or "")) == "true"
+end
+
+local function quest_data()
+  local char = gmcp and gmcp.Char
+  local quest = char and char.Quest
+  if type(quest) ~= "table" then
+    return nil
+  end
+
+  if quest.status == nil and type(quest[1]) == "table" then
+    quest = quest[1]
+  end
+  return quest
+end
+
+local function format_minutes(value)
+  local minutes = math.max(0, quest_number(value))
+  if minutes == 1 then
+    return "1 minute"
+  end
+  return tostring(minutes) .. " minutes"
+end
+
+local function named_reference(name, vnum, fallback)
+  local text = clean_quest_text(name)
+  local number = quest_number(vnum)
+  if text == "" then
+    text = fallback or "Unknown"
+  end
+  if number > 0 then
+    text = text .. " [#" .. tostring(number) .. "]"
+  end
+  return text
+end
+
+local function emit_quest_row(label, value, colour)
+  local text = clean_quest_text(value)
+  if text == "" then
+    text = "-"
+  end
+
+  QuestStatusConsole:cecho(
+    "<white>" .. string.format("%-15s", label) .. "<reset>" ..
+    (colour or "<white>") .. text .. "<reset>\n"
+  )
+end
+
+local function resolved_status(quest)
+  local status = string.lower(clean_quest_text(quest.status))
+  if status == "available" or status == "cooldown" or
+     status == "active" or status == "return" then
+    return status
+  end
+
+  if quest_flag(quest.active) then
+    return quest_flag(quest.complete) and "return" or "active"
+  end
+  if quest_number(quest.nextquest) > 0 then
+    return "cooldown"
+  end
+  return "available"
+end
+
+local status_display = {
+  available = { text = "Available",       colour = "<green>" },
+  cooldown  = { text = "Cooldown",        colour = "<yellow>" },
+  active    = { text = "Active",          colour = "<cyan>" },
+  ["return"] = { text = "Ready to return", colour = "<green>" },
+}
+
+function update_quest_status()
+  if not QuestStatusConsole then
+    return
+  end
+
+  QuestStatusConsole:clear()
+  QuestStatusConsole:resetAutoWrap()
+
+  local quest = quest_data()
+  if not quest then
+    QuestStatusConsole:cecho("<white>Quest data unavailable.<reset>")
+    return
+  end
+
+  local status = resolved_status(quest)
+  local display = status_display[status] or status_display.available
+  local active = quest_flag(quest.active)
+  local complete = quest_flag(quest.complete)
+  local objective_type = string.lower(clean_quest_text(quest.type))
+
+  emit_quest_row("Status", display.text, display.colour)
+
+  if active then
+    local objective = "Unknown"
+    local target_vnum = 0
+    if objective_type == "kill" then
+      objective = "Kill target"
+      target_vnum = quest_number(quest.mob_vnum)
+    elseif objective_type == "retrieve" then
+      objective = "Retrieve object"
+      target_vnum = quest_number(quest.object_vnum)
+    end
+
+    local target_fallback = "Unknown target"
+    if objective_type == "kill" and complete then
+      target_fallback = "Target defeated"
+    end
+
+    emit_quest_row("Objective", objective, "<yellow>")
+    emit_quest_row(
+      "Target",
+      named_reference(quest.target_name, target_vnum, target_fallback),
+      "<white>"
+    )
+    emit_quest_row(
+      "Progress",
+      complete and "Complete - return to questgiver" or "In progress",
+      complete and "<green>" or "<cyan>"
+    )
+    emit_quest_row(
+      "Area",
+      clean_quest_text(quest.area_name) ~= "" and quest.area_name or "Unknown",
+      "<white>"
+    )
+    emit_quest_row(
+      "Room",
+      named_reference(quest.room_name, quest.room_vnum, "Unknown"),
+      "<white>"
+    )
+    emit_quest_row(
+      "Questgiver",
+      named_reference(quest.giver_name, quest.giver_vnum, "Unknown"),
+      "<white>"
+    )
+    emit_quest_row("Time remaining", format_minutes(quest.countdown), "<yellow>")
+  elseif status == "cooldown" then
+    QuestStatusConsole:cecho("\n<white>No active autoquest.<reset>\n")
+    emit_quest_row("Next quest", format_minutes(quest.nextquest), "<yellow>")
+  else
+    QuestStatusConsole:cecho("\n<white>No active autoquest.<reset>\n")
+    emit_quest_row("Next quest", "Available now", "<green>")
+  end
+
+  QuestStatusConsole:decho("\n")
+  emit_quest_row("Quest points", quest_number(quest.points), "<yellow>")
+  emit_quest_row("Lifetime QP", quest_number(quest.total_points), "<yellow>")
+
+  local required = quest_number(quest.level_qp_required)
+  local shortfall = quest_number(quest.level_qp_shortfall)
+  if required <= 0 then
+    emit_quest_row("Level gate", "No requirement at this level", "<green>")
+  elseif shortfall <= 0 then
+    emit_quest_row(
+      "Level gate",
+      tostring(required) .. " required - met",
+      "<green>"
+    )
+  else
+    emit_quest_row(
+      "Level gate",
+      tostring(required) .. " required - " .. tostring(shortfall) .. " remaining",
+      "<yellow>"
+    )
+  end
+end

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.109"
+DD_GUI.package_version = "0.0.110"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## What changed

- add a `Quest Status` tab beside `Affects`, backed exclusively by `gmcp.Char.Quest`
- render available, cooldown, active, and ready-to-return states with objective, location, questgiver, timing, quest-point, and level-gate details
- replay cached quest state during GUI bootstrap
- make the Inventory / Equipped and Affects / Quest Status panels equal height by default, with migration for the previous shipped geometry
- update README documentation and bump the package to `0.0.110`

## Why

DD4 now publishes complete autoquest state through GMCP, so the GUI can present current quest information without parsing game text.

## Validation

- `git diff --cached --check`
- UpdateFunctions manifest parsed with PowerShell `ConvertFrom-Json`
- `./scripts/build-and-upload.ps1` completed and uploaded the production package
- generated `build/DD_GUI.xml` parsed as XML and contains the new handler, console, and package version
- production package URL returns HTTP 200 with the expected artifact size

Live Mudlet screenshot validation was attempted, but the Windows computer-control helper failed to retain its execution context.
