### PR TITLE
Frame character condition gauges

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ data. The main panels are:
   resistances. Characters below level 100 also receive compact segmented
   `THIRST` and `HUNGER` gauges from `Char.Vitals`. The gauges are hidden for
   Vampires, whose DD4 condition values do not decay, and on older servers that
-  do not provide the new current/maximum fields.
+  do not provide the new current/maximum fields. Their two-cell row uses the
+  same braided frame as the footer gauges, sharing the character panel's outer
+  edges and using single square junctions at the internal divisions.
 - **Comms:** communications received from the GMCP `Comm` structure. The `All`
   tab is always first. Other tabs appear only when GMCP reports that the
   character can access and has enabled that channel. Messages include their
@@ -184,7 +186,8 @@ data. The main panels are:
   The four footer status gauges use an even inset on all four sides inside the
   shared braided frame, so their black breathing room remains balanced when
   the gauge band is resized. The character sheet's hunger and thirst bars use
-  the same segmented gauge treatment in a compact two-column row.
+  the same segmented gauge and braided-container treatment in a compact
+  two-column row.
 
 The main MUD console and panel consoles use the profile's shared scrollbar
 style: narrow black tracks have restrained dark-red edges, while the moving

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.117",
+  "version": "0.0.118",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/BoxesDefinitions.lua
+++ b/src/scripts/DD/BoxesDefinitions.lua
@@ -140,6 +140,8 @@ local function raise_data_surfaces()
                 CharsheetPFPConsole,
                 CharsheetImageFrame,
                 DD_GUI and DD_GUI.CharsheetConditions,
+                DD_GUI and DD_GUI.ThirstColumn,
+                DD_GUI and DD_GUI.HungerColumn,
                 DD_GUI and DD_GUI.Thirst,
                 DD_GUI and DD_GUI.Hunger,
                 DD_GUI and DD_GUI.ThirstLabel,

--- a/src/scripts/DD/CharsheetConsole.lua
+++ b/src/scripts/DD/CharsheetConsole.lua
@@ -28,6 +28,8 @@ end
 local function set_condition_gauges_visible(visible)
     local widgets = {
       DD_GUI.CharsheetConditions,
+      DD_GUI.ThirstColumn,
+      DD_GUI.HungerColumn,
       DD_GUI.Thirst,
       DD_GUI.Hunger,
       DD_GUI.ThirstLabel,
@@ -47,7 +49,16 @@ end
 
 function DD_GUI.update_character_condition_gauges()
     local visible = character_condition_gauges_visible()
+    local frame_visibility_changed =
+      DD_GUI.CharsheetConditionFrameVisible ~= visible
+    DD_GUI.CharsheetConditionFrameVisible = visible
     set_condition_gauges_visible(visible)
+
+    if frame_visibility_changed and DD_GUI.FrameGrid and
+       DD_GUI.FrameGrid.schedule_refresh then
+      DD_GUI.FrameGrid:schedule_refresh(0.02)
+    end
+
     if not visible then
       return
     end
@@ -68,11 +79,28 @@ local function build_character_condition_gauges()
       return
     end
 
+    -- The condition band must use the character panel's true outer bounds so
+    -- its braid can reuse the existing side and bottom edges without gaps.
+    local go_inside = DD_GUI.CharsheetBox.goInside
+    DD_GUI.CharsheetBox.goInside = false
     DD_GUI.CharsheetConditions = Geyser.Container:new({
       name = "DD_GUI.CharsheetConditions",
-      x = "4%", y = "89%",
-      width = "92%", height = "9%",
+      x = "0%", y = "87%",
+      width = "100%", height = "13%",
     }, DD_GUI.CharsheetBox)
+    DD_GUI.CharsheetBox.goInside = go_inside
+
+    DD_GUI.ThirstColumn = Geyser.Container:new({
+      name = "DD_GUI.ThirstColumn",
+      x = "0%", y = "0%",
+      width = "50%", height = "100%",
+    }, DD_GUI.CharsheetConditions)
+
+    DD_GUI.HungerColumn = Geyser.Container:new({
+      name = "DD_GUI.HungerColumn",
+      x = "50%", y = "0%",
+      width = "50%", height = "100%",
+    }, DD_GUI.CharsheetConditions)
 
     local colors = DD_GUI.Theme and DD_GUI.Theme.colors or {
       thirst = "rgb(35,112,153)",
@@ -81,14 +109,12 @@ local function build_character_condition_gauges()
     local vitals = gmcp.Char.Vitals
 
     DD_GUI.Thirst, DD_GUI.ThirstLabel = DD_GUI.new_status_gauge(
-      "DD_GUI.Thirst", DD_GUI.CharsheetConditions, "THIRST", colors.thirst,
-      vitals.thirst, vitals.maxthirst,
-      {x = "0%", y = "0%", width = "49%", height = "100%"})
+      "DD_GUI.Thirst", DD_GUI.ThirstColumn, "THIRST", colors.thirst,
+      vitals.thirst, vitals.maxthirst)
 
     DD_GUI.Hunger, DD_GUI.HungerLabel = DD_GUI.new_status_gauge(
-      "DD_GUI.Hunger", DD_GUI.CharsheetConditions, "HUNGER", colors.hunger,
-      vitals.hunger, vitals.maxhunger,
-      {x = "51%", y = "0%", width = "49%", height = "100%"})
+      "DD_GUI.Hunger", DD_GUI.HungerColumn, "HUNGER", colors.hunger,
+      vitals.hunger, vitals.maxhunger)
 
     DD_GUI.update_character_condition_gauges()
 end
