### PR TITLE
Remove redundant character rage text

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ data. The main panels are:
   rage resource is the blood reserve. Werewolf rage rises in wolf or direwolf
   form, drains outside those forms, and becomes compulsive above 90. At level
   100 and above, ordinary hunger/thirst bars are hidden while a Vampire's
-  `BLOOD` or a Werewolf's `RAGE` remains available. The gauges are also hidden
-  on older servers that do not provide the relevant current/maximum fields.
+  `BLOOD` or a Werewolf's `RAGE` remains available; these gauges are the sole
+  character-sheet display for those resources. The gauges are also hidden on
+  older servers that do not provide the relevant current/maximum fields.
   Character conditions appear
   in a compact portrait grid of touching 19px square black tiles with dark-red edges
   that starts at the lower-right, fills five icons right-to-left, and wraps

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.129",
+  "version": "0.0.130",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/UpdateFunctions/update_vitals.lua
+++ b/src/scripts/DD/UpdateFunctions/update_vitals.lua
@@ -252,16 +252,6 @@ if (current_affect_name() == "mist walk")  then
     )
 end
 
-if (gmcp.Char.Base.subclass == "Werewolf") or (gmcp.Char.Base.subclass == "Vampire") then
-  CharsheetConsole:cecho(
-    "<white>"
-    ..string.format("                <white>Rage:  <red>%s<reset>/<red>%s<reset>\n",
-        gmcp.Char.Vitals.rage,
-        gmcp.Char.Vitals.maxrage)
-    .."<reset>"
-  )
-end
-
 CharsheetConsole:cecho(""
     ..string.format("\n                <white>Str: <cyan>%s<reset>(<ansi_cyan>%s<reset>)",
         gmcp.Char.Stats.str_mod,

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -3,7 +3,7 @@ mudlet = mudlet or {}
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.129"
+DD_GUI.package_version = "0.0.130"
 
 -- DD_GUI owns the native mapper surface. Remove the legacy generic mapper as
 -- early as possible so its profile-level map/autosave.dat is not loaded beside


### PR DESCRIPTION
## Summary
- remove the legacy character-sheet Rage current/max text
- keep Vampire BLOOD and Werewolf RAGE gauges as the resource display
- update README and bump DD_GUI to 0.0.130

## Verification
- .\\scripts\\build-and-upload.ps1 completed successfully
- package uploaded as DD_GUI 0.0.130
- git diff --check passed