### PR TITLE
Harden exit state routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ data. The main panels are:
   (removed), `1` (open), `2` (closed), or `3` (locked); up/down states remain
   available to compass routing through the GUI's per-room cache because older
   Mudlet native door drawing only supports compass-plane directions. Exit
+  states from DD4's complete `Room.Info.exit_details` snapshot are the
+  authoritative source for compass and speedwalk decisions. The snapshot is
+  applied by room vnum as soon as `gmcp.Room.Info` arrives, including during
+  bootstrap and reconnect, and an empty `exit_details` object deliberately
+  clears stale door state. Legacy destination-only `Room.Info.exits` data is
+  never interpreted as a door state.
   movement costs bias native pathfinding through per-exit weights, and arrival
   metadata repairs the previous room's outbound link when a newly discovered
   room was previously only an exit stub. DD4 wall exits remain visible as
@@ -167,13 +173,18 @@ data. The main panels are:
   clickable navigation compass. The compass includes `EQ` for equipment and
   `SCAN` for scanning. Movement buttons briefly highlight their borders while
   leaving the black cell background unchanged. For mapped rooms, movement
-  parses the current MUD `[Exits: ...]` line before sending: plain exits are
-  open, `(direction)` is closed, and `[direction]` is locked. A locked exit
-  sends `unlock`, `open`, then the movement command in sequence; a closed exit
-  sends `open`, then the movement command in sequence. The parsed state is kept per room, with
-  Mudlet mapper door data as a fallback when no current Exits line is
-  available. If neither source has a state, it sends the normal movement
-  command. Status gauges clamp GMCP current values to their reported maximums
+  uses the current room's rich GMCP exit state before sending: `open` sends
+  the direction, `closed` sends `open direction` then the direction, and
+  `locked` sends `unlock direction`, `open direction`, then the direction.
+  Walls are treated as non-routable. The legacy MUD `[Exits: ...]` line is a
+  complete compatibility snapshot when rich GMCP exit data is unavailable:
+  plain exits are open, `(direction)` is closed, and `[direction]` is locked.
+  The parser replaces stale directions instead of merging them forever, and
+  the native Mudlet door table remains a per-direction fallback for older or
+  partial profiles. If a compass or mapper movement still receives a closed,
+  locked, missing-key, or wall response, the attempted direction is corrected
+  immediately for the next attempt. If neither source has a state, it sends
+  the normal movement command. Status gauges clamp GMCP current values to their reported maximums
   and keep their fills inside their parent panels. Enemy hitpoints are rendered
   in a dedicated overlay below the enemy text, so the red gauge remains visible
   when the enemy console refreshes and disappears outside combat. The compass has the same shared braided

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.124",
+  "version": "0.0.125",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/CompassExits.lua
+++ b/src/scripts/DD/CompassExits.lua
@@ -1,6 +1,7 @@
 DD_GUI = DD_GUI or {}
 
 DD_GUI.exit_status_by_room = DD_GUI.exit_status_by_room or {}
