### PR TITLE
Tile portrait condition icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,11 @@ data. The main panels are:
   `THIRST` and `HUNGER` gauges from `Char.Vitals`. The gauges are hidden for
   Vampires, whose DD4 condition values do not decay, and on older servers that
   do not provide the new current/maximum fields. Character conditions appear
-  in a compact portrait grid that starts at the lower-right, fills five icons
-  right-to-left, and wraps upward. Icons retain their first-detected activation
-  order while active and compact when one clears. The tankard's brightness
+  in a compact portrait grid of touching square black tiles with dark-red edges
+  that starts at the lower-right, fills five icons right-to-left, and wraps
+  upward. The tile and its icon artwork share the same affect-strength alpha.
+  Icons retain their first-detected activation order while active and compact when
+  one clears. The tankard's brightness
   follows `drunk/maxdrunk`. Affect icons cover poison/nausea or `AFF_POISON`
   (`gives = "poison"`), `AFF_HOLD` (`hold`), `AFF_CURSE` (`curse`), `AFF_SLOW`
   (`slow`), `AFF_CONFUSION` (`confused`), `AFF_DAZED` (`dazed`),

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.125",
+  "version": "0.0.126",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/CharsheetConsole.lua
+++ b/src/scripts/DD/CharsheetConsole.lua
@@ -65,10 +65,18 @@ end
 
 local PORTRAIT_ICON_BASE_SIZE = 15
 local PORTRAIT_ICON_SIZE = 18
-local PORTRAIT_ICON_GAP = 1
+local PORTRAIT_ICON_GAP = 0
 local PORTRAIT_ICON_COLUMNS = 5
 local PORTRAIT_ICON_RIGHT = 2
 local PORTRAIT_ICON_BOTTOM = 3
+local PORTRAIT_ICON_TILE_STYLE = {
+    fill = {0, 0, 0},
+    fill_opacity = 0.78,
+    border = {104, 18, 29},
+    border_opacity = 0.95,
+    border_width = 1,
+    radius = 0,
+}
 
 local function perceptual_icon_alpha(value, maximum)
     value = tonumber(value) or 0
@@ -803,6 +811,9 @@ local function render_portrait_condition_icon(key, alpha, defer_layout)
 
     alpha = tonumber(alpha) or 0
     if alpha > 0 and state.alpha ~= alpha then
+      -- The tile is part of the condition's visual state, so its fill and
+      -- edge fade with the same duration/intensity as the icon artwork.
+      style_icon_part(state.icon, alpha, PORTRAIT_ICON_TILE_STYLE)
       for _, part_spec in ipairs(spec.parts) do
         style_icon_part(DD_GUI[spec.root .. part_spec[1]], alpha,
           part_spec[6])
@@ -886,6 +897,7 @@ local function new_portrait_icon(name)
     icon:setStyleSheet([[
       background-color: rgba(0,0,0,0);
       border: 0px;
+      border-radius: 0px;
     ]])
     if DD_GUI.set_widget_clickthrough then
       DD_GUI.set_widget_clickthrough(icon, false)

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.125"
+DD_GUI.package_version = "0.0.126"
 
 -- DD_GUI owns the native mapper surface. Remove the legacy generic mapper as
 -- early as possible so its profile-level map/autosave.dat is not loaded beside


### PR DESCRIPTION
## What changed

- Put portrait condition overlays on touching 18x18 square tiles.
- Use a shared black tile with a subdued dark-red edge for the condition grid.
- Fade the tile fill and edge with the same alpha used by the affect artwork.
- Keep the existing lower-right anchor, five-column wrapping, activation order, and tooltips.

## Validation

- `CharsheetConsole.lua` passed Lua syntax validation.
- `./scripts/build-and-upload.ps1` completed successfully for DD_GUI `0.0.126`.
- The production package matches the local build by SHA-256.
