### PR TITLE
Add tooltips and adverse condition icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,20 @@ data. The main panels are:
   `THIRST` and `HUNGER` gauges from `Char.Vitals`. The gauges are hidden for
   Vampires, whose DD4 condition values do not decay, and on older servers that
   do not provide the new current/maximum fields. Character conditions appear
-  in a compact portrait grid that starts at the lower-right, fills six icons
+  in a compact portrait grid that starts at the lower-right, fills five icons
   right-to-left, and wraps upward. Icons retain their first-detected activation
   order while active and compact when one clears. The tankard's brightness
   follows `drunk/maxdrunk`. Affect icons cover poison/nausea or `AFF_POISON`
   (`gives = "poison"`), `AFF_HOLD` (`hold`), `AFF_CURSE` (`curse`), `AFF_SLOW`
   (`slow`), `AFF_CONFUSION` (`confused`), `AFF_DAZED` (`dazed`),
   `AFF_NO_RECALL` (`no_recall`), `AFF_SWALLOWED` (`swallowed`), and `AFF_BLIND`
-  (`blindness`). Each affect icon uses the longest matching duration, is fully
-  bright at 20 or more ticks, fades toward expiry, and disappears immediately
-  when no matching GMCP affect remains.
+  (`blindness`), plus `AFF_PRAYER_PLAGUE` (`plague`), `AFF_DOT` (`DOT`), and
+  `AFF_PRONE` (`prone`). It also covers eye, head, arm, leg, heart, tail, and
+  torso trauma, along with `AFF_FAERIE_FIRE`, `AFF_SLEEP`, and `AFF_CHARM`.
+  Each affect icon uses the longest matching duration, is fully bright at 20
+  or more ticks, fades toward expiry, and disappears immediately when no
+  matching GMCP affect remains. Hovering over any icon identifies the
+  condition, briefly explains its effect, and describes the brightness scale.
 - **Comms:** communications received from the GMCP `Comm` structure. The `All`
   tab is always first. Other tabs appear only when GMCP reports that the
   character can access and has enabled that channel. Messages include their

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.121",
+  "version": "0.0.122",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/CharsheetConsole.lua
+++ b/src/scripts/DD/CharsheetConsole.lua
@@ -63,9 +63,10 @@ function DD_GUI.update_character_condition_gauges()
     end
 end
 
-local PORTRAIT_ICON_SIZE = 15
+local PORTRAIT_ICON_BASE_SIZE = 15
+local PORTRAIT_ICON_SIZE = 18
 local PORTRAIT_ICON_GAP = 1
-local PORTRAIT_ICON_COLUMNS = 6
+local PORTRAIT_ICON_COLUMNS = 5
 local PORTRAIT_ICON_RIGHT = 2
 local PORTRAIT_ICON_BOTTOM = 3
 
@@ -162,6 +163,85 @@ local AFFECT_ICON_DEFINITIONS = {
     key = "swallowed",
     matches = function(name, gives)
       return gives == "swallowed" or name == "swallowed"
+    end,
+  },
+  {
+    key = "plague",
+    matches = function(name, gives)
+      return gives == "plague" or name == "plague"
+    end,
+  },
+  {
+    key = "dot",
+    matches = function(name, gives)
+      return gives == "dot" or name == "dot" or
+             name == "damage over time"
+    end,
+  },
+  {
+    key = "prone",
+    matches = function(name, gives)
+      return gives == "prone" or name == "prone"
+    end,
+  },
+  {
+    key = "eye_trauma",
+    matches = function(name, gives)
+      return gives == "eye trauma" or name == "eye trauma"
+    end,
+  },
+  {
+    key = "head_trauma",
+    matches = function(name, gives)
+      return gives == "head trauma" or name == "head trauma"
+    end,
+  },
+  {
+    key = "arm_trauma",
+    matches = function(name, gives)
+      return gives == "arm trauma" or name == "arm trauma"
+    end,
+  },
+  {
+    key = "leg_trauma",
+    matches = function(name, gives)
+      return gives == "leg trauma" or name == "leg trauma"
+    end,
+  },
+  {
+    key = "heart_trauma",
+    matches = function(name, gives)
+      return gives == "heart trauma" or name == "heart trauma"
+    end,
+  },
+  {
+    key = "tail_trauma",
+    matches = function(name, gives)
+      return gives == "tail trauma" or name == "tail trauma"
+    end,
+  },
+  {
+    key = "torso_trauma",
+    matches = function(name, gives)
+      return gives == "torso trauma" or name == "torso trauma"
+    end,
+  },
+  {
+    key = "faerie_fire",
+    matches = function(name, gives)
+      return gives == "faerie fire" or name == "faerie fire"
+    end,
+  },
+  {
+    key = "sleep",
+    matches = function(name, gives)
+      return gives == "sleep" or name == "sleep"
+    end,
+  },
+  {
+    key = "charm",
+    matches = function(name, gives)
+      return gives == "charm" or name == "charm"
     end,
   },
   {
@@ -345,6 +425,12 @@ local function scaled_alpha(alpha, factor)
       math.floor((tonumber(alpha) or 0) * (factor or 1) + 0.5)))
 end
 