+DD_GUI.exit_status_meta_by_room = DD_GUI.exit_status_meta_by_room or {}
 
 local compass_exit_aliases = {
         n = "n",
@@ -27,69 +28,334 @@ local compass_exit_aliases = {
         out = "out",
 }
 
-local function compass_current_room_id()
-        if type(map) == "table" and type(map.room_info) == "table" then
-                return tonumber(map.room_info.vnum)
+local function copy_statuses(statuses)
+        local copy = {}
+        for direction, status in pairs(statuses or {}) do
+                local short = compass_exit_aliases[tostring(direction):lower()]
+                if short then
+                        copy[short] = tonumber(status) or 0
+                end
+        end
+        return copy
+end
+
+local function normalise_status(value)
+        if type(value) == "table" then
+                if value.wall == true or value.blocked == true then
+                        return 4
+                elseif value.locked == true or value.is_locked == true then
+                        return 3
+                elseif value.closed == true or value.is_closed == true then
+                        return 2
+                elseif value.open == true or value.is_open == true then
+                        return 1
+                end
+                value = value.status or value.state or value.door_state
         end
 
+        local numeric = tonumber(value)
+        if numeric then
+                return math.max(0, math.min(4, math.floor(numeric)))
+        end
+
+        local text = tostring(value or ""):lower():gsub("^%s+", ""):gsub("%s+$", "")
+        if text == "wall" or text == "blocked" then
+                return 4
+        elseif text == "locked" or text == "lock" then
+                return 3
+        elseif text == "closed" or text == "close" then
+                return 2
+        elseif text == "open" or text == "opened" then
+                return 1
+        end
+        return nil
+end
+
+local function current_room_id()
+        -- GMCP is the freshest source during a room transition. The mapper
+        -- cache can be one event behind while the room text is still arriving.
         if gmcp and gmcp.Room and type(gmcp.Room.Info) == "table" then
-                return tonumber(gmcp.Room.Info.vnum)
+                local room_id = tonumber(gmcp.Room.Info.vnum)
+                if room_id then
+                        return room_id
+                end
+        end
+
+        if type(map) == "table" and type(map.room_info) == "table" then
+                return tonumber(map.room_info.vnum)
         end
 
         return nil
 end
 
-function DD_GUI.update_exit_status(exit_text)
+local function gmcp_exit_statuses(info)
+        if type(info) ~= "table" then
+                return {}, false
+        end
+
         local statuses = {}
-        local text = tostring(exit_text or "")
-        text = text:gsub("\27%[[0-9;]*m", "")
-        local room_id = compass_current_room_id()
-        local previous = room_id and DD_GUI.exit_status_by_room[room_id]
-        if type(previous) == "table" then
-                for direction, status in pairs(previous) do
-                        statuses[direction] = status
+        local details = info.exit_details or info.exitDetails or info.exit_detail
+        local has_rich_payload = type(details) == "table"
+        local has_rich_status = false
+
+        local function read(source, allow_scalar)
+                if type(source) ~= "table" then
+                        return
+                end
+                for direction, value in pairs(source) do
+                        -- Room.Info.exits is historically a direction -> room
+                        -- id table. Only its nested rich form may contribute
+                        -- a scalar state; otherwise a destination such as
+                        -- "3025" would look like a blocked status.
+                        if not allow_scalar and type(value) ~= "table" then
+                                value = nil
+                        end
+                        local short = compass_exit_aliases[tostring(direction):lower()]
+                        local status = short and normalise_status(value)
+                        if short and status ~= nil then
+                                statuses[short] = status
+                                has_rich_status = true
+                        end
                 end
         end
 
-        for token in text:gmatch("%S+") do
-                local first = token:sub(1, 1)
-                local last = token:sub(-1)
-                local status = 1
+        read(details, true)
 
-                if first == "(" and last == ")" then
-                        status = 2
-                elseif first == "[" and last == "]" then
-                        status = 3
-                end
-
-                local direction = token
-                if first == "(" or first == "[" then
-                        direction = direction:sub(2)
-                end
-                if last == ")" or last == "]" then
-                        direction = direction:sub(1, -2)
-                end
-                direction = direction:lower()
-                local compass_direction = compass_exit_aliases[direction]
-                if compass_direction then
-                        statuses[compass_direction] = status
-                end
+        -- Keep compatibility with a future/alternate Room.Info shape that
+        -- embeds state directly in `exits` instead of `exit_details`.
+        if not has_rich_payload or not has_rich_status then
+                read(info.exits, false)
         end
 
-        if room_id then
-                DD_GUI.exit_status_by_room[room_id] = statuses
-                DD_GUI.exit_status_room = room_id
-                if DD_GUI.mapper_set_exit_status then
-                        DD_GUI.mapper_set_exit_status(room_id, statuses)
+        -- DD4 sends exit_details as a complete object, including an empty
+        -- object for a room with no traversable exits. That is authoritative
+        -- even when there are no individual statuses to copy.
+        return statuses, has_rich_payload or has_rich_status
+end
+
+local function apply_statuses(room_id, statuses, source, complete)
+        room_id = tonumber(room_id)
+        if not room_id or type(statuses) ~= "table" then
+                return false
+        end
+
+        local metadata = DD_GUI.exit_status_meta_by_room[room_id]
+        if source == "text" and metadata and metadata.source == "gmcp" and
+           metadata.complete then
+                -- The legacy [Exits: ...] line must never overwrite DD4's
+                -- richer, authoritative door state.
+                return false
+        end
+
+        local previous = DD_GUI.exit_status_by_room[room_id]
+        local normalised = {}
+        if complete == true then
+                normalised = copy_statuses(statuses)
+        else
+                normalised = copy_statuses(previous)
+                for direction, status in pairs(copy_statuses(statuses)) do
+                        normalised[direction] = status
                 end
+        end
+        DD_GUI.exit_status_by_room[room_id] = normalised
+        DD_GUI.exit_status_meta_by_room[room_id] = {
+                source = source or "unknown",
+                complete = complete == true,
+        }
+        DD_GUI.exit_status_room = room_id
+
+        if DD_GUI.mapper_set_exit_status then
+                pcall(
+                        DD_GUI.mapper_set_exit_status,
+                        room_id,
+                        normalised,
+                        source ~= "gmcp",
+                        complete == true,
+                        previous
+                )
+        end
+        return true
+end
+
+-- GMCPMapper uses this same path when it reconciles a fresh Room.Info
+-- snapshot. Keep it public so the mapper and the compass cannot drift apart.
+DD_GUI.apply_exit_status = apply_statuses
+
+local function clear_pending_exit_move()
+        if DD_GUI.exit_move_timer and type(killTimer) == "function" then
+                pcall(killTimer, DD_GUI.exit_move_timer)
+        end
+        DD_GUI.exit_move_timer = nil
+        DD_GUI.pending_exit_move = nil
+end
+
+function DD_GUI.note_exit_move(direction, room_id)
+        local short = compass_exit_aliases[tostring(direction or ""):lower()]
+        local source_room = tonumber(room_id) or current_room_id()
+        if not short or not source_room then
+                return false
+        end
+
+        clear_pending_exit_move()
+        DD_GUI.pending_exit_move = {
+                room_id = source_room,
+                direction = short,
+        }
+        if type(tempTimer) == "function" then
+                DD_GUI.exit_move_timer = tempTimer(3, function()
+                        clear_pending_exit_move()
+                end)
+        end
+        return true
+end
+
+function DD_GUI.clear_pending_exit_move(current_room)
+        local pending = DD_GUI.pending_exit_move
+        if not pending then
+                return
+        end
+        if current_room == nil or tonumber(current_room) ~= pending.room_id then
+                clear_pending_exit_move()
         end
 end
 
-if not DD_GUI.exit_status_event_handler then
-        DD_GUI.exit_status_event_handler = registerAnonymousEventHandler(
+function DD_GUI.mark_pending_exit_failed(state)
+        local pending = DD_GUI.pending_exit_move
+        local status = normalise_status(state)
+        if not pending or not status then
+                return false
+        end
+        apply_statuses(
+                pending.room_id,
+                {[pending.direction] = status},
+                "failure",
+                false
+        )
+        clear_pending_exit_move()
+        return true
+end
+
+function DD_GUI.refresh_exit_status_from_gmcp()
+        local info = gmcp and gmcp.Room and gmcp.Room.Info
+        local room_id = type(info) == "table" and tonumber(info.vnum)
+        if not room_id then
+                return false
+        end
+
+        DD_GUI.clear_pending_exit_move(room_id)
+
+        local statuses, complete = gmcp_exit_statuses(info)
+        if complete then
+                return apply_statuses(room_id, statuses, "gmcp", true)
+        end
+
+        -- Do not let a rich snapshot from an earlier connection suppress the
+        -- text fallback when this session is using an older/partial payload.
+        local metadata = DD_GUI.exit_status_meta_by_room[room_id]
+        if metadata and metadata.source == "gmcp" then
+                DD_GUI.exit_status_meta_by_room[room_id] = nil
+                DD_GUI.exit_status_by_room[room_id] = nil
+        end
+        return false
+end
+
+function DD_GUI.update_exit_status(exit_text, complete_snapshot)
+        local room_id = current_room_id()
+        if not room_id then
+                return false
+        end
+
+        local metadata = DD_GUI.exit_status_meta_by_room[room_id]
+        if metadata and metadata.source == "gmcp" and metadata.complete then
+                return false
+        end
+
+        local text = tostring(exit_text or "")
+        text = text:gsub("\27%[[0-9;]*m", ""):lower()
+
+        -- [Exits: ...] is a complete snapshot. Start empty so a door which
+        -- was just opened/closed cannot retain its previous state forever.
+        local statuses = {}
+        local found = 0
+
+        local function record(direction, status)
+                local short = compass_exit_aliases[direction:lower()]
+                if short then
+                        statuses[short] = status
+                        found = found + 1
+                end
+        end
+
+        for direction in text:gmatch("%(%s*([%a]+)%s*%)") do
+                record(direction, 2)
+        end
+        for direction in text:gmatch("%[%s*([%a]+)%s*%]") do
+                record(direction, 3)
+        end
+
+        -- Remove marked tokens before reading plain exits, so `(down)` and
+        -- `[east]` cannot be reclassified as open exits.
+        local plain_text = text:gsub("%(%s*[%a]+%s*%)", " ")
+                :gsub("%[%s*[%a]+%s*%]", " ")
+        for token in plain_text:gmatch("%S+") do
+                token = token:gsub("^[,;:]+", ""):gsub("[,;%.]+$", "")
+                token = token:gsub("^exits:?$", "")
+                local short = compass_exit_aliases[token]
+                if short then
+                        statuses[short] = 1
+                        found = found + 1
+                end
+        end
+
+        if found == 0 and complete_snapshot ~= true then
+                return false
+        end
+        return apply_statuses(room_id, statuses, "text", true)
+end
+
+local function kill_handler(handler_id)
+        if handler_id and type(killAnonymousEventHandler) == "function" then
+                pcall(killAnonymousEventHandler, handler_id)
+        end
+end
+
+-- Replace handlers left by an older live package tree. This matters during
+-- reinstallgui/bootstrap, where globals survive package removal.
+kill_handler(DD_GUI.exit_status_event_handler)
+for _, handler_id in pairs(DD_GUI.exit_status_handlers or {}) do
+        kill_handler(handler_id)
+end
+if DD_GUI.exit_status_refresh_timer and type(killTimer) == "function" then
+        pcall(killTimer, DD_GUI.exit_status_refresh_timer)
+end
+DD_GUI.exit_status_refresh_timer = nil
+
+DD_GUI.exit_status_handlers = {}
+if type(registerAnonymousEventHandler) == "function" then
+        DD_GUI.exit_status_handlers.room = registerAnonymousEventHandler(
                 "gmcp.Room.Info",
                 function()
-                        DD_GUI.exit_status_room = nil
+                        DD_GUI.refresh_exit_status_from_gmcp()
+                end
+        )
+        DD_GUI.exit_status_event_handler = DD_GUI.exit_status_handlers.room
+
+        DD_GUI.exit_status_handlers.connection = registerAnonymousEventHandler(
+                "sysConnectionEvent",
+                function()
+                        clear_pending_exit_move()
+                        DD_GUI.refresh_exit_status_from_gmcp()
+                        if type(tempTimer) == "function" then
+                                if DD_GUI.exit_status_refresh_timer and type(killTimer) == "function" then
+                                        pcall(killTimer, DD_GUI.exit_status_refresh_timer)
+                                end
+                                DD_GUI.exit_status_refresh_timer = tempTimer(0.1, function()
+                                        DD_GUI.exit_status_refresh_timer = nil
+                                        DD_GUI.refresh_exit_status_from_gmcp()
+                                end)
+                        end
                 end
         )
 end
+
+DD_GUI.refresh_exit_status_from_gmcp()

--- a/src/scripts/DD/GMCPMapper.lua
+++ b/src/scripts/DD/GMCPMapper.lua
@@ -103,9 +103,24 @@ function load_dd_mapper()
                 return move_vectors[short_direction(direction)]
         end
 
+        local function current_room_id()
+                if gmcp and gmcp.Room and type(gmcp.Room.Info) == "table" then
+                        local room_id = dd_mapper_number(gmcp.Room.Info.vnum)
+                        if room_id then
+                                return room_id
+                        end
+                end
+                return map.room_info and dd_mapper_number(map.room_info.vnum)
+        end
+
         local function normalise_door_status(value)
                 if type(value) == "number" then
-                        return math.max(0, math.min(3, math.floor(value)))
+                        return math.max(0, math.min(4, math.floor(value)))
+                end
+
+                local numeric = tonumber(value)
+                if numeric then
+                        return math.max(0, math.min(4, math.floor(numeric)))
                 end
 
                 local text = tostring(value or ""):lower()
@@ -137,10 +152,22 @@ function load_dd_mapper()
                                 value.to or value.vnum or value.room or value.id or value.destination
                         )
                         local raw_status = value.status or value.state or value.door_state
+                        if raw_status == nil then
+                                if value.wall == true or value.blocked == true then
+                                        raw_status = "wall"
+                                elseif value.locked == true or value.is_locked == true then
+                                        raw_status = "locked"
+                                elseif value.closed == true or value.is_closed == true then
+                                        raw_status = "closed"
+                                elseif value.open == true or value.is_open == true then
+                                        raw_status = "open"
+                                end
+                        end
                         if raw_status ~= nil then
                                 result.status = normalise_door_status(raw_status)
                                 result.has_status = true
-                                result.blocked = tostring(raw_status):lower() == "wall" or
+                                result.blocked = result.status == 4 or
+                                        tostring(raw_status):lower() == "wall" or
                                         tostring(raw_status):lower() == "blocked"
                         end
                         result.door = value.door or value.door_name
@@ -248,11 +275,13 @@ function load_dd_mapper()
                 end
 
                 local exits = {}
+                local has_exit_status = false
                 if type(source.exits) == "table" then
                         for direction, value in pairs(source.exits) do
                                 local short = short_direction(direction)
                                 if direction_names[short] then
                                         exits[short] = normalise_exit(value)
+                                        has_exit_status = has_exit_status or exits[short].has_status
                                 end
                         end
                 end
@@ -264,6 +293,10 @@ function load_dd_mapper()
                 if type(exit_details) == "table" then
                         for direction, value in pairs(exit_details) do
                                 merge_exit_detail(exits, direction, value)
+                                local detail = exits[short_direction(direction)]
+                                if detail then
+                                        has_exit_status = has_exit_status or detail.has_status
+                                end
                         end
                 end
 
@@ -283,6 +316,7 @@ function load_dd_mapper()
                         flags = source.flags,
                         tags = normalise_tags(source.tags),
                         exits = exits,
+                        exit_status_complete = type(exit_details) == "table" or has_exit_status,
                         special_exits = normalise_special_exits(
                                 source.special_exits or source.specialExits or source.special_exit_details
                         ),
@@ -618,7 +652,11 @@ function load_dd_mapper()
                         w = true, s = true, se = true, sw = true,
                 }
                 if present and native_door_directions[short] and type(setDoor) == "function" then
