### PR TITLE
Mitigate profile mapper reload freezes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,12 @@ data. The main panels are:
   such as `!`, `Q`, `T`, `H`, `$`, or `S`; existing user symbols are preserved.
 - **Mapper ownership:** DD_GUI uses its own GMCP/native mapper. During bootstrap
   it removes Mudlet's conflicting `generic_mapper` package, whose obsolete
-  updater can otherwise request a dead `versions.lua` URL.
+  updater can otherwise request a dead `versions.lua` URL. The cleanup now runs
+  as soon as the DD_GUI folder loads, before the GUI starts its own mapper, so
+  the generic package's profile-level `map\autosave.dat` is not loaded beside
+  DD_GUI during development reloads. `ddmap cleanup` repeats that removal if a
+  local profile still has the old package installed; restart Mudlet afterward if
+  it was freezing while reading the generic map.
   The custom mapper accepts the current direction-to-vnum exit shape and also
   understands a future richer exit object with destination, door state, door
   name, command, arrival, area ID, and special-exit fields. Older payloads are
@@ -202,6 +207,7 @@ These aliases are available from the Mudlet command line:
 | `ddmap audit` | Report map areas, rooms, overlaps, unnamed rooms, and dangling exits without changing map data. |
 | `ddmap fit` | Fit and centre the current mapped area. |
 | `ddmap safe` / `ddmap fast` | Toggle confirmation-based or immediate mapper speedwalks. |
+| `ddmap cleanup` | Remove the legacy `generic_mapper` package from the profile before restarting Mudlet. |
 | `ddmap reset` / `ddmap cancel` | Confirm or cancel a pending mapper area reset when the dialog/link fallback is used. |
 | `ignores` | Preserve the legacy mapper command; the GMCP mapper reports that text ignore patterns are unnecessary when generic_mapper is absent. |
 | `ugui` | Uninstall the `DD_GUI` package. |
@@ -251,6 +257,18 @@ file. Keep that file local and never commit or print it.
 
 Keep this README synchronized with significant GUI, alias, keybinding, package,
 and workflow changes.
+
+### Development reload recovery
+
+If a local package reload drives Mudlet CPU usage high or leaves it frozen on
+`Reading map ... map\autosave.dat`, the profile is still loading the legacy
+`generic_mapper` package. Run `ddmap cleanup` once the profile responds, close
+and restart Mudlet, and then load DD_GUI again. DD_GUI also guards its own
+persistent `dragons_domain_mapper.dat` load so repeated `bootstrap()` calls do
+not parse the native map repeatedly in one session. If Mudlet cannot respond
+long enough to run the command, make a backup of the profile's
+`map\autosave.dat`, rename that file, restart Mudlet, and let DD_GUI rebuild
+from its own persistent map; the generic file is not used by DD_GUI.
 
 For smaller changes, you may wish to work in Mudlet's built-in text editor so you can quickly view the changes, then copy the code over to your local `dd-gui` repo after you're satisfied with it before building the package.
 

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.114",
+  "version": "0.0.115",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/aliases/DD/mapper/ddmap.lua
+++ b/src/aliases/DD/mapper/ddmap.lua
@@ -26,6 +26,17 @@ elseif target == "off" then
   if type(removeMapMenu) == "function" then
     pcall(removeMapMenu, "DD_GUI.Mapper")
   end
+elseif target == "cleanup" then
+  if DD_GUI and DD_GUI.remove_conflicting_generic_mapper then
+    local removed = DD_GUI.remove_conflicting_generic_mapper(true)
+    if removed then
+      cecho("<yellow>Removed generic_mapper. Restart Mudlet before reconnecting if its map load was freezing this profile.<reset>\n")
+    else
+      cecho("<white>The conflicting generic_mapper package is not installed, or could not be removed.<reset>\n")
+    end
+  else
+    cecho("<red>DD_GUI mapper cleanup is unavailable until bootstrap completes.<reset>\n")
+  end
 elseif target == "audit" then
   if DD_GUI and DD_GUI.mapper_audit then
     DD_GUI.mapper_audit()

