### PR TITLE
Disable stale Generic Mapper updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ data. The main panels are:
   even internal padding, and its title is kept to one compact room/vnum line
   with no extra rule beneath it, so northern rooms remain visible even when a
   room name is long.
+- **Mapper ownership:** DD_GUI uses its own GMCP/native mapper. During bootstrap
+  it removes Mudlet's conflicting `generic_mapper` package, whose obsolete
+  updater can otherwise request a dead `versions.lua` URL.
 - **Character sheet:** profile image, character details, statistics, and
   resistances.
 - **Comms:** communications received from the GMCP `Comm` structure. The `All`

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.110",
+  "version": "0.0.111",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/GetCustomContent.lua
+++ b/src/scripts/DD/GetCustomContent.lua
@@ -8,11 +8,31 @@ local lfs = require "lfs"
 
 downloadQueue = downloadQueue or {}
 isDownloadingFileList = false
+local active_download_path = nil
 
 -- Make the file list path/URL visible to all handlers
 FILELIST_LOCAL = ms_path .. "/custom_filelist.txt"
 FILELIST_URL   = "https://www.dragons-domain.org/main/gui/custom/files.php"
 CONTENT_BASE   = "https://www.dragons-domain.org/main/gui/custom/"
+
+local function normalise_download_path(path)
+  return tostring(path or ""):gsub("\\", "/")
+end
+
+local function is_dd_gui_download(path)
+  local candidate = normalise_download_path(path)
+  local root = normalise_download_path(ms_path)
+
+  if candidate == "" or root == "" then
+    return false
+  end
+
+  return candidate == root or candidate:sub(1, #root + 1) == root .. "/"
+end
+
+local function is_same_download(path_a, path_b)
+  return normalise_download_path(path_a) == normalise_download_path(path_b)
+end
 
 -- Ensure all parent directories for a path exist (cross-platform)
 local function ensure_dir_for(path)
@@ -31,18 +51,43 @@ end
 
 -- Event handlers
 function onDownloadDone(_, filename)
+  if not is_dd_gui_download(filename) then
+    return
+  end
+
   -- Was it the file list?
-  if isDownloadingFileList and filename == FILELIST_LOCAL then
+  if isDownloadingFileList and is_same_download(filename, FILELIST_LOCAL) then
     isDownloadingFileList = false
+    active_download_path = nil
     process_file_list()
     return
   end
+
+  if not is_same_download(filename, active_download_path) then
+    return
+  end
+
+  active_download_path = nil
   -- Otherwise proceed with the queue
   start_next_download()
 end
 
 function onDownloadError(badFile, reason)
+  if not is_dd_gui_download(badFile) then
+    return
+  end
+
+  if isDownloadingFileList and not is_same_download(badFile, FILELIST_LOCAL) then
+    return
+  end
+
+  if not isDownloadingFileList and not is_same_download(badFile, active_download_path) then
+    return
+  end
+
   cecho(string.format("\n<white>Download failed for %s: %s\n", badFile or "<unknown>", reason or ""))
+  isDownloadingFileList = false
+  active_download_path = nil
   start_next_download()
 end
 
@@ -50,6 +95,7 @@ end
 function get_custom_content()
   cecho("\n\n<white>Downloading any new custom media...\n")
   isDownloadingFileList = true
+  active_download_path = FILELIST_LOCAL
   ensure_dir_for(FILELIST_LOCAL)
   downloadFile(FILELIST_LOCAL, FILELIST_URL)
 end
@@ -89,10 +135,12 @@ end
 
 function start_next_download()
   if #downloadQueue == 0 then
+    active_download_path = nil
     --cecho("\n<white>All downloads completed.\n")
     return
   end
   local nextDownload = table.remove(downloadQueue, 1)
+  active_download_path = nextDownload.saveto
   ensure_dir_for(nextDownload.saveto)
   downloadFile(nextDownload.saveto, nextDownload.url)
 end

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -1,5 +1,26 @@
 DD_GUI = DD_GUI or {}
 
+local function remove_conflicting_generic_mapper()
+        if DD_GUI.generic_mapper_checked then
+                return
+        end
+
+        DD_GUI.generic_mapper_checked = true
+
+        if type(uninstallPackage) ~= "function" then
+                return
+        end
+
+        if type(getPackageInfo) == "function" then
+                local ok, version = pcall(getPackageInfo, "generic_mapper", "version")
+                if not ok or version == nil or tostring(version) == "" then
+                        return
+                end
+        end
+
+        pcall(uninstallPackage, "generic_mapper")
+end
+
 local function run_update(fn)
         if type(fn) ~= "function" then
                 return
@@ -186,6 +207,8 @@ end
 DD_GUI.show_current_roots = dd_gui_show_current_roots
 
 function bootstrap()
+        remove_conflicting_generic_mapper()
+
         local package_version = dd_gui_installed_version()
 
         if DD_GUI.Theme and DD_GUI.Theme.apply_profile_style then

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.110"
+DD_GUI.package_version = "0.0.111"
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## What changed

- remove Mudlet's conflicting `generic_mapper` package during DD_GUI bootstrap when it is installed
- scope DD_GUI's download completion and error handlers to the profile-owned `DD_GUI_Content` paths
- document mapper ownership and the stale updater behavior
- bump the package to `0.0.111`

## Root cause

Mudlet 4.22 ships the Generic Mapper updater with a hard-coded `https://raw.githubusercontent.com/Mudlet/Mudlet/development/src/mudlet-lua/lua/generic-mapper/versions.lua` URL. That file currently returns 404. DD_GUI already uses its own GMCP/native mapper, so the extra package is unnecessary and can conflict with the mapper state. DD_GUI's broad `sysDownloadError` listener also reported that unrelated failure as though it were a custom-content failure.

## Validation

- `git diff --cached --check`
- UpdateFunctions manifest still parses with PowerShell `ConvertFrom-Json`
- generated `build/DD_GUI.xml` parses as XML and contains version `0.0.111`
- `./scripts/build-and-upload.ps1` completed and uploaded both artifacts
- public `DD_GUI.mpackage` and `DD_GUI.xml` URLs return HTTP 200