+local function scaled_icon_metric(value, minimum)
+    local scaled = math.floor((tonumber(value) or 0) *
+      PORTRAIT_ICON_SIZE / PORTRAIT_ICON_BASE_SIZE + 0.5)
+    return math.max(minimum or 0, scaled)
+end
+
 local function rgba(color, alpha)
     return string.format("rgba(%d,%d,%d,%d)",
       color[1], color[2], color[3], alpha)
@@ -375,12 +461,14 @@ local function style_icon_part(part, alpha, style)
       %s
       border-radius: %dpx;
       %s
-    ]], background, border, style.radius or 0, style.extra or ""))
+    ]], background, border, scaled_icon_metric(style.radius or 0),
+      style.extra or ""))
 end
 
 local PORTRAIT_ICON_SPECS = {
   drunk = {
     root = "DrunkIcon",
+    tooltip = "Drunk: your current intoxication. Brightness shows how drunk you are.",
     parts = {
       {"Handle", 10, 7, 4, 6, {border = {255,190,55}, radius = 2,
         extra = "border-left: 0px;"}},
@@ -396,6 +484,7 @@ local PORTRAIT_ICON_SPECS = {
   },
   poison = {
     root = "PoisonIcon",
+    tooltip = "Poisoned: poison or nausea is affecting you. Brightness shows remaining duration.",
     parts = {
       {"Stopper", 5, 1, 6, 3, {fill = {85,55,31}, border = {189,145,73},
         radius = 1}},
@@ -412,6 +501,7 @@ local PORTRAIT_ICON_SPECS = {
   },
   hold = {
     root = "HoldIcon",
+    tooltip = "Held: you are trapped, paralysed, or otherwise restrained. Brightness shows remaining duration.",
     parts = {
       {"LeftCuff", 0, 4, 6, 8, {border = {174,201,211}, radius = 3}},
       {"RightCuff", 9, 4, 6, 8, {border = {174,201,211}, radius = 3}},
@@ -427,6 +517,7 @@ local PORTRAIT_ICON_SPECS = {
   },
   curse = {
     root = "CurseIcon",
+    tooltip = "Cursed: a magical curse is affecting you and may prevent recall. Brightness shows remaining duration.",
     parts = {
       {"Eye", 1, 4, 13, 8, {fill = {39,7,53}, fill_opacity = 0.72,
         border = {221,81,255}, radius = 6}},
@@ -442,6 +533,7 @@ local PORTRAIT_ICON_SPECS = {
   },
   slow = {
     root = "SlowIcon",
+    tooltip = "Slowed: your actions and movement are slowed. Brightness shows remaining duration.",
     parts = {
       {"TopBar", 2, 1, 11, 2, {fill = {164,229,255}, radius = 1}},
       {"BottomBar", 2, 12, 11, 2, {fill = {164,229,255}, radius = 1}},
@@ -454,6 +546,7 @@ local PORTRAIT_ICON_SPECS = {
   },
   confusion = {
     root = "ConfusionIcon",
+    tooltip = "Confused: confusion is affecting your actions. Brightness shows remaining duration.",
     parts = {
       {"ArcTop", 4, 1, 8, 3, {fill = {240,77,224}, radius = 2}},
       {"ArcRight", 10, 3, 3, 7, {fill = {209,48,198}, radius = 2}},
@@ -465,6 +558,7 @@ local PORTRAIT_ICON_SPECS = {
   },
   dazed = {
     root = "DazedIcon",
+    tooltip = "Dazed: you may be temporarily unable to act. Brightness shows remaining duration.",
     parts = {
       {"Horizontal", 2, 7, 11, 2, {fill = {245,185,38}}},
       {"Vertical", 7, 2, 2, 11, {fill = {245,185,38}}},
@@ -476,6 +570,7 @@ local PORTRAIT_ICON_SPECS = {
   },
   no_recall = {
     root = "NoRecallIcon",
+    tooltip = "No recall: magical recall is blocked. Brightness shows remaining duration.",
     parts = {
       {"Top", 3, 2, 9, 2, {fill = {211,87,82}}},
       {"Left", 3, 3, 2, 10, {fill = {157,45,45}}},
@@ -488,6 +583,7 @@ local PORTRAIT_ICON_SPECS = {
   },
   swallowed = {
     root = "SwallowedIcon",
+    tooltip = "Swallowed: you are inside a creature. Brightness shows remaining duration.",
     parts = {
       {"TopJaw", 1, 2, 13, 5, {fill = {63,105,47},
         border = {145,211,91}, radius = 3}},
@@ -500,8 +596,185 @@ local PORTRAIT_ICON_SPECS = {
       {"ToothRight", 11, 6, 2, 2, {fill = {238,232,199}}},
     },
   },
+  plague = {
+    root = "PlagueIcon",
+    tooltip = "Plagued: a virulent magical disease is affecting you. Brightness shows remaining duration.",
+    parts = {
+      {"Head", 3, 1, 9, 9, {fill = {94,116,31},
+        border = {202,231,91}, radius = 5}},
+      {"EyeLeft", 5, 4, 2, 2, {fill = {18,25,7}, radius = 1}},
+      {"EyeRight", 9, 4, 2, 2, {fill = {18,25,7}, radius = 1}},
+      {"Nose", 7, 6, 2, 2, {fill = {36,43,12}, radius = 1}},
+      {"Jaw", 5, 9, 6, 4, {fill = {119,139,38},
+        border = {202,231,91}, radius = 1}},
+      {"ToothLeft", 6, 10, 1, 2, {fill = {226,235,163}}},
+      {"ToothRight", 9, 10, 1, 2, {fill = {226,235,163}}},
+      {"Pox", 2, 3, 2, 2, {fill = {222,184,47}, radius = 1}},
+    },
+  },
+  dot = {
+    root = "DotIcon",
+    tooltip = "Damage over time: an ongoing effect is repeatedly hurting you. Brightness shows remaining duration.",
+    parts = {
+      {"Flame", 4, 3, 8, 11, {fill = {171,23,27},
+        border = {255,91,45}, radius = 5}},
+      {"Tip", 7, 1, 3, 5, {fill = {241,65,30}, radius = 2}},
+      {"Core", 7, 7, 3, 5, {fill = {255,184,48},
+        border = {255,231,123}, radius = 2}},
+      {"Spark", 11, 2, 2, 3, {fill = {255,115,44}, radius = 1}},
+    },
+  },
+  prone = {
+    root = "ProneIcon",
+    tooltip = "Prone: you have been knocked down. Brightness shows remaining duration.",
+    parts = {
+      {"Ground", 1, 12, 13, 2, {fill = {151,160,170}, radius = 1}},
+      {"Head", 1, 7, 4, 4, {fill = {221,178,121},
+        border = {255,220,167}, radius = 2}},
+      {"Body", 5, 7, 7, 3, {fill = {121,54,48},
+        border = {226,112,88}, radius = 1}},
+      {"Arm", 6, 4, 2, 4, {fill = {226,112,88}, radius = 1}},
+      {"Leg", 11, 9, 3, 3, {fill = {89,101,119}, radius = 1}},
+      {"Dust", 2, 4, 2, 2, {fill = {186,193,200},
+        fill_opacity = 0.72, radius = 1}},
+    },
+  },
+  eye_trauma = {
+    root = "EyeTraumaIcon",
+    tooltip = "Eye trauma: your eyes have been injured. Brightness shows remaining duration.",
+    parts = {
+      {"Eye", 1, 5, 13, 7, {fill = {40,31,34},
+        border = {220,202,190}, radius = 6}},
+      {"Iris", 5, 6, 5, 5, {fill = {164,24,31},
+        border = {255,93,91}, radius = 3}},
+      {"Pupil", 7, 7, 2, 3, {fill = {12,4,5}, radius = 1}},
+      {"Wound", 11, 2, 2, 5, {fill = {242,48,48}, radius = 1}},
+      {"Blood", 12, 10, 2, 3, {fill = {176,18,28}, radius = 1}},
+    },
+  },
+  head_trauma = {
+    root = "HeadTraumaIcon",
+    tooltip = "Head trauma: your head has been injured. Brightness shows remaining duration.",
+    parts = {
+      {"Head", 3, 2, 9, 10, {fill = {184,153,120},
+        border = {239,211,171}, radius = 5}},
+      {"Neck", 6, 11, 4, 3, {fill = {141,111,86}, radius = 1}},
+      {"CrackTop", 8, 2, 2, 4, {fill = {225,43,48}}},
+      {"CrackSide", 6, 5, 3, 2, {fill = {225,43,48}}},
+      {"Impact", 11, 1, 3, 3, {fill = {255,126,66}, radius = 2}},
+    },
+  },
+  arm_trauma = {
+    root = "ArmTraumaIcon",
+    tooltip = "Arm trauma: one of your arms has been injured. Brightness shows remaining duration.",
+    parts = {
+      {"Head", 6, 1, 4, 4, {fill = {204,211,217}, radius = 2}},
+      {"Torso", 6, 5, 4, 6, {fill = {108,121,135}, radius = 1}},
+      {"GoodArm", 2, 6, 5, 2, {fill = {157,169,180}, radius = 1}},
+      {"HurtArm", 9, 6, 5, 2, {fill = {220,43,48},
+        border = {255,121,104}, radius = 1}},
+      {"LeftLeg", 5, 10, 2, 4, {fill = {108,121,135}, radius = 1}},
+      {"RightLeg", 9, 10, 2, 4, {fill = {108,121,135}, radius = 1}},
+    },
+  },
+  leg_trauma = {
+    root = "LegTraumaIcon",
+    tooltip = "Leg trauma: one of your legs has been injured. Brightness shows remaining duration.",
+    parts = {
+      {"Head", 6, 1, 4, 4, {fill = {204,211,217}, radius = 2}},
+      {"Torso", 6, 5, 4, 6, {fill = {108,121,135}, radius = 1}},
+      {"LeftArm", 2, 6, 5, 2, {fill = {157,169,180}, radius = 1}},
+      {"RightArm", 9, 6, 5, 2, {fill = {157,169,180}, radius = 1}},
+      {"GoodLeg", 5, 10, 2, 4, {fill = {108,121,135}, radius = 1}},
+      {"HurtLeg", 9, 10, 2, 4, {fill = {220,43,48},
+        border = {255,121,104}, radius = 1}},
+    },
+  },
+  heart_trauma = {
+    root = "HeartTraumaIcon",
+    tooltip = "Heart trauma: your heart has been injured. Brightness shows remaining duration.",
+    parts = {
+      {"LeftLobe", 3, 3, 6, 6, {fill = {171,20,32},
+        border = {255,82,83}, radius = 4}},
+      {"RightLobe", 7, 3, 6, 6, {fill = {171,20,32},
+        border = {255,82,83}, radius = 4}},
+      {"Point", 5, 7, 6, 6, {fill = {194,24,35}, radius = 3}},
+      {"Wound", 7, 4, 2, 7, {fill = {255,197,86}}},
+      {"Pulse", 2, 8, 4, 2, {fill = {255,230,160}}},
+    },
+  },
+  tail_trauma = {
+    root = "TailTraumaIcon",
+    tooltip = "Tail trauma: your tail has been injured. Brightness shows remaining duration.",
+    parts = {
+      {"Head", 2, 3, 4, 4, {fill = {181,190,199}, radius = 2}},
+      {"Body", 5, 5, 6, 6, {fill = {105,119,132}, radius = 2}},
+      {"LeftLeg", 5, 10, 2, 4, {fill = {105,119,132}, radius = 1}},
+      {"RightLeg", 9, 10, 2, 4, {fill = {105,119,132}, radius = 1}},
+      {"Tail", 10, 8, 4, 2, {fill = {220,43,48},
+        border = {255,121,104}, radius = 1}},
+      {"TailTip", 13, 6, 2, 4, {fill = {220,43,48}, radius = 1}},
+    },
+  },
+  torso_trauma = {
+    root = "TorsoTraumaIcon",
+    tooltip = "Torso trauma: your body has been injured. Brightness shows remaining duration.",
+    parts = {
+      {"Head", 6, 1, 4, 4, {fill = {204,211,217}, radius = 2}},
+      {"Torso", 6, 5, 4, 6, {fill = {220,43,48},
+        border = {255,121,104}, radius = 1}},
+      {"LeftArm", 2, 6, 5, 2, {fill = {157,169,180}, radius = 1}},
+      {"RightArm", 9, 6, 5, 2, {fill = {157,169,180}, radius = 1}},
+      {"LeftLeg", 5, 10, 2, 4, {fill = {108,121,135}, radius = 1}},
+      {"RightLeg", 9, 10, 2, 4, {fill = {108,121,135}, radius = 1}},
+    },
+  },
+  faerie_fire = {
+    root = "FaerieFireIcon",
+    tooltip = "Faerie fire: revealing magical flames surround you. Brightness shows remaining duration.",
+    parts = {
+      {"Flame", 4, 3, 8, 11, {fill = {116,35,170},
+        border = {227,105,255}, radius = 5}},
+      {"Tip", 7, 1, 3, 5, {fill = {195,68,241}, radius = 2}},
+      {"Core", 7, 7, 3, 5, {fill = {67,222,239},
+        border = {181,251,255}, radius = 2}},
+      {"SparkLeft", 2, 5, 2, 3, {fill = {207,91,250}, radius = 1}},
+      {"SparkRight", 12, 3, 2, 3, {fill = {93,225,241}, radius = 1}},
+    },
+  },
+  sleep = {
+    root = "SleepIcon",
+    tooltip = "Asleep: magical sleep is preventing you from acting. Brightness shows remaining duration.",
+    parts = {
+      {"Bed", 1, 8, 13, 5, {fill = {35,58,101},
+        border = {128,177,238}, radius = 2}},
+      {"Pillow", 2, 6, 5, 4, {fill = {183,211,242},
+        border = {230,244,255}, radius = 2}},
+      {"Blanket", 7, 7, 6, 5, {fill = {61,101,165}, radius = 2}},
+      {"PostLeft", 1, 7, 2, 7, {fill = {132,165,205}, radius = 1}},
+      {"PostRight", 13, 9, 2, 5, {fill = {132,165,205}, radius = 1}},
+      {"Dream", 9, 2, 4, 3, {fill = {151,207,255},
+        fill_opacity = 0.72, radius = 2}},
+    },
+  },
+  charm = {
+    root = "CharmIcon",
+    tooltip = "Charmed: another creature is influencing your will. Brightness shows remaining duration.",
+    parts = {
+      {"LeftLobe", 3, 3, 6, 6, {fill = {198,45,131},
+        border = {255,133,207}, radius = 4}},
+      {"RightLobe", 7, 3, 6, 6, {fill = {198,45,131},
+        border = {255,133,207}, radius = 4}},
+      {"Point", 5, 7, 6, 6, {fill = {220,51,143}, radius = 3}},
+      {"ChainLeft", 1, 7, 5, 2, {fill = {169,184,197}, radius = 1}},
+      {"ChainRight", 10, 7, 5, 2, {fill = {169,184,197}, radius = 1}},
+      {"Lock", 7, 6, 2, 4, {fill = {235,221,139},
+        border = {255,246,180}, radius = 1}},
+    },
+  },
   blind = {
     root = "BlindIcon",
+    tooltip = "Blind: you cannot see normally. Brightness shows remaining duration.",
     parts = {
       {"Band", 1, 5, 13, 6, {fill = {28,31,37},
         border = {184,194,207}, radius = 2}},
@@ -516,7 +789,9 @@ local PORTRAIT_ICON_SPECS = {
 
 local PORTRAIT_ICON_BUILD_ORDER = {
   "drunk", "poison", "hold", "curse", "slow", "confusion", "dazed",
-  "no_recall", "swallowed", "blind",
+  "no_recall", "swallowed", "plague", "dot", "prone", "eye_trauma",
+  "head_trauma", "arm_trauma", "leg_trauma", "heart_trauma",
+  "tail_trauma", "torso_trauma", "faerie_fire", "sleep", "charm", "blind",
 }
 
 local function render_portrait_condition_icon(key, alpha, defer_layout)
@@ -583,7 +858,22 @@ function DD_GUI.update_affect_icons()
     DD_GUI.layout_portrait_condition_icons()
 end
 
-local function new_portrait_icon(name)
+local function configure_portrait_icon_hover(widget, tooltip)
+    local configured = false
+    if widget and type(widget.setToolTip) == "function" then
+      configured = pcall(widget.setToolTip, widget, tooltip, 12)
+    end
+    if not configured and widget and widget.name and
+       type(setLabelToolTip) == "function" then
+      configured = pcall(setLabelToolTip, widget.name, tooltip, 12)
+    end
+
+    if DD_GUI.set_widget_clickthrough then
+      DD_GUI.set_widget_clickthrough(widget, not configured)
+    end
+end
+
+local function new_portrait_icon(name, tooltip)
     local icon = Geyser.Label:new({
       name = name,
       x = 0, y = 0,
@@ -593,23 +883,21 @@ local function new_portrait_icon(name)
       background-color: rgba(0,0,0,0);
       border: 0px;
     ]])
-    if DD_GUI.set_widget_clickthrough then
-      DD_GUI.set_widget_clickthrough(icon, true)
-    end
+    configure_portrait_icon_hover(icon, tooltip)
     icon:hide()
     return icon
 end
 
-local function new_portrait_icon_part(parent, name, part_spec)
+local function new_portrait_icon_part(parent, name, part_spec, tooltip)
     local part = Geyser.Label:new({
       name = name,
-      x = part_spec[2], y = part_spec[3],
-      width = part_spec[4], height = part_spec[5],
+      x = scaled_icon_metric(part_spec[2]),
+      y = scaled_icon_metric(part_spec[3]),
+      width = scaled_icon_metric(part_spec[4], 1),
+      height = scaled_icon_metric(part_spec[5], 1),
     }, parent)
     part:setStyleSheet([[background-color: rgba(0,0,0,0); border: 0px;]])
-    if DD_GUI.set_widget_clickthrough then
-      DD_GUI.set_widget_clickthrough(part, true)
-    end
+    configure_portrait_icon_hover(part, tooltip)
     return part
 end
 
@@ -621,14 +909,14 @@ local function build_portrait_condition_icons()
     for _, key in ipairs(PORTRAIT_ICON_BUILD_ORDER) do
       local spec = PORTRAIT_ICON_SPECS[key]
       local root_name = "DD_GUI." .. spec.root
-      local icon = new_portrait_icon(root_name)
+      local icon = new_portrait_icon(root_name, spec.tooltip)
       DD_GUI[spec.root] = icon
       local surfaces = {icon}
 
       for _, part_spec in ipairs(spec.parts) do
         local suffix = part_spec[1]
         local part = new_portrait_icon_part(icon,
-          root_name .. "." .. suffix, part_spec)
+          root_name .. "." .. suffix, part_spec, spec.tooltip)
         DD_GUI[spec.root .. suffix] = part
         table.insert(surfaces, part)
       end

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.121"
+DD_GUI.package_version = "0.0.122"
 
 -- DD_GUI owns the native mapper surface. Remove the legacy generic mapper as
 -- early as possible so its profile-level map/autosave.dat is not loaded beside


### PR DESCRIPTION
Adds 12-second player-facing tooltips to every portrait condition surface, enlarges the artwork to scalable 18px Qt-rendered symbols, and changes the grid to five columns with upward wrapping. Expands coverage to plague, damage over time, prone, seven trauma flags, faerie fire, sleep, and charm for 23 total conditions. Updates README documentation and bumps DD_GUI to 0.0.122. Validation includes Lua parsing, a 23-condition Fengari simulation covering exact GMCP values, tooltips, fades, geometry, and five-row wrapping, package build/upload, and matching production SHA-256.