--- a/src/scripts/DD/FrameGrid.lua
+++ b/src/scripts/DD/FrameGrid.lua
@@ -976,8 +976,11 @@ function FrameGrid:register()
 end
 
 function FrameGrid:schedule_refresh(delay)
-        if self.refresh_timer and type(killTimer) == "function" then
-                killTimer(self.refresh_timer)
+        -- Resize and reposition events often arrive as a burst. One pending
+        -- render is enough; repeatedly killing and recreating the timer can
+        -- monopolise Mudlet while a development package is being reloaded.
+        if self.refresh_timer then
+                return
         end
         if type(tempTimer) ~= "function" then
                 self:render()

--- a/src/scripts/DD/GetCustomContent.lua
+++ b/src/scripts/DD/GetCustomContent.lua
@@ -1,3 +1,5 @@
+DD_GUI = DD_GUI or {}
+
 local function looks_like_file(relPath)
   -- has a basename with a dot extension and does not end with '/'
   return relPath:match("[^/]+%.[^/]+$") ~= nil
@@ -145,6 +147,17 @@ function start_next_download()
   downloadFile(nextDownload.saveto, nextDownload.url)
 end
 
--- Register (safe to call once at load time)
-registerAnonymousEventHandler("sysDownloadDone",  "onDownloadDone")
-registerAnonymousEventHandler("sysDownloadError", "onDownloadError")
+-- Replace the previous callbacks when local source files are reloaded. Without
+-- this, every reload can make one completed download advance the queue several
+-- times and leave the downloader in a corrupt state.
+DD_GUI.download_event_handlers = DD_GUI.download_event_handlers or {}
+for _, handler_id in pairs(DD_GUI.download_event_handlers) do
+  if handler_id and type(killAnonymousEventHandler) == "function" then
+    pcall(killAnonymousEventHandler, handler_id)
+  end
+end
+
+DD_GUI.download_event_handlers = {
+  done = registerAnonymousEventHandler("sysDownloadDone", "onDownloadDone"),
+  error = registerAnonymousEventHandler("sysDownloadError", "onDownloadError"),
+}

--- a/src/scripts/DD/InitialiseMapper.lua
+++ b/src/scripts/DD/InitialiseMapper.lua
@@ -98,7 +98,32 @@ function save_dd_mapper()
         return saved
 end
 
+local function safe_load_map(path)
+        if type(loadMap) ~= "function" then
+                return false, "Mudlet loadMap() is unavailable"
+        end
+
+        local ok, loaded, error_message = pcall(loadMap, path)
+        if not ok then
+                return false, tostring(loaded)
+        end
+
+        return loaded == true, error_message
+end
+
 function initialise_mapper()
+        if DD_GUI.mapper_load_in_progress then
+                return false
+        end
+
+        -- A local development reload can invoke bootstrap more than once.
+        -- Native map parsing is expensive and the same map is already resident,
+        -- so never ask Mudlet to parse it repeatedly in one profile session.
+        if DD_GUI.mapper_load_attempted then
+                return DD_GUI.mapper_loaded == true
+        end
+
+        DD_GUI.mapper_load_attempted = true
         expandAlias("ignores")
 
         local bundled_map = asset_path("maps/mud_school.dat")
@@ -114,12 +139,31 @@ function initialise_mapper()
                 migrate_legacy_map = true
         end
 
-        local loaded, error_message = loadMap(map_to_load)
+        DD_GUI.mapper_load_in_progress = true
+        local loaded, error_message = safe_load_map(map_to_load)
+        DD_GUI.mapper_load_in_progress = false
 
