### PR TITLE
Quarantine generic mapper and shade gauges

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ data. The main panels are:
   it removes Mudlet's conflicting `generic_mapper` package, whose obsolete
   updater can otherwise request a dead `versions.lua` URL. The cleanup now runs
   as soon as the DD_GUI folder loads, before the GUI starts its own mapper, so
-  the generic package's profile-level `map\autosave.dat` is not loaded beside
-  DD_GUI during development reloads. `ddmap cleanup` repeats that removal if a
-  local profile still has the old package installed; restart Mudlet afterward if
-  it was freezing while reading the generic map.
+  the generic package's profile-level `map\\autosave.dat` is not loaded beside
+  DD_GUI during development reloads. DD_GUI also watches package-install events
+  and retries removal if Mudlet or the generic updater attempts to bring the
+  package back. `ddmap cleanup` remains available as a manual forced removal if
+  a local profile still has the old package installed; restart Mudlet afterward
+  if it was freezing while reading the generic map.
   The custom mapper accepts both the original direction-to-vnum exit shape and
   the current richer DD4 payload. Native mapper doors are updated with `0`
   (removed), `1` (open), `2` (closed), or `3` (locked); up/down states remain
@@ -221,8 +223,10 @@ data. The main panels are:
 
   The four footer status gauges use an even inset on all four sides inside the
   shared braided frame, so their black breathing room remains balanced when
-  the gauge band is resized. The character sheet's hunger and thirst bars use
-  the same segmented gauge treatment in a compact two-column row.
+  the gauge band is resized. The character sheet's hunger, thirst, blood, and
+  rage bars use the same segmented gauge treatment in a compact adaptive row.
+  Every filled gauge interpolates from a dim version of its hue at empty to a
+  bright version at full, including enemy hitpoints.
 
 The main MUD console and panel consoles use the profile's shared scrollbar
 style: narrow black tracks have restrained dark-red edges, while the moving
@@ -318,11 +322,13 @@ and workflow changes.
 
 If a local package reload drives Mudlet CPU usage high or leaves it frozen on
 `Reading map ... map\autosave.dat`, the profile is still loading the legacy
-`generic_mapper` package. Run `ddmap cleanup` once the profile responds, close
-and restart Mudlet, and then load DD_GUI again. DD_GUI also guards its own
-persistent `dragons_domain_mapper.dat` load so repeated `bootstrap()` calls do
-not parse the native map repeatedly in one session. If Mudlet cannot respond
-long enough to run the command, make a backup of the profile's
+`generic_mapper` package. Current DD_GUI builds mark the profile as mapper-owned
+and automatically quarantine later generic-mapper install attempts; run
+`ddmap cleanup` once the profile responds only if an older build left the
+package active. Close and restart Mudlet, and then load DD_GUI again. DD_GUI
+also guards its own persistent `dragons_domain_mapper.dat` load so repeated
+`bootstrap()` calls do not parse the native map repeatedly in one session. If
+Mudlet cannot respond long enough to run the command, make a backup of the profile's
 `map\autosave.dat`, rename that file, restart Mudlet, and let DD_GUI rebuild
 from its own persistent map; the generic file is not used by DD_GUI.
 

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.130",
+  "version": "0.0.131",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/DD_GUI.GaugesBox.lua
+++ b/src/scripts/DD/DD_GUI.GaugesBox.lua
@@ -7,6 +7,47 @@ local function gauge_value(value, maximum)
     return math.max(0, math.min(1000, (value * 1000) / maximum))
 end
 