-                        local native_status = math.max(0, math.min(3, tonumber(status) or 0))
+                        local numeric_status = tonumber(status) or 0
+                        -- A wall is a mapper stub, not a locked door. Clear
+                        -- any old native door marker if the room was rebuilt.
+                        local native_status = numeric_status == 4 and 0 or
+                                math.max(0, math.min(3, numeric_status))
                         pcall(setDoor, room_id, short, native_status)
                 end
         end
@@ -636,7 +674,17 @@ function load_dd_mapper()
                 end
 
                 DD_GUI.exit_status_by_room = DD_GUI.exit_status_by_room or {}
-                DD_GUI.exit_status_by_room[info.vnum] = DD_GUI.exit_status_by_room[info.vnum] or {}
+                if info.exit_status_complete and DD_GUI.apply_exit_status then
+                        local snapshot = {}
+                        for direction, exit in pairs(info.exits) do
+                                if exit.has_status then
+                                        snapshot[direction] = exit.status
+                                end
+                        end
+                        DD_GUI.apply_exit_status(info.vnum, snapshot, "gmcp", true)
+                end
+                DD_GUI.exit_status_by_room[info.vnum] =
+                        DD_GUI.exit_status_by_room[info.vnum] or {}
                 for direction, exit in pairs(info.exits) do
                         if exit.blocked then
                                 pcall(setExitStub, info.vnum, direction, true)
