### PR TITLE
Fix reinstallgui package handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you have any issues with the automated installation and update system for the
 
 To uninstall the GUI, you can simply type:
 
-`lua uninstallPackage("DD_GUI")`, use the built-in `ugui` alias, or use Mudlet's graphical package manager. The GUI copies any legacy downloaded content into the profile-owned `DD_GUI_Content` directory before removal when needed. To safely uninstall and reinstall the latest remote package, use `reinstallgui`; it lets the alias return, waits three seconds between the two operations so Mudlet can finish removing the old package, then installs from the canonical `.mpackage` URL and reports the installed package version. The handoff uses profile-level named timers and install/uninstall events so the reinstall callback survives removal of the old package.
+`lua uninstallPackage("DD_GUI")`, use the built-in `ugui` alias, or use Mudlet's graphical package manager. The GUI copies any legacy downloaded content into the profile-owned `DD_GUI_Content` directory before removal when needed. To safely uninstall and reinstall the latest remote package, use `reinstallgui`. It first downloads the package to a local staging file, waits for the download-complete event, then schedules the uninstall and installs that completed local file after Mudlet has had time to remove the old package. The handoff uses profile-level named timers and event handlers, retries transient download or install failures, accepts a reinstall of the same version, and reports either the installed package version or the actual failure. Downloaded custom content is not removed.
 
 ## Layout controls
 
@@ -271,7 +271,7 @@ These aliases are available from the Mudlet command line:
 | `ddmap reset` / `ddmap cancel` | Confirm or cancel a pending mapper area reset when the dialog/link fallback is used. |
 | `ignores` | Preserve the legacy mapper command; the GMCP mapper reports that text ignore patterns are unnecessary when generic_mapper is absent. |
 | `ugui` | Uninstall the `DD_GUI` package. |
-| `reinstallgui` | Defer the uninstall, wait three seconds, reinstall the latest remote package with a profile-level handoff, and report its installed version without removing downloaded custom content. |
+| `reinstallgui` | Download the latest package locally, safely remove and reinstall `DD_GUI`, retry transient failures, and report the installed version without removing downloaded custom content. |
 
 
 ## Keyboard controls

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/aliases/DD/reinstallgui.lua
+++ b/src/aliases/DD/reinstallgui.lua
@@ -1,17 +1,47 @@
+local package_name = "DD_GUI"
 local package_url = "https://www.dragons-domain.org/main/gui/DD_GUI.mpackage"
-local package_install_url = package_url
-local uninstall_delay = 0.1
-local reinstall_delay = 3
-local version_check_delay = 5
-local max_version_checks = 12
+local uninstall_delay = 0.2
+local reinstall_delay = 4
+local download_retry_delay = 2
+local install_retry_delay = 2
+local max_download_attempts = 3
+local max_install_attempts = 3
+local max_install_checks = 20
 local timer_owner = "DD_GUI.reinstallgui"
+local download_timer_name = "download"
 local uninstall_timer_name = "uninstall"
 local install_timer_name = "install"
-local version_timer_name = "version"
+local status_timer_name = "status"
+local download_done_event_name = "downloaded"
+local download_error_event_name = "download_error"
 local install_event_name = "installed"
 local uninstall_event_name = "uninstalling"
 
-local state = DD_GUI or {}
+DD_GUI = DD_GUI or {}
+local state = DD_GUI
+
+local function normalise_path(path)
+        return tostring(path or ""):gsub("\\", "/")
+end
+
+local function staging_path()
+        local root
+        if type(getMudletHomeDir) == "function" then
+                local ok, home = pcall(getMudletHomeDir)
+                if ok and home and home ~= "" then
+                        root = home
+                end
+        end
+        root = root or ms_path or "."
+        root = tostring(root):gsub("[/\\]+$", "")
+        return root .. "\\DD_GUI_reinstall.mpackage"
+end
+
+local local_package_path = staging_path()
+
+local function is_staging_path(path)
+        return normalise_path(path) == normalise_path(local_package_path)
+end
 
 local function cancel_schedule(schedule)
         if not schedule then
@@ -27,14 +57,14 @@ local function cancel_schedule(schedule)
                         pcall(killTimer, schedule.id)
                 end
         elseif type(schedule) == "number" and type(killTimer) == "function" then
-                -- Compatibility with the previous tempTimer-based alias.
+                -- Compatibility with the old tempTimer-based alias.
                 pcall(killTimer, schedule)
         end
 end
 
 local function schedule_timer(name, delay, callback)