+local function gauge_ratio(value, maximum)
+    value = tonumber(value) or 0
+    maximum = tonumber(maximum) or 0
+    if maximum <= 0 then
+      return 0
+    end
+    return math.max(0, math.min(1, value / maximum))
+end
+
+local function gauge_front_css(color, ratio)
+    local theme = DD_GUI.Theme
+    local fill_color = color
+    if theme and theme.gauge_fill_color then
+      fill_color = theme:gauge_fill_color(color, ratio)
+    end
+
+    if theme and theme.gauge_front_css then
+      return theme:gauge_front_css(fill_color)
+    end
+
+    return string.format([[
+      background-color: %s;
+      border: 1px solid black;
+      border-radius: 0px;
+    ]], fill_color or "grey")
+end
+
+local function update_gauge_fill_color(gauge, color, value, maximum)
+    if not gauge or not gauge.front then
+      return
+    end
+
+    local css = gauge_front_css(color, gauge_ratio(value, maximum))
+    if gauge._dd_gui_fill_css == css then
+      return
+    end
+
+    gauge._dd_gui_fill_css = css
+    gauge.front:setStyleSheet(css)
+end
+
 local function delete_existing_widget(widget)
     if not widget then
       return
@@ -60,11 +101,11 @@ local function new_status_gauge(name, parent, label_text, color, value, maximum,
       border: 1px solid grey;
       border-radius: 0px;
     ]])
-    gauge.front:setStyleSheet(theme and theme:gauge_front_css(color) or [[
-      background-color: grey;
-      border: 1px solid black;
-      border-radius: 0px;
-    ]])
+    local native_set_value = gauge.setValue
+    function gauge:setValue(current, limit, ...)
+      update_gauge_fill_color(self, color, current, limit)
+      return native_set_value(self, current, limit, ...)
+    end
     gauge:setValue(gauge_value(value, maximum), 1000)
     add_gauge_segments(gauge, name)
 

--- a/src/scripts/DD/EnemyConsole.lua
+++ b/src/scripts/DD/EnemyConsole.lua
@@ -496,10 +496,24 @@ function build_enemy_console()
       width = "92%", height = "10%",
     }, DD_GUI.EnemyBox)
     local theme = DD_GUI.Theme
+    local enemy_gauge_color = theme and theme.colors.hp or "rgb(180,0,0)"
+    local function enemy_gauge_front_css(ratio)
+      local fill_color = enemy_gauge_color
+      if theme and theme.gauge_fill_color then
+        fill_color = theme:gauge_fill_color(enemy_gauge_color, ratio)
+      end
+      if theme and theme.gauge_front_css then
+        return theme:gauge_front_css(fill_color)
+      end
+      return string.format(
+        "background-color: %s; border: 1px solid black; border-radius: 0px;",
+        fill_color
+      )
+    end
     EnemyConsoleHitpointsGaugeBackCSS = CSSMan.new(theme and
       theme:gauge_back_css() or [[background-color: rgb(0,0,0);]])
     EnemyConsoleHitpointsGaugeFrontCSS = CSSMan.new(theme and
-      theme:gauge_front_css(theme.colors.hp) or
+      enemy_gauge_front_css(0) or
       [[background-color: rgb(180,0,0);]])
 
     EnemyConsoleHitpointsContainer:setStyleSheet(
@@ -521,6 +535,11 @@ function build_enemy_console()
       local ratio = 0
       if limit > 0 then
         ratio = math.max(0, math.min(1, current / limit))
+      end
+      local front_css = enemy_gauge_front_css(ratio)
+      if self._dd_gui_fill_css ~= front_css then
+        self._dd_gui_fill_css = front_css
+        self:setStyleSheet(front_css)
       end
       -- The track starts at 4% and is 92% wide. Resize the fill against
       -- that track rather than the whole panel, or a full bar overruns the

--- a/src/scripts/DD/GoldBoxTheme.lua
+++ b/src/scripts/DD/GoldBoxTheme.lua
@@ -105,6 +105,34 @@ function Theme:gauge_back_css()
         ]], self.colors.panel_alt, self.colors.dark_frame)
 end
 