-        if not loaded and map_to_load ~= bundled_map then
-                cecho(string.format("<yellow>Unable to load saved Dragons Domain map: %s. Loading the bundled map instead.<reset>\n", error_message or "unknown error"))
-                loadMap(bundled_map)
-        elseif migrate_legacy_map then
-                save_dd_mapper()
+        if loaded then
+                DD_GUI.mapper_loaded = true
+                DD_GUI.mapper_loaded_path = map_to_load
+                if migrate_legacy_map then
+                        save_dd_mapper()
+                end
+                return true
         end
+
+        if map_to_load ~= bundled_map then
+                cecho(string.format("<yellow>Unable to load saved Dragons Domain map: %s. Loading the bundled map instead.<reset>\n", error_message or "unknown error"))
+                local fallback_loaded, fallback_error = safe_load_map(bundled_map)
+                if fallback_loaded then
+                        DD_GUI.mapper_loaded = true
+                        DD_GUI.mapper_loaded_path = bundled_map
+                        return true
+                end
+
+                cecho(string.format("<red>Unable to load the bundled Dragons Domain map: %s<reset>\n", fallback_error or "unknown error"))
+        end
+
+        DD_GUI.mapper_load_error = error_message or "unknown error"
+        return false
 end

--- a/src/scripts/DD/MainWindow.lua
+++ b/src/scripts/DD/MainWindow.lua
@@ -103,7 +103,7 @@ function ui_container()
         -- Defer border changes until the adjustable container has finished updating.
         function ui.updatecontent()
                 if ui.eventtimer then