@@ -658,7 +706,11 @@ function load_dd_mapper()
                                         tostring(exit.door or "") == "" then
                                         native_status = 0
                                 end
-                                set_exit_door(info.vnum, direction, native_status, true)
+                                if exit.status == 4 then
+                                        set_exit_door(info.vnum, direction, 0, true)
+                                else
+                                        set_exit_door(info.vnum, direction, native_status, true)
+                                end
                         end
                         if exit.cost and type(setExitWeight) == "function" then
                                 local cost_weight = math.max(0, math.floor(exit.cost) - 1)
@@ -1128,7 +1180,10 @@ function load_dd_mapper()
                 end
 
                 route.awaiting = action.to
-                route.last_room = map.room_info.vnum
+                route.last_room = current_room_id() or map.room_info.vnum
+                if DD_GUI.note_exit_move then
+                        DD_GUI.note_exit_move(action.direction, action.from)
+                end
                 local commands = movement_commands(action.from, action.direction)
                 if #commands == 0 then
                         stop_route("Speedwalk stopped: the next exit is a wall.")
@@ -1160,7 +1215,7 @@ function load_dd_mapper()
                         return false
                 end
 
-                local current = tonumber(map.room_info.vnum)
+                local current = current_room_id()
                 if not current then
                         mapper_echo("The current room is not known yet.", true)
                         return false