@@ -99,7 +125,7 @@ function build_charsheet_console()
       name="CharsheetConsole",
       x = "4%", y = "2%",
       width="92%",
-      height="86%",
+      height="84%",
       autoWrap = false,
       color = "black",
       scrollBar = false,

--- a/src/scripts/DD/FrameGrid.lua
+++ b/src/scripts/DD/FrameGrid.lua
@@ -290,12 +290,34 @@ function FrameGrid:collect_regions()
                         -- overlap substantially.
                         if gap_width >= -self.thickness / 2 then
                                 self.gauge_dividers[#self.gauge_dividers + 1] = {
+                                        orientation = "v",
                                         x = gap_start + gap_width / 2,
                                         y = bottom.y,
                                         height = bottom.height,
                                 }
                         end
                 end
+        end
+
+        -- The character condition gauges form a two-cell band inside the
+        -- character panel. Its outer left, right, and bottom edges already
+        -- belong to CharsheetBox, so add only the top braid and one shared
+        -- vertical divider. This keeps every junction single and square.
+        local condition_band = widget_bounds(
+                DD_GUI.CharsheetConditions)
+        if DD_GUI.CharsheetConditionFrameVisible == true and condition_band then
+                self.gauge_dividers[#self.gauge_dividers + 1] = {
+                        orientation = "h",
+                        x = condition_band.x,
+                        y = condition_band.y,
+                        width = condition_band.width,
+                }
+                self.gauge_dividers[#self.gauge_dividers + 1] = {
+                        orientation = "v",
+                        x = condition_band.x + condition_band.width / 2,
+                        y = condition_band.y,
+                        height = condition_band.height,
+                }
         end
 end
 
@@ -813,25 +835,47 @@ function FrameGrid:draw_visuals()
         for _, divider in ipairs(self.gauge_dividers or {}) do
                 divider_index = divider_index + 1
                 local color = self:regular_color()
-                local segment = Geyser.Label:new({
+                local orientation = divider.orientation or "v"
+                local constraints = {
                         name = "DD_GUI.FrameGrid.GaugeDivider." .. divider_index,
-                        x = round(divider.x - self.thickness / 2),
-                        y = round(divider.y),
-                        width = self.thickness,
-                        height = math.max(1, round(divider.height)),
-                }, root)
-                segment._dd_gui_frame_orientation = "v"
+                }
+                local endpoints
+                if orientation == "h" then
+                        constraints.x = round(divider.x)
+                        constraints.y = round(
+                                divider.y - self.thickness / 2)
+                        constraints.width = math.max(1, round(divider.width))
+                        constraints.height = self.thickness
+                        endpoints = {
+                                { x = divider.x, y = divider.y },
+                                { x = divider.x + divider.width, y = divider.y },
+                        }
+                else
+                        constraints.x = round(
+                                divider.x - self.thickness / 2)
+                        constraints.y = round(divider.y)
+                        constraints.width = self.thickness
+                        constraints.height = math.max(1, round(divider.height))
+                        endpoints = {
+                                { x = divider.x, y = divider.y },
+                                { x = divider.x,
+                                  y = divider.y + divider.height },
+                        }
+                end
+
+                local segment = Geyser.Label:new(constraints, root)
+                segment._dd_gui_frame_orientation = orientation
                 segment._dd_gui_frame_entries = {}
                 segment._dd_gui_frame_color = color
-                self:line_style(segment, "v", color)
+                self:line_style(segment, orientation, color)
                 self.segments[#self.segments + 1] = segment
 
-                for _, y in ipairs({ divider.y, divider.y + divider.height }) do
+                for endpoint_index, endpoint in ipairs(endpoints) do
                         local marker = Geyser.Label:new({
                                 name = "DD_GUI.FrameGrid.GaugeDividerNode." ..
-                                        divider_index .. "." .. tostring(y),
-                                x = round(divider.x - self.node_size / 2),
-                                y = round(y - self.node_size / 2),
+                                        divider_index .. "." .. endpoint_index,
+                                x = round(endpoint.x - self.node_size / 2),
+                                y = round(endpoint.y - self.node_size / 2),
                                 width = self.node_size,
                                 height = self.node_size,
                         }, root)

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.117"
+DD_GUI.package_version = "0.0.118"
 
 -- DD_GUI owns the native mapper surface. Remove the legacy generic mapper as
 -- early as possible so its profile-level map/autosave.dat is not loaded beside


### PR DESCRIPTION
## Summary
- place thirst and hunger in a shared two-cell braided band within the character panel
- reuse the character frame edges and add single square junctions at the internal dividers
- preserve the footer gauge styling and dynamic visibility rules
- document the framed condition row and bump the package to 0.0.118

## Validation
- `npx --yes luaparse --quiet` on changed Lua files
- `./scripts/build-and-upload.ps1`
- production package SHA-256 matches the local build