-                        killTimer(ui.eventtimer)
+                        return
                 end
 
                 ui.eventtimer = tempTimer(0, function()

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -1,24 +1,13 @@
 DD_GUI = DD_GUI or {}
 
+-- A source reload must not let a timer from the previous package tree flush
+-- into widgets while this script set is still being replaced.
+DD_GUI.bootstrap_ready = false
+
 local function remove_conflicting_generic_mapper()
-        if DD_GUI.generic_mapper_checked then
-                return
+        if DD_GUI.remove_conflicting_generic_mapper then
+                DD_GUI.remove_conflicting_generic_mapper()
         end
-
-        DD_GUI.generic_mapper_checked = true
-
-        if type(uninstallPackage) ~= "function" then
-                return
-        end
-
-        if type(getPackageInfo) == "function" then
-                local ok, version = pcall(getPackageInfo, "generic_mapper", "version")
-                if not ok or version == nil or tostring(version) == "" then
-                        return
-                end
-        end
-
-        pcall(uninstallPackage, "generic_mapper")
 end
 
 local function run_update(fn)
@@ -32,7 +21,7 @@ local function run_update(fn)
         end
 end
 
-function DD_GUI.refresh_data()
+local function dd_gui_refresh_data_impl()
         if not gmcp or type(gmcp.Char) ~= "table" then
                 return
         end
@@ -81,6 +70,151 @@ function DD_GUI.refresh_data()
                 run_update(update_channel_status)
         end
 end
+
+function DD_GUI.refresh_data()
+        if DD_GUI.data_refresh_in_progress then
+                return
+        end
+
+        DD_GUI.data_refresh_in_progress = true
+        local ok, error_message = pcall(dd_gui_refresh_data_impl)
+        DD_GUI.data_refresh_in_progress = false
+        if not ok then
+                DD_GUI.last_data_refresh_error = tostring(error_message)
+        end
+end
+
+-- GMCP can arrive in bursts during reconnect. Keep one managed handler per
+-- event and coalesce a burst into one short deferred update pass. Named event
+-- handlers prevent a local source reload from stacking another copy.
+local data_refresh_specs = {
+        {key = "vitals", event = "gmcp.Char.Vitals", updates = {"update_vitals", "update_equipped"}},
+        {key = "affects", event = "gmcp.Char.Affect", updates = {"update_affects"}},
+        {key = "quest", event = "gmcp.Char.Quest", updates = {"update_quest_status"}},
+        {key = "inventory", event = "gmcp.Char.Items", updates = {"update_inventory"}},
+        {key = "worn", event = "gmcp.Char.Worn", updates = {"update_equipped"}},
+        {key = "base", event = "gmcp.Char.Base", updates = {"update_equipped"}},
+        {key = "room", event = "gmcp.Room.Info", updates = {"update_travel"}},
+        {key = "enemy", event = "gmcp.Char.Enemies", updates = {"update_enemy"}},
+        {key = "comms", event = "gmcp.Comm.Channel.Text", updates = {"update_comms"}},
+        {key = "channels", event = "gmcp.Char.Channels", updates = {"update_channel_status"}},
+}
+
+local data_refresh_owner = "DD_GUI"
+
+local function data_refresh_handler_name(spec)
+        return "data_refresh_" .. spec.key
+end
+
+local function cancel_data_refresh_timer()
+        if DD_GUI.data_refresh_timer and type(killTimer) == "function" then
+                pcall(killTimer, DD_GUI.data_refresh_timer)
+        end
+        DD_GUI.data_refresh_timer = nil
+end
+
+function DD_GUI.unregister_data_refresh_handlers()
+        cancel_data_refresh_timer()
+        DD_GUI.pending_data_updates = {}
+
+        if type(deleteNamedEventHandler) == "function" then
+                for _, spec in ipairs(data_refresh_specs) do
+                        pcall(deleteNamedEventHandler, data_refresh_owner,
+                                data_refresh_handler_name(spec))
+                end
+        end
+
+        for _, handler_id in pairs(DD_GUI.data_refresh_handler_ids or {}) do
+                if handler_id and type(killAnonymousEventHandler) == "function" then
+                        pcall(killAnonymousEventHandler, handler_id)
+                end
+        end
+
+        DD_GUI.data_refresh_handler_ids = {}
+        DD_GUI.data_refresh_handlers_named = false
+end
+
+local function flush_data_refresh()
+        DD_GUI.data_refresh_timer = nil
+        if not DD_GUI.bootstrap_ready then
+                return
+        end
+
+        local pending = DD_GUI.pending_data_updates or {}
+        DD_GUI.pending_data_updates = {}
+        for _, spec in ipairs(data_refresh_specs) do
+                for _, update_name in ipairs(spec.updates) do
+                        if pending[update_name] then
+                                run_update(_G[update_name])
+                        end
+                end
+        end
+end
+
+function DD_GUI.schedule_data_refresh(update_names)
+        DD_GUI.pending_data_updates = DD_GUI.pending_data_updates or {}
+        for _, update_name in ipairs(update_names or {}) do
+                DD_GUI.pending_data_updates[update_name] = true
+        end
+
+        if DD_GUI.data_refresh_timer then
+                return
+        end
+
+        if type(tempTimer) ~= "function" then
+                flush_data_refresh()
+                return
+        end
+
+        DD_GUI.data_refresh_timer = tempTimer(0.03, flush_data_refresh)
+end
+
+local function register_data_refresh_handlers()
+        DD_GUI.unregister_data_refresh_handlers()
+
+        local function make_data_refresh_handler(updates)
+                return function()
+                        DD_GUI.schedule_data_refresh(updates)
+                end
+        end
+
+        local named_registration_ok = type(registerNamedEventHandler) == "function" and
+                type(deleteNamedEventHandler) == "function"
+        if named_registration_ok then
+                for _, spec in ipairs(data_refresh_specs) do
+                        local ok, result = pcall(
+                                registerNamedEventHandler,
+                                data_refresh_owner,
+                                data_refresh_handler_name(spec),
+                                spec.event,
+                                make_data_refresh_handler(spec.updates),
+                                false
+                        )
+                        if not ok or result == false then
+                                named_registration_ok = false
+                                break
+                        end
+                end
+        end
+
+        if named_registration_ok then
+                DD_GUI.data_refresh_handlers_named = true
+                return
+        end
+
+        -- Older Mudlet builds may not provide named event handlers. The
+        -- anonymous fallback still replaces the previous IDs on reload.
+        DD_GUI.unregister_data_refresh_handlers()
+        for _, spec in ipairs(data_refresh_specs) do
+                local handler_id = registerAnonymousEventHandler(
+                        spec.event,
+                        make_data_refresh_handler(spec.updates)
+                )
+                table.insert(DD_GUI.data_refresh_handler_ids, handler_id)
+        end
+end
+
+register_data_refresh_handlers()
 
 -- Rebuilds can happen while the server already has a complete GMCP snapshot.
 -- Replay that snapshot after creating the widgets instead of waiting for the
@@ -206,7 +340,7 @@ end
 
 DD_GUI.show_current_roots = dd_gui_show_current_roots
 
-function bootstrap()
+local function dd_gui_bootstrap_impl()
         remove_conflicting_generic_mapper()
 
         local package_version = dd_gui_installed_version()
@@ -297,6 +431,10 @@ function bootstrap()
         DD_GUI.bootstrap_ready = true
         DD_GUI.bootstrap_version = package_version
 
+        if next(DD_GUI.pending_data_updates or {}) then
+                DD_GUI.schedule_data_refresh()
+        end
+
         -- Geyser completes its initial geometry and stacking pass after
         -- bootstrap. Refresh once more so package updates also repaint the
         -- newly created consoles after that pass.
@@ -316,4 +454,21 @@ function bootstrap()
                         DD_GUI.FrameGrid:schedule_refresh(0.05)
                 end
         end)
