### PR TITLE
Fix mapper click routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,9 @@ data. The main panels are:
   frame as the main panels, and keyboard/button movement uses the same brief
   border-only pressed highlight.
 
-  Mapper speedwalks now wait for each expected GMCP room transition, stop when
-  movement fails or diverges from the known route, include current
+  Clicking a reachable room in the native mapper starts an automatic walk to
+  it. Mapper speedwalks wait for each expected GMCP room transition, stop when
+  movement fails or genuinely diverges from the known route, include current
   closed/locked door commands, and use the richer exit costs when available.
   `ddmap fast` restores immediate route sending; `ddmap safe` restores
   confirmation-based routing. The existing `[Exits: ...]` parser remains a

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.123",
+  "version": "0.0.124",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/GMCPMapper.lua
+++ b/src/scripts/DD/GMCPMapper.lua
@@ -1175,13 +1175,35 @@ function load_dd_mapper()
                         return false
                 end
 
-                local path = {}
+                local encountered = {}
                 local directions = {}
                 for index, value in ipairs(speedWalkPath or {}) do
-                        path[index] = tonumber(value)
+                        encountered[index] = tonumber(value)
                 end
                 for index, value in ipairs(speedWalkDir or {}) do
                         directions[index] = value
+                end
+
+                -- Mudlet normally returns only the rooms encountered after
+                -- leaving the source room. Some older mapper integrations
+                -- included the source, so accept both shapes and normalise to
+                -- one room at each end of every direction.
+                local path = {}
+                if #encountered == #directions then
+                        path[1] = current
+                        for index, value in ipairs(encountered) do
+                                path[index + 1] = value
+                        end
+                elseif #encountered == #directions + 1 and encountered[1] == current then
+                        path = encountered
+                else
+                        mapper_echo("The mapper returned an invalid route.", true)
+                        return false
+                end
+
+                if path[#path] ~= room_id then
+                        mapper_echo("The mapper returned an incomplete route.", true)
+                        return false
                 end
 
                 local actions = {}

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.123"
+DD_GUI.package_version = "0.0.124"
 
 -- DD_GUI owns the native mapper surface. Remove the legacy generic mapper as
 -- early as possible so its profile-level map/autosave.dat is not loaded beside


### PR DESCRIPTION
## What changed

- Normalise Mudlet's destination-only `speedWalkPath` by prepending the current room.
- Retain compatibility with source-inclusive path tables.
- Restore adjacent-room and multi-room click-to-walk routing without false divergence errors.
- Document click-to-walk behavior and release DD_GUI 0.0.124.

## Root cause

DD_GUI treated the first room returned by Mudlet as the route source. Mudlet actually returns the rooms encountered after leaving the source, so DD_GUI skipped the first leg and rejected the correct first arrival as a route divergence.

## Validation

- Lua syntax parsed with `luaparse`.
- Fengari route mocks passed for destination-only, source-inclusive, and adjacent-room paths.
- `build-and-upload.ps1` completed successfully.
- The uploaded production package SHA-256 matches the local build.