-        -- Named timers live in Mudlet's profile-level ID manager rather than
-        -- in the package tree, so package removal cannot erase the handoff.
+        -- Named timers belong to the profile ID manager, so they remain alive
+        -- when the package that created this alias is removed.
         if type(registerNamedTimer) == "function" and
            type(deleteNamedTimer) == "function" then
                 pcall(deleteNamedTimer, timer_owner, name)
@@ -60,206 +90,395 @@ local function delete_named_event(name)
         end
 end
 
-local function installed_version()
-        local version
-        -- Prefer Mudlet's package metadata because DD_GUI.package_version can
-        -- remain in memory briefly while a replacement package is loading.
+local function package_is_installed()
+        if type(getPackages) == "function" then
+                local ok, packages = pcall(getPackages)
+                if ok and type(packages) == "table" then
+                        for key, installed_name in pairs(packages) do
+                                if tostring(installed_name):lower() ==
+                                   package_name:lower() or
+                                   tostring(key):lower() == package_name:lower() then
+                                        return true
+                                end
+                        end
+                        return false
+                end
+        end
+
         if type(getPackageInfo) == "function" then
-                local ok, package_version = pcall(
+                local ok, version = pcall(
                         getPackageInfo,
-                        "DD_GUI",
+                        package_name,
                         "version"
                 )
                 if ok then
-                        version = package_version
+                        return version ~= nil and tostring(version) ~= ""
                 end
         end
-        if (not version or version == "") and
-           DD_GUI and DD_GUI.package_version then
-                version = DD_GUI.package_version
+
+        return state.package_version ~= nil
+end
+
+local function installed_version()
+        if type(getPackageInfo) == "function" then
+                local ok, version = pcall(
+                        getPackageInfo,
+                        package_name,
+                        "version"
+                )
+                if ok and version and tostring(version) ~= "" then
+                        return version
+                end
         end
-        return version
+
+        if state.package_version then
+                return state.package_version
+        end
+
+        return nil
 end
 
 local function report_installed_version()
         local version = installed_version()
-
         if version and version ~= "" then
                 echo("\nDD_GUI version: " .. tostring(version) .. "\n")
         else
-                echo("\nDD_GUI package version is unavailable.\n")
+                echo("\nDD_GUI was installed, but its package version is unavailable.\n")
         end
 end
 
-local previous_version = installed_version()
-local version_check_attempts = 0
-
-local function check_installed_version()
-        state.reinstall_version_timer = nil
-        if not state.reinstall_install_finished then
-                local version = installed_version()
-                if state.reinstall_install_requested and
-                   previous_version and version and
-                   tostring(version) ~= tostring(previous_version) then
-                        state.reinstall_install_succeeded = true
-                        state.reinstall_install_finished = true
-                        state.reinstall_install_requested = false
-                else
-                        state.reinstall_version_timer = schedule_timer(
-                                version_timer_name, 1, check_installed_version)
-                        return
-                end
-        end
-
-        if not state.reinstall_install_finished then
-                state.reinstall_version_timer = schedule_timer(
-                        version_timer_name, 1, check_installed_version)
-                return
-        end
-
-        if not state.reinstall_install_succeeded then
-                echo("\nDD_GUI version check skipped because installation failed.\n")
-                return
-        end
-
-        version_check_attempts = version_check_attempts + 1
-        local version = installed_version()
-        if version_check_attempts < max_version_checks and
-           (not version or version == "" or
-            (previous_version and
-             tostring(version) == tostring(previous_version))) then
-                state.reinstall_version_timer = schedule_timer(
-                        version_timer_name, 1, check_installed_version)
-                return
-        end
-
-        if previous_version and version and
-           tostring(version) == tostring(previous_version) then
-                echo("\nDD_GUI version check timed out; installed version is " ..
-                        tostring(version) .. ".\n")
-                return
-        end
-
-        report_installed_version()
+local function delete_reinstall_handlers()
+        delete_named_event(download_done_event_name)
+        delete_named_event(download_error_event_name)
+        delete_named_event(install_event_name)
+        delete_named_event(uninstall_event_name)
 end
 
-if DD_GUI and DD_GUI.migrate_legacy_content then
-        DD_GUI.migrate_legacy_content()
-end
+local function finish_reinstall(success, message)
+        if state.reinstall_finished then
+                return
+        end
 
-cancel_schedule(state.reinstall_timer)
-cancel_schedule(state.reinstall_install_timer)
-cancel_schedule(state.reinstall_version_timer)
-state.reinstall_timer = nil
-state.reinstall_install_timer = nil
-state.reinstall_version_timer = nil
-delete_named_event(install_event_name)
-delete_named_event(uninstall_event_name)
-state.reinstall_install_succeeded = false
-state.reinstall_install_finished = false
-state.reinstall_install_requested = false
-state.reinstall_pending = true
-
-local install_scheduled = false
-
-local function install_latest_package()
+        state.reinstall_finished = true
+        state.reinstall_pending = false
+        cancel_schedule(state.reinstall_download_timer)
+        cancel_schedule(state.reinstall_timer)
+        cancel_schedule(state.reinstall_install_timer)
+        cancel_schedule(state.reinstall_status_timer)
+        state.reinstall_download_timer = nil
+        state.reinstall_timer = nil
         state.reinstall_install_timer = nil
-        state.reinstall_install_requested = true
-        echo("\nInstalling the latest DD_GUI package...\n")
+        state.reinstall_status_timer = nil
+        delete_reinstall_handlers()
 
-        local call_ok, result, error_message = pcall(
-                installPackage,
-                package_install_url
-        )
-        if (not call_ok or result == false or
-            (result == nil and error_message ~= nil)) and
-           not state.reinstall_install_succeeded then
-                state.reinstall_install_finished = true
-                state.reinstall_install_requested = false
-                echo("DD_GUI install failed: " ..
-                        tostring(error_message or result or "unknown error") ..
-                        "\n")
-                delete_named_event(install_event_name)
-                return
+        if success then
+                state.reinstall_install_succeeded = true
+                echo("\nDD_GUI reinstall completed.\n")
+                report_installed_version()
+        else
+                state.reinstall_install_succeeded = false
+                echo("\nDD_GUI reinstall failed: " ..
+                        tostring(message or "unknown error") .. "\n")
         end
-
-        -- installPackage() can return before the package's install event and
-        -- new folder.lua have run. Leave the request pending until either
-        -- that event or the version poll observes the new metadata.
 end
 
 local function schedule_install()
-        if install_scheduled then
+        if state.reinstall_finished or state.reinstall_install_scheduled then
                 return
         end
 
-        install_scheduled = true
-        state.reinstall_pending = false
+        state.reinstall_install_scheduled = true
         state.reinstall_install_timer = schedule_timer(
                 install_timer_name,
                 reinstall_delay,
-                install_latest_package
+                function()
+                        state.reinstall_install_timer = nil
+                        state.reinstall_install_scheduled = false
+                        if state.reinstall_finished then
+                                return
+                        end
+                        state.reinstall_phase = "installing"
+                        state.reinstall_install_requested = true
+                        state.reinstall_install_attempts =
+                                state.reinstall_install_attempts + 1
+                        echo("\nInstalling the downloaded DD_GUI package...\n")
+
+                        local call_ok, result, error_message = pcall(
+                                installPackage,
+                                local_package_path
+                        )
+                        if not call_ok or result == false or
+                           (result == nil and error_message ~= nil) then
+                                if state.reinstall_install_attempts <
+                                   max_install_attempts then
+                                        echo("DD_GUI install attempt " ..
+                                                tostring(state.reinstall_install_attempts) ..
+                                                " failed; retrying in " ..
+                                                tostring(install_retry_delay) ..
+                                                " seconds.\n")
+                                        state.reinstall_install_timer = schedule_timer(
+                                                install_timer_name,
+                                                install_retry_delay,
+                                                function()
+                                                        state.reinstall_install_scheduled = false
+                                                        state.reinstall_install_timer = nil
+                                                        state.reinstall_phase = "ready_to_install"
+                                                        schedule_install()
+                                                end
+                                        )
+                                        return
+                                end
+
+                                finish_reinstall(
+                                        false,
+                                        error_message or result or "installPackage() rejected the local package"
+                                )
+                                return
+                        end
+
+                        state.reinstall_install_checks = 0
+                        local check_install_status
+                        check_install_status = function()
+                                        state.reinstall_status_timer = nil
+                                        if state.reinstall_finished then
+                                                return
+                                        end
+
+                                        if state.reinstall_install_succeeded or
+                                           package_is_installed() then
+                                                finish_reinstall(true)
+                                                return
+                                        end
+
+                                        state.reinstall_install_checks =
+                                                state.reinstall_install_checks + 1
+                                        if state.reinstall_install_checks >=
+                                           max_install_checks then
+                                                finish_reinstall(
+                                                        false,
+                                                        "the package did not appear after " ..
+                                                        tostring(max_install_checks) ..
+                                                        " seconds"
+                                                )
+                                                return
+                                        end
+
+                                        state.reinstall_status_timer = schedule_timer(
+                                                status_timer_name,
+                                                1,
+                                                check_install_status
+                                        )
+                                end
+                        state.reinstall_status_timer = schedule_timer(
+                                status_timer_name,
+                                1,
+                                check_install_status
+                        )
+                end
         )
 end
 
--- These handlers are profile-level objects, not package objects. The
--- uninstall event fires before Mudlet removes this package, giving us a
--- reliable place to arm the surviving install timer.
-if type(registerNamedEventHandler) == "function" then
-        pcall(
-                registerNamedEventHandler,
-                timer_owner,
-                uninstall_event_name,
-                "sysUninstallPackage",
-                function(_, name)
-                        if name == "DD_GUI" and state.reinstall_pending then
-                                schedule_install()
-                        end
-                end,
-                true
-        )
-
-        pcall(
-                registerNamedEventHandler,
-                timer_owner,
-                install_event_name,
-                "sysInstallPackage",
-                function(_, name)
-                        if name == "DD_GUI" and
-                           state.reinstall_install_requested then
-                                state.reinstall_install_succeeded = true
-                                state.reinstall_install_finished = true
-                                state.reinstall_install_requested = false
-                        end
-                end,
-                true
-        )
-end
-
-echo("\nDD_GUI will uninstall shortly, then reinstall in " ..
-        reinstall_delay .. " seconds...\n")
-
--- Create this timer before removing the package so it survives the package
--- replacement. The install request itself is asynchronous, so wait beyond
--- the uninstall and reinstall delays before reading the new metadata.
-state.reinstall_version_timer = schedule_timer(
-        version_timer_name,
-        uninstall_delay + reinstall_delay + version_check_delay,
-        check_installed_version
-)
-
--- Let this alias return before removing the package that owns it. Mudlet can
--- terminate when uninstallPackage() mutates the active package mid-alias.
-state.reinstall_timer = schedule_timer(uninstall_timer_name, uninstall_delay, function()
-        state.reinstall_timer = nil
-        local ok, err = pcall(uninstallPackage, "DD_GUI")
-        if not ok then
-                echo("DD_GUI uninstall failed: " .. tostring(err) .. "\n")
-                state.reinstall_pending = false
-                delete_named_event(uninstall_event_name)
+local function schedule_uninstall()
+        if state.reinstall_finished or state.reinstall_uninstall_scheduled then
                 return
         end
-        -- The named uninstall event normally schedules this. The fallback
-        -- covers Mudlet builds that do not expose named event handlers.
-        schedule_install()
-end)
+
+        state.reinstall_uninstall_scheduled = true
+        state.reinstall_timer = schedule_timer(
+                uninstall_timer_name,
+                uninstall_delay,
+                function()
+                        state.reinstall_timer = nil
+                        if state.reinstall_finished then
+                                return
+                        end
+
+                        state.reinstall_phase = "uninstalling"
+                        echo("\nRemoving the current DD_GUI package...\n")
+
+                        -- Arm the local install before mutating the package
+                        -- that owns this alias. The named timer is the normal
+                        -- handoff; the named uninstall event is an early path
+                        -- when Mudlet emits it before the fallback timer.
+                        schedule_install()
+
+                        local ok, result, error_message = pcall(
+                                uninstallPackage,
+                                package_name
+                        )
+                        if not ok then
+                                finish_reinstall(
+                                        false,
+                                        error_message or result or "uninstallPackage() failed"
+                                )
+                        end
+                end
+        )
+end
+
+local function begin_download()
+        if state.reinstall_finished then
+                return
+        end
+
+        state.reinstall_download_timer = nil
+        state.reinstall_phase = "downloading"
+        state.reinstall_download_attempts = state.reinstall_download_attempts + 1
+        os.remove(local_package_path)
+        echo("\nDownloading the latest DD_GUI package...\n")
+
+        local call_ok, result, error_message = pcall(
+                downloadFile,
+                local_package_path,
+                package_url
+        )
+        if not call_ok or result == false then
+                if state.reinstall_download_attempts < max_download_attempts then
+                        echo("DD_GUI download attempt " ..
+                                tostring(state.reinstall_download_attempts) ..
+                                " failed; retrying in " ..
+                                tostring(download_retry_delay) ..
+                                " seconds.\n")
+                        state.reinstall_download_timer = schedule_timer(
+                                download_timer_name,
+                                download_retry_delay,
+                                begin_download
+                        )
+                        return
+                end
+
+                finish_reinstall(
+                        false,
+                        error_message or result or "downloadFile() rejected the package URL"
+                )
+        end
+end
+
+local function on_download_done(event_name, filename)
+        local candidate = filename or event_name
+        if not is_staging_path(candidate) or
+           state.reinstall_phase ~= "downloading" then
+                return
+        end
+
+        state.reinstall_download_timer = nil
+        state.reinstall_phase = "downloaded"
+        echo("DD_GUI package download completed.\n")
+        schedule_uninstall()
+end
+
+local function on_download_error(event_name, reason, filename)
+        local candidate = filename
+        if not is_staging_path(candidate) and is_staging_path(reason) then
+                candidate = reason
+        end
+        if not is_staging_path(candidate) or
+           state.reinstall_phase ~= "downloading" then
+                return
+        end
+
+        state.reinstall_download_timer = nil
+        if state.reinstall_download_attempts < max_download_attempts then
+                echo("DD_GUI download failed: " .. tostring(reason or "unknown error") ..
+                        "; retrying in " .. tostring(download_retry_delay) ..
+                        " seconds.\n")
+                state.reinstall_download_timer = schedule_timer(
+                        download_timer_name,
+                        download_retry_delay,
+                        begin_download
+                )
+                return
+        end
+
+        finish_reinstall(false, reason or "download failed")
+end
+
+local function on_uninstall(event_name, name)
+        if state.reinstall_finished or
+           tostring(name or event_name):lower() ~= package_name:lower() then
+                return
+        end
+
+        if state.reinstall_phase == "uninstalling" then
+                state.reinstall_phase = "ready_to_install"
+        end
+end
+
+local function on_install(event_name, name)
+        if state.reinstall_finished or
+           tostring(name or event_name):lower() ~= package_name:lower() or
+           not state.reinstall_install_requested then
+                return
+        end
+
+        state.reinstall_install_succeeded = true
+        finish_reinstall(true)
+end
+
+local function register_reinstall_handlers()
+        delete_reinstall_handlers()
+        if type(registerNamedEventHandler) ~= "function" then
+                return false
+        end
+
+        local registrations = {
+                {download_done_event_name, "sysDownloadDone", on_download_done, false},
+                {download_error_event_name, "sysDownloadError", on_download_error, false},
+                {uninstall_event_name, "sysUninstallPackage", on_uninstall, true},
+                {install_event_name, "sysInstallPackage", on_install, true},
+        }
+
+        for _, registration in ipairs(registrations) do
+                local ok, result = pcall(
+                        registerNamedEventHandler,
+                        timer_owner,
+                        registration[1],
+                        registration[2],
+                        registration[3],
+                        registration[4]
+                )
+                if not ok or not result then
+                        delete_reinstall_handlers()
+                        return false
+                end
+        end
+
+        return true
+end
+
+if DD_GUI.migrate_legacy_content then
+        DD_GUI.migrate_legacy_content()
+end
+
+cancel_schedule(state.reinstall_download_timer)
+cancel_schedule(state.reinstall_timer)
+cancel_schedule(state.reinstall_install_timer)
+cancel_schedule(state.reinstall_status_timer)
+state.reinstall_download_timer = nil
+state.reinstall_timer = nil
+state.reinstall_install_timer = nil
+state.reinstall_status_timer = nil
+state.reinstall_download_attempts = 0
+state.reinstall_install_attempts = 0
+state.reinstall_install_checks = 0
+state.reinstall_install_requested = false
+state.reinstall_install_succeeded = false
+state.reinstall_install_scheduled = false
+state.reinstall_uninstall_scheduled = false
+state.reinstall_finished = false
+state.reinstall_pending = true
+
+if not register_reinstall_handlers() then
+        finish_reinstall(
+                false,
+                "this Mudlet version cannot register the profile-level reinstall handoff"
+        )
+        return
+end
+
+echo("\nDD_GUI will download the latest package before uninstalling the current one.\n")
+state.reinstall_download_timer = schedule_timer(
+        download_timer_name,
+        0.1,
+        begin_download
+)

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -9,7 +9,7 @@ mudlet.mapper_script = true
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.131"
+DD_GUI.package_version = "0.0.132"
 
 -- Return nil when Mudlet cannot answer the package query. In that case the
 -- removal attempt is still made, because leaving the package installed is the


### PR DESCRIPTION
## Summary\n- stage the latest DD_GUI package with downloadFile before uninstalling the current package\n- use profile-level download/install/uninstall event handlers and timers\n- retry transient download/install failures and accept same-version reinstalls\n- document the new reinstall flow and bump the package version\n\n## Verification\n- .\\scripts\\build-and-upload.ps1\n- remote package size matches build/DD_GUI.mpackage\n- git diff --check