+local function parse_rgb(color)
+        local red, green, blue = tostring(color or ""):match(
+                "^%s*rgb%s*%(%s*(%d+)%s*,%s*(%d+)%s*,%s*(%d+)%s*%)%s*$"
+        )
+        if not red then
+                return nil
+        end
+        return tonumber(red), tonumber(green), tonumber(blue)
+end
+
+function Theme:gauge_fill_color(color, ratio)
+        local red, green, blue = parse_rgb(color)
+        if not red then
+                return color
+        end
+
+        ratio = math.max(0, math.min(1, tonumber(ratio) or 0))
+        -- Keep the hue consistent while lifting a full bar toward a bright
+        -- highlight and letting an empty bar settle into the dark frame.
+        local brightness = 0.32 + (ratio * 1.03)
+        return string.format(
+                "rgb(%d,%d,%d)",
+                math.min(255, math.floor((red * brightness) + 0.5)),
+                math.min(255, math.floor((green * brightness) + 0.5)),
+                math.min(255, math.floor((blue * brightness) + 0.5))
+        )
+end
+
 function Theme:gauge_front_css(color)
         return string.format([[
                 background-color: %s;

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -1,43 +1,131 @@
 DD_GUI = DD_GUI or {}
 mudlet = mudlet or {}
+local GENERIC_MAPPER_PACKAGE = "generic_mapper"
+
+-- Register DD_GUI as the profile's mapper before touching the bundled mapper
+-- package. Mudlet ships generic_mapper in new profiles and uses this flag to
+-- recognise that another mapper owns the profile.
+mudlet.mapper_script = true
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.130"
+DD_GUI.package_version = "0.0.131"
+
+-- Return nil when Mudlet cannot answer the package query. In that case the
+-- removal attempt is still made, because leaving the package installed is the
+-- more dangerous failure mode for this profile.
+local function generic_mapper_is_installed()
+        -- getPackages() reports package presence directly. This is more
+        -- reliable than probing version metadata, since the bundled mapper's
+        -- metadata is not guaranteed to contain a version on older Mudlet
+        -- profiles.
+        if type(getPackages) == "function" then
+                local ok, packages = pcall(getPackages)
+                if ok and type(packages) == "table" then
+                        for _, package_name in pairs(packages) do
+                                if tostring(package_name):lower() ==
+                                   GENERIC_MAPPER_PACKAGE then
+                                        return true
+                                end
+                        end
+                        return false
+                end
+        end
+
+        if type(getPackageInfo) ~= "function" then
+                return nil
+        end
+
+        local ok, version = pcall(
+                getPackageInfo,
+                GENERIC_MAPPER_PACKAGE,
+                "version"
+        )
+        if not ok then
+                return nil
+        end
+
+        return version ~= nil and tostring(version) ~= ""
+end
 
 -- DD_GUI owns the native mapper surface. Remove the legacy generic mapper as
 -- early as possible so its profile-level map/autosave.dat is not loaded beside
--- the DD_GUI map during a local development reload.
-function DD_GUI.remove_conflicting_generic_mapper(force)
-        if DD_GUI.generic_mapper_checked and not force then
-                return DD_GUI.generic_mapper_removed == true
+-- the DD_GUI map during a local development reload. This deliberately avoids
+-- a permanent "already checked" cache: the package can be installed again by
+-- Mudlet or by its own updater after the first cleanup.
+function DD_GUI.remove_conflicting_generic_mapper(_force)
+        if DD_GUI.generic_mapper_uninstalling then
+                return false
         end
-
-        DD_GUI.generic_mapper_checked = true
-        DD_GUI.generic_mapper_removed = false
 
         if type(uninstallPackage) ~= "function" then
                 return false
         end
 
-        local installed = true
-        if type(getPackageInfo) == "function" then
-                local ok, version = pcall(getPackageInfo, "generic_mapper", "version")
-                installed = ok and version ~= nil and tostring(version) ~= ""
+        local installed = generic_mapper_is_installed()
+        if installed == false then
+                DD_GUI.generic_mapper_removed = false
+                return false
         end
 
-        if installed then
-                local ok, result = pcall(uninstallPackage, "generic_mapper")
-                DD_GUI.generic_mapper_removed = ok and result ~= false
-                if DD_GUI.generic_mapper_removed and type(cecho) == "function" then
-                        cecho("<yellow>Removed the conflicting generic_mapper package; DD_GUI owns the mapper.<reset>\n")
-                end
+        DD_GUI.generic_mapper_uninstalling = true
+        local ok, result = pcall(
+                uninstallPackage,
+                GENERIC_MAPPER_PACKAGE
+        )
+        DD_GUI.generic_mapper_uninstalling = false
+
+        DD_GUI.generic_mapper_removed = ok and result ~= false
+        if DD_GUI.generic_mapper_removed and type(cecho) == "function" then
+                cecho("<yellow>Removed the conflicting generic_mapper package; DD_GUI owns the mapper.<reset>\n")
         end
 
         return DD_GUI.generic_mapper_removed == true
 end
 
-DD_GUI.remove_conflicting_generic_mapper()
+function DD_GUI.cancel_generic_mapper_cleanup()
+        if DD_GUI.generic_mapper_cleanup_timer and type(killTimer) == "function" then
+                pcall(killTimer, DD_GUI.generic_mapper_cleanup_timer)
+        end
+        DD_GUI.generic_mapper_cleanup_timer = nil
+end
+
+-- A package-install event can arrive after the initial folder script has run.
+-- Give Mudlet time to finish registering the package, then remove it again;
+-- retry briefly because the bundled mapper may install asynchronously.
+function DD_GUI.schedule_generic_mapper_cleanup(watch_install)
+        DD_GUI.cancel_generic_mapper_cleanup()
+
+        local attempts = 0
+        local function cleanup()
+                DD_GUI.generic_mapper_cleanup_timer = nil
+                attempts = attempts + 1
+
+                local installed = generic_mapper_is_installed()
+                if installed == false and not watch_install then
+                        return
+                end
+
+                if installed ~= false then
+                        DD_GUI.remove_conflicting_generic_mapper(true)
+                end
+                if attempts < 12 and type(tempTimer) == "function" then
+                        DD_GUI.generic_mapper_cleanup_timer = tempTimer(
+                                0.25,
+                                cleanup
+                        )
+                end
+        end
+
+        if type(tempTimer) == "function" then
+                DD_GUI.generic_mapper_cleanup_timer = tempTimer(0.05, cleanup)
+        else
+                cleanup()
+        end
+end
+
+DD_GUI.remove_conflicting_generic_mapper(true)
+DD_GUI.schedule_generic_mapper_cleanup(false)
 
 local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"
@@ -141,19 +229,24 @@ function DD_GUI.migrate_legacy_content()
         )
 end
 
-mudlet.mapper_script = true
-
 function myScriptInstalled(_, name)
+        if tostring(name or ""):lower() == GENERIC_MAPPER_PACKAGE then
+                DD_GUI.schedule_generic_mapper_cleanup(true)
+                return
+        end
+
         if name ~= "DD_GUI" then
                 return
         end
-        DD_GUI.remove_conflicting_generic_mapper()
+        DD_GUI.remove_conflicting_generic_mapper(true)
+        DD_GUI.schedule_generic_mapper_cleanup(true)
         DD_GUI.migrate_legacy_content()
         bootstrap()
 end
 
 function myScriptUninstalled(_, name)
         if name == "DD_GUI" then
+                DD_GUI.cancel_generic_mapper_cleanup()
                 if DD_GUI.unregister_data_refresh_handlers then
                         DD_GUI.unregister_data_refresh_handlers()
                 end


### PR DESCRIPTION
## Summary
- mark DD_GUI as mapper owner before cleanup and quarantine generic_mapper installs
- detect package presence through getPackages(), with install-event retries
- shade all status and enemy gauges from dim at empty to bright at full
- document the protection and bump the package to 0.0.131

## Verification
- .\\scripts\\build-and-upload.ps1 completed successfully
- package uploaded as DD_GUI 0.0.131
- git diff --check passed