@@ -1236,6 +1291,9 @@ function load_dd_mapper()
                 map.walkDirs = directions
                 if not map.configs.dd_safe_speedwalk then
                         for _, action in ipairs(actions) do
+                                if DD_GUI.note_exit_move then
+                                        DD_GUI.note_exit_move(action.direction, action.from)
+                                end
                                 for _, command in ipairs(movement_commands(action.from, action.direction)) do
                                         send(command)
                                 end
@@ -1263,18 +1321,36 @@ function load_dd_mapper()
                 end
         end
 
-        function DD_GUI.mapper_set_exit_status(room_id, statuses)
+        function DD_GUI.mapper_set_exit_status(room_id, statuses, draw_doors,
+                                                complete, previous)
                 room_id = tonumber(room_id)
                 if not room_id or type(statuses) ~= "table" then
                         return
                 end
                 DD_GUI.exit_status_by_room = DD_GUI.exit_status_by_room or {}
-                DD_GUI.exit_status_by_room[room_id] = DD_GUI.exit_status_by_room[room_id] or {}
+                local old_statuses = previous or DD_GUI.exit_status_by_room[room_id] or {}
+                if complete == true then
+                        for direction in pairs(old_statuses) do
+                                if statuses[direction] == nil then
+                                        set_exit_door(room_id, direction, 0, true)
+                                end
+                        end
+                        DD_GUI.exit_status_by_room[room_id] = {}
+                end
+                DD_GUI.exit_status_by_room[room_id] =
+                        DD_GUI.exit_status_by_room[room_id] or {}
                 for direction, status in pairs(statuses) do
                         local short = short_direction(direction)
                         local numeric_status = tonumber(status) or 0
                         DD_GUI.exit_status_by_room[room_id][short] = numeric_status