+end
+
+function bootstrap()
+        if DD_GUI.bootstrap_in_progress then
+                return
+        end
+
+        DD_GUI.bootstrap_in_progress = true
+        local ok, error_message = pcall(dd_gui_bootstrap_impl)
+        DD_GUI.bootstrap_in_progress = false
+        if not ok then
+                DD_GUI.last_bootstrap_error = tostring(error_message)
+                if type(cecho) == "function" then
+                        cecho("<red>DD_GUI bootstrap failed: " ..
+                                tostring(error_message) .. "<reset>\n")
+                end
+        end
 end

--- a/src/scripts/DD/UpdateFunctions/scripts.json
+++ b/src/scripts/DD/UpdateFunctions/scripts.json
@@ -1,60 +1,31 @@
 [
 
         {
-                "name": "update_vitals",
-                "eventHandlerList": [ 
-                        "gmcp.Char.Vitals"
-                ]
+                "name": "update_vitals"
         },
         {
-                "name": "update_affects",
-                "eventHandlerList": [ 
-                        "gmcp.Char.Affect"
-                ]
+                "name": "update_affects"
         },
         {
-                "name": "update_quest_status",
-                "eventHandlerList": [
-                        "gmcp.Char.Quest"
-                ]
+                "name": "update_quest_status"
         },
         {
-                "name": "update_inventory",
-                "eventHandlerList": [
-                        "gmcp.Char.Items"
-                ]
+                "name": "update_inventory"
         },
         {
-                "name": "update_equipped",
-                "eventHandlerList": [
-                        "gmcp.Char.Worn",
-                        "gmcp.Char.Base",
-                        "gmcp.Char.Vitals"
-                ]
+                "name": "update_equipped"
         },
         {
-                "name": "update_travel",
-                "eventHandlerList": [ 
-                        "gmcp.Room.Info"
-                ]
+                "name": "update_travel"
         },
         {
-                "name": "update_enemy",
-                "eventHandlerList": [ 
-                        "gmcp.Char.Enemies"
-                ]
+                "name": "update_enemy"
         },
         {
-                "name": "update_comms",
-                "eventHandlerList": [
-                        "gmcp.Comm.Channel.Text"
-                ]
+                "name": "update_comms"
         },
         {
-                "name": "update_channel_status",
-                "eventHandlerList": [
-                        "gmcp.Char.Channels"
-                ]
+                "name": "update_channel_status"
         },
         {
                 "name": "bootstrap"

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,41 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.114"
+DD_GUI.package_version = "0.0.115"
+
+-- DD_GUI owns the native mapper surface. Remove the legacy generic mapper as
+-- early as possible so its profile-level map/autosave.dat is not loaded beside
+-- the DD_GUI map during a local development reload.
+function DD_GUI.remove_conflicting_generic_mapper(force)
+        if DD_GUI.generic_mapper_checked and not force then
+                return DD_GUI.generic_mapper_removed == true
+        end
+
+        DD_GUI.generic_mapper_checked = true
+        DD_GUI.generic_mapper_removed = false
+
+        if type(uninstallPackage) ~= "function" then
+                return false
+        end
+
+        local installed = true
+        if type(getPackageInfo) == "function" then
+                local ok, version = pcall(getPackageInfo, "generic_mapper", "version")
+                installed = ok and version ~= nil and tostring(version) ~= ""
+        end
+
+        if installed then
+                local ok, result = pcall(uninstallPackage, "generic_mapper")
+                DD_GUI.generic_mapper_removed = ok and result ~= false
+                if DD_GUI.generic_mapper_removed and type(cecho) == "function" then
+                        cecho("<yellow>Removed the conflicting generic_mapper package; DD_GUI owns the mapper.<reset>\n")
+                end
+        end
+
+        return DD_GUI.generic_mapper_removed == true
+end
+
+DD_GUI.remove_conflicting_generic_mapper()
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"
@@ -113,15 +147,32 @@ function myScriptInstalled(_, name)
         if name ~= "DD_GUI" then
                 return
         end
+        DD_GUI.remove_conflicting_generic_mapper()
         DD_GUI.migrate_legacy_content()
         bootstrap()
 end
 
 function myScriptUninstalled(_, name)
         if name == "DD_GUI" then
+                if DD_GUI.unregister_data_refresh_handlers then
+                        DD_GUI.unregister_data_refresh_handlers()
+                end
                 DD_GUI.migrate_legacy_content()
         end
 end
 
-registerAnonymousEventHandler("sysInstallPackage", "myScriptInstalled")
-registerAnonymousEventHandler("sysUninstallPackage", "myScriptUninstalled")
+local function register_package_handlers()
+        DD_GUI.package_event_handlers = DD_GUI.package_event_handlers or {}
+        for _, handler_id in pairs(DD_GUI.package_event_handlers) do
+                if handler_id and type(killAnonymousEventHandler) == "function" then
+                        pcall(killAnonymousEventHandler, handler_id)
+                end
+        end
+
+        DD_GUI.package_event_handlers = {
+                install = registerAnonymousEventHandler("sysInstallPackage", "myScriptInstalled"),
+                uninstall = registerAnonymousEventHandler("sysUninstallPackage", "myScriptUninstalled"),
+        }
+end
+
+register_package_handlers()

--- a/src/scripts/DD/scripts.json
+++ b/src/scripts/DD/scripts.json
@@ -33,10 +33,7 @@
         "name": "CharsheetConsole"
   },
   {
-        "name": "compass.resize",
-        "eventHandlerList": [ 
-                "sysWindowResizeEvent"
-        ]
+        "name": "compass.resize"
   },
   {
         "name": "CreateBackground"


### PR DESCRIPTION
## Summary\n- remove the legacy generic_mapper package as DD_GUI loads and add the ddmap cleanup recovery alias\n- guard DD_GUI map loading, bootstrap, GMCP refresh bursts, download callbacks, and layout refresh timers during local reloads\n- update the README and publish package version 0.0.115\n\n## Verification\n- .\\scripts\\build-and-upload.ps1\n- remote DD_GUI.xml reports version 0.0.115\n- JSON validation and git diff --check pass