-                        set_exit_door(room_id, short, numeric_status, true)
+                        if draw_doors ~= false then
+                                set_exit_door(
+                                        room_id,
+                                        short,
+                                        numeric_status == 4 and 0 or numeric_status,
+                                        true
+                                )
+                        end
                 end
         end
 

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -398,6 +398,9 @@ local function dd_gui_bootstrap_impl()
         end
         initialise_mapper()
         load_dd_mapper()
+        if DD_GUI.refresh_exit_status_from_gmcp then
+                DD_GUI.refresh_exit_status_from_gmcp()
+        end
         if DD_GUI.apply_mapper_theme then
                 DD_GUI.apply_mapper_theme()
         end

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -245,19 +245,25 @@ function build_compass()
 
   function compass.door_status(name)
     local direction = compass.door_directions[name]
-    if not direction or type(map) ~= "table" or
-       type(map.room_info) ~= "table" then
+    if not direction then
       return nil
     end
 
-    local room_id = tonumber(map.room_info.vnum)
+    local room_id
+    if gmcp and gmcp.Room and type(gmcp.Room.Info) == "table" then
+      room_id = tonumber(gmcp.Room.Info.vnum)
+    end
+    if not room_id and type(map) == "table" and
+       type(map.room_info) == "table" then
+      room_id = tonumber(map.room_info.vnum)
+    end
     if not room_id then
       return nil
     end
 
     local parsed_status = DD_GUI.exit_status_by_room and
       DD_GUI.exit_status_by_room[room_id]
-    if parsed_status then
+    if parsed_status and parsed_status[name] ~= nil then
       return tonumber(parsed_status[name]) or 0
     end
 
@@ -282,10 +288,19 @@ function build_compass()
     if status == 4 then
       return
     elseif status == 3 then
+      if DD_GUI.note_exit_move then
+        DD_GUI.note_exit_move(name)
+      end
       sendAll(0.2, "unlock " .. command, "open " .. command, command)
     elseif status == 2 then
+      if DD_GUI.note_exit_move then
+        DD_GUI.note_exit_move(name)
+      end
       sendAll(0.2, "open " .. command, command)
     else
+      if DD_GUI.note_exit_move then
+        DD_GUI.note_exit_move(name)
+      end
       send(command)
     end
   end

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.124"
+DD_GUI.package_version = "0.0.125"
 
 -- DD_GUI owns the native mapper surface. Remove the legacy generic mapper as
 -- early as possible so its profile-level map/autosave.dat is not loaded beside

--- a/src/triggers/DD/Mapping/FailedMove.lua
+++ b/src/triggers/DD/Mapping/FailedMove.lua
@@ -1,1 +1,13 @@
+local line = tostring(matches and matches[1] or ""):lower()
+if DD_GUI and DD_GUI.mark_pending_exit_failed then
+        if string.find(line, "lack the key", 1, true) or
+           string.find(line, "locked", 1, true) then
+                DD_GUI.mark_pending_exit_failed("locked")
+        elseif string.find(line, "wall blocks", 1, true) then
+                DD_GUI.mark_pending_exit_failed("wall")
+        elseif string.find(line, " is closed", 1, true) or
+               string.find(line, " are closed", 1, true) then
+                DD_GUI.mark_pending_exit_failed("closed")
+        end
+end
 raiseEvent("onMoveFail")

--- a/src/triggers/DD/Mapping/UpdateExitStatus.lua
+++ b/src/triggers/DD/Mapping/UpdateExitStatus.lua
@@ -1,3 +1,3 @@
 if DD_GUI and DD_GUI.update_exit_status then
-        DD_GUI.update_exit_status(matches[2])
+        DD_GUI.update_exit_status(matches[2], true)
 end

--- a/src/triggers/DD/Mapping/triggers.json
+++ b/src/triggers/DD/Mapping/triggers.json
@@ -13,6 +13,14 @@
                         {
                                 "pattern": "^It\\'s locked\\.$",
                                 "type": "regex"
+                        },
+                        {
+                                "pattern": "^The .+ is closed\\.$",
+                                "type": "regex"
+                        },
+                        {
+                                "pattern": "^The .+ are closed\\.$",
+                                "type": "regex"
                         }
                 ]
         },


### PR DESCRIPTION
## What changed

- Treat DD4 `Room.Info.exit_details` as the authoritative per-room exit-state snapshot.
- Reconcile complete GMCP and legacy text snapshots without retaining stale directions, including empty-exit rooms.
- Refresh exit state during bootstrap, reconnect, and live room updates; prefer live GMCP room identity in compass and mapper routing.
- Correct the cached direction after a compass or safe speedwalk attempt reports a closed door, lock, missing key, or wall.
- Preserve native mapper fallback behavior for older or partial profiles and document the new routing behavior.

## Validation

- Lua syntax checks passed for all changed Lua files.
- `triggers.json` parses successfully.
- Isolated Fengari regression checks passed for rich GMCP, legacy exits, text fallback, stale-state replacement, failed movement correction, and reconnect refresh.
- `./scripts/build-and-upload.ps1` completed successfully for DD_GUI `0.0.125`.
- The production package matches the local build by SHA-256.
