### PR TITLE
Stabilize startup sync and prioritize active content

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the codebase for the [Mudlet](https://www.mudlet.org/)-based GUI used by
 
 ## Installation (players)
 
-To install and use the GUI, connect to the MUD through Mudlet at **dragons-domain.org** on port **8888**. The GUI should automatically install when you connect, and the extra custom content should automatically download after you log in.
+To install and use the GUI, connect to the MUD through Mudlet at **dragons-domain.org** on port **8888**. The GUI should automatically install when you connect, and the extra custom content should automatically download after you log in. The content synchronizer downloads one asset at a time with a short event-loop yield, so a first-run cache containing thousands of assets does not monopolize Mudlet; an interrupted sync resumes from the profile-owned cache. When GMCP identifies the current room, active enemy, or character portrait, matching images are promoted ahead of the background queue.
 
 You should expect a short delay while content downloads the first time you connect. Downloaded sounds, images, layouts, and other custom content are stored in the profile-owned `DD_GUI_Content` directory, separate from the installable package, so uninstalling and reinstalling the GUI does not remove them. Later connections and package updates reuse the existing content and only download new or changed assets. GUI settings, maps, comms history, and comms tab order are kept with the active Mudlet profile rather than inside the package.
 
@@ -104,7 +104,11 @@ data. The main panels are:
   updater can otherwise request a dead `versions.lua` URL. The cleanup now runs
   as soon as the DD_GUI folder loads, before the GUI starts its own mapper, so
   the generic package's profile-level `map\\autosave.dat` is not loaded beside
-  DD_GUI during development reloads. DD_GUI also watches package-install events
+  DD_GUI during development reloads. If that legacy autosave already exists,
+  DD_GUI moves it, and the newest dated legacy `map\\*map.dat` snapshot, to a
+  `.dd_gui_disabled` backup (adding a numeric suffix when needed) instead of
+  deleting them; DD_GUI never touches its own `dragons_domain_mapper.dat`.
+  DD_GUI also watches package-install events
   and retries removal if Mudlet or the generic updater attempts to bring the
   package back. `ddmap cleanup` remains available as a manual forced removal if
   a local profile still has the old package installed; restart Mudlet afterward

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.132",
+  "version": "0.0.134",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/CharsheetConsole.lua
+++ b/src/scripts/DD/CharsheetConsole.lua
@@ -1152,6 +1152,9 @@ end
 
 function build_charsheet_console()
 
+    local character_base = gmcp and gmcp.Char and
+      type(gmcp.Char.Base) == "table" and gmcp.Char.Base or {}
+
     CharsheetConsole = Geyser.MiniConsole:new({
       name="CharsheetConsole",
       x = "4%", y = "2%",
@@ -1197,14 +1200,14 @@ function build_charsheet_console()
     if not pfp_filename then
       local chsex_string = 'male'
 
-      if (gmcp.Char.Base.sex == 0) then
+      if (tonumber(character_base.sex) == 0) then
         chsex_string = 'neutral'
-      elseif (gmcp.Char.Base.sex == 2) then
+      elseif (tonumber(character_base.sex) == 2) then
         chsex_string = 'female'
       end
 
-      pfp_filename = firstToLower(gmcp.Char.Base.race) .. '_'
-                         ..firstToLower(gmcp.Char.Base.class) .. '_'
+      pfp_filename = firstToLower(character_base.race) .. '_'
+                         ..firstToLower(character_base.class) .. '_'
                          ..chsex_string .. '_1.png'
     end
     --display(pfp_filename)

--- a/src/scripts/DD/GetCustomContent.lua
+++ b/src/scripts/DD/GetCustomContent.lua
@@ -8,9 +8,50 @@ end
 -- Globals / constants
 local lfs = require "lfs"
 
-downloadQueue = downloadQueue or {}
-isDownloadingFileList = false
-local active_download_path = nil
+downloadQueue = DD_GUI.content_download_queue or downloadQueue or {}
+DD_GUI.content_download_queue = downloadQueue
+isDownloadingFileList = DD_GUI.content_download_list_active == true
+local active_download_path = DD_GUI.content_download_path
+
+-- Large first-run content sets can contain thousands of files. Keep one
+-- request active and yield between completion callbacks so the client can
+-- continue painting and processing input. Persist the state on DD_GUI so a
+-- package reload can replace handlers without losing the queue.
+local CONTENT_DOWNLOAD_DELAY = 0.05
+
+local function set_list_download_active(active)
+  isDownloadingFileList = active == true
+  DD_GUI.content_download_list_active = isDownloadingFileList
+end
+
+local function set_active_download(path)
+  active_download_path = path
+  DD_GUI.content_download_path = path
+end
+
+local function clear_content_download_queue()
+  downloadQueue = {}
+  DD_GUI.content_download_queue = downloadQueue
+end
+
+local function schedule_next_download(delay)
+  if DD_GUI.content_download_timer then
+    return
+  end
+
+  if type(tempTimer) ~= "function" then
+    start_next_download()
+    return
+  end
+
+  DD_GUI.content_download_timer = tempTimer(
+    delay or CONTENT_DOWNLOAD_DELAY,
+    function()
+      DD_GUI.content_download_timer = nil
+      start_next_download()
+    end
+  )
+end
 
 -- Make the file list path/URL visible to all handlers
 FILELIST_LOCAL = ms_path .. "/custom_filelist.txt"
@@ -36,6 +77,186 @@ local function is_same_download(path_a, path_b)
   return normalise_download_path(path_a) == normalise_download_path(path_b)
 end
 
+local environment_assets = {
+  [0] = "0_sect_inside.png",
+  [1] = "1_sect_city.png",
+  [2] = "2_sect_field.png",
+  [3] = "3_sect_forest.png",
+  [4] = "4_sect_hills.png",
+  [5] = "5_sect_mountain.png",
+  [6] = "6_sect_water_swim.png",
+  [7] = "7_sect_water_noswim.png",
+  [8] = "8_sect_underwater.png",
+  [9] = "9_sect_air.png",
+  [10] = "10_sect_desert.png",
+  [11] = "11_sect_swamp.png",
+  [12] = "12_sect_underwater_ground.png",
+}
+
+local function room_asset_name(name)
+  return tostring(name or ""):lower()
+    :gsub("/", "_")
+    :gsub(" ", "_")
+    :gsub("'", "_")
+    :gsub("<", "_")
+    :gsub(">", "_")
+    :gsub("{", "_")
+end
+
+local function enemy_asset_name(name)
+  return tostring(name or ""):lower()
+    :gsub(" ", "_")
+    :gsub("'", "_")
+end
+
+local function character_asset_name(name)
+  return tostring(name or ""):lower()
+    :gsub("[^%w]+", "_")
+    :gsub("^_+", "")
+    :gsub("_+$", "")
+end
+
+local function add_exact_priority(exact, path, priority)
+  if path == "" then
+    return
+  end
+
+  if exact[path] == nil or priority < exact[path] then
+    exact[path] = priority
+  end
+end
+
+local function current_content_prefixes()
+  local exact = {}
+  local prefixes = {}
+  local signature = {}
+  local character = gmcp and gmcp.Char
+  local room = gmcp and gmcp.Room and gmcp.Room.Info
+  if type(room) == "table" then
+    local room_vnum = tonumber(room.vnum)
+    signature[#signature + 1] = "room:" .. tostring(room_vnum or "")
+    signature[#signature + 1] = tostring(room.name or "")
+    signature[#signature + 1] = tostring(room.sector or "")
+    if room_vnum and room_vnum ~= 0 then
+      prefixes[#prefixes + 1] = {
+        value = "custom_rooms/" .. room_vnum .. "_",
+        priority = 1,
+      }
+    end
+
+    local sector = tonumber(room.sector)
+    if environment_assets[sector] then
+      add_exact_priority(exact, "environments/" .. environment_assets[sector], 2)
+    end
+  end
+
+  local enemies = gmcp and gmcp.Char and gmcp.Char.Enemies
+  local enemy = nil
+  if type(enemies) == "table" and type(enemies[1]) == "table" then
+    enemy = enemies[1]
+    if enemy.name == nil and type(enemy[1]) == "table" then
+      enemy = enemy[1]
+    end
+  end
+  if type(enemy) == "table" then
+    local enemy_vnum = tonumber(enemy.vnum) or tonumber(enemy.isnpc)
+    signature[#signature + 1] = "enemy:" .. tostring(enemy_vnum or "")
+    signature[#signature + 1] = tostring(enemy.name or "")
+    if enemy_vnum and enemy_vnum ~= 0 then
+      prefixes[#prefixes + 1] = {
+        value = "mobs/" .. enemy_vnum .. "_",
+        priority = 0,
+      }
+      add_exact_priority(exact,
+        "mobs/" .. enemy_vnum .. "_" .. enemy_asset_name(enemy.name) .. ".png", 0)
+    end
+  end
+
+  local room_name = type(room) == "table" and room.name
+  local room_vnum = type(room) == "table" and tonumber(room.vnum)
+  if room_vnum and room_vnum ~= 0 and room_name then
+    add_exact_priority(exact,
+      "custom_rooms/" .. room_vnum .. "_" .. room_asset_name(room_name) .. ".png", 0)
+  end
+
+  local base = type(character) == "table" and character.Base
+  local vitals = type(character) == "table" and character.Vitals
+  if type(base) == "table" then
+    local character_name = character_asset_name(base.name)
+    signature[#signature + 1] = "character:" .. character_name
+    signature[#signature + 1] = tostring(base.race or "")
+    signature[#signature + 1] = tostring(base.class or "")
+    signature[#signature + 1] = tostring(base.subclass or "")
+    signature[#signature + 1] = tostring(base.sex or "")
+    if character_name ~= "" then
+      add_exact_priority(exact, "avatars/" .. character_name .. ".png", 0)
+    end
+
+    local sex_name = "male"
+    if tonumber(base.sex) == 0 then
+      sex_name = "neuter"
+    elseif tonumber(base.sex) == 2 then
+      sex_name = "female"
+    end
+
+    local race_name = tostring(base.race or "unknown"):lower():gsub("-", "_")
+    add_exact_priority(exact, "avatars/" .. race_name .. "_" .. sex_name .. "_1.png", 1)
+
+    -- Form portraits override normal and character-named portraits in
+    -- update_vitals(), so promote the active form to the front of the queue.
+    local form = type(vitals) == "table" and tostring(vitals.form or ""):lower()
+    signature[#signature + 1] = "form:" .. form
+    if form ~= "" and form ~= "normal" then
+      if tostring(base.class or "") == "Shape Shifter" or
+         tostring(base.subclass or "") == "Werewolf" or
+         tostring(base.subclass or "") == "Vampire" then
+        add_exact_priority(exact, "avatars/" .. form .. "_form.png", -1)
+      end
+    end
+  end
+
+  return exact, prefixes, table.concat(signature, "|")
+end
+
+function DD_GUI.prioritize_content_queue(force)
+  if type(downloadQueue) ~= "table" or #downloadQueue < 2 then
+    return
+  end
+
+  local exact, prefixes, signature = current_content_prefixes()
+  if not force and DD_GUI.content_download_priority_key == signature then
+    return
+  end
+  DD_GUI.content_download_priority_key = signature
+
+  for sequence, item in ipairs(downloadQueue) do
+    local path = normalise_download_path(item.saveto or "")
+    local relative = path
+    local root = normalise_download_path(ms_path) .. "/"
+    if relative:sub(1, #root) == root then
+      relative = relative:sub(#root + 1)
+    end
+    relative = relative:lower()
+
+    local priority = exact[relative] or 100
+    for _, candidate in ipairs(prefixes) do
+      if relative:sub(1, #candidate.value) == candidate.value then
+        priority = math.min(priority, candidate.priority)
+      end
+    end
+    item.priority = priority
+    item.sequence = item.sequence or sequence
+  end
+
+  table.sort(downloadQueue, function(left, right)
+    if left.priority ~= right.priority then
+      return left.priority < right.priority
+    end
+    return left.sequence < right.sequence
+  end)
+  DD_GUI.content_download_queue = downloadQueue
+end
+
 -- Ensure all parent directories for a path exist (cross-platform)
 local function ensure_dir_for(path)
   local norm = path:gsub("\\", "/")
@@ -59,8 +280,8 @@ function onDownloadDone(_, filename)
 
   -- Was it the file list?
   if isDownloadingFileList and is_same_download(filename, FILELIST_LOCAL) then
-    isDownloadingFileList = false
-    active_download_path = nil
+    set_list_download_active(false)
+    set_active_download(nil)
     process_file_list()
     return
   end
@@ -69,9 +290,9 @@ function onDownloadDone(_, filename)
     return
   end
 
-  active_download_path = nil
-  -- Otherwise proceed with the queue
-  start_next_download()
+  set_active_download(nil)
+  -- Yield to the client event loop before starting another request.
+  schedule_next_download()
 end
 
 function onDownloadError(badFile, reason)
@@ -88,16 +309,29 @@ function onDownloadError(badFile, reason)
   end
 
   cecho(string.format("\n<white>Download failed for %s: %s\n", badFile or "<unknown>", reason or ""))
-  isDownloadingFileList = false
-  active_download_path = nil
-  start_next_download()
+  if isDownloadingFileList and is_same_download(badFile, FILELIST_LOCAL) then
+    set_list_download_active(false)
+    clear_content_download_queue()
+    set_active_download(nil)
+    DD_GUI.content_download_active = false
+    return
+  end
+
+  set_active_download(nil)
+  schedule_next_download()
 end
 
 -- Kick-off
 function get_custom_content()
+  if DD_GUI.content_download_active or isDownloadingFileList or
+     active_download_path or #downloadQueue > 0 then
+    return
+  end
+
   cecho("\n\n<white>Downloading any new custom media...\n")
-  isDownloadingFileList = true
-  active_download_path = FILELIST_LOCAL
+  DD_GUI.content_download_active = true
+  set_list_download_active(true)
+  set_active_download(FILELIST_LOCAL)
   ensure_dir_for(FILELIST_LOCAL)
   downloadFile(FILELIST_LOCAL, FILELIST_URL)
 end
@@ -106,10 +340,11 @@ end
 function process_file_list()
   if not file_exists(FILELIST_LOCAL) then
     cecho("\n<white>Custom media unable to be checked.\n")
+    DD_GUI.content_download_active = false
     return
   end
 
-  downloadQueue = {}
+  clear_content_download_queue()
   local lines = lines_from(FILELIST_LOCAL)
 
   for _, v in ipairs(lines) do
@@ -132,19 +367,30 @@ function process_file_list()
     end
   end
 
-  start_next_download()
+  DD_GUI.prioritize_content_queue(true)
+  schedule_next_download(0)
 end
 
 function start_next_download()
+  if active_download_path then
+    return
+  end
+
   if #downloadQueue == 0 then
-    active_download_path = nil
+    set_active_download(nil)
+    DD_GUI.content_download_active = false
     --cecho("\n<white>All downloads completed.\n")
     return
   end
   local nextDownload = table.remove(downloadQueue, 1)
-  active_download_path = nextDownload.saveto
+  DD_GUI.content_download_queue = downloadQueue
+  set_active_download(nextDownload.saveto)
   ensure_dir_for(nextDownload.saveto)
-  downloadFile(nextDownload.saveto, nextDownload.url)
+  local ok, result = pcall(downloadFile, nextDownload.saveto, nextDownload.url)
+  if not ok or result == false then
+    set_active_download(nil)
+    schedule_next_download()
+  end
 end
 
 -- Replace the previous callbacks when local source files are reloaded. Without

--- a/src/scripts/DD/HelperFunctions/string_functions.lua
+++ b/src/scripts/DD/HelperFunctions/string_functions.lua
@@ -1,8 +1,11 @@
 function replace_char(pos, str, r)
+        str = tostring(str or "")
+        r = tostring(r or "")
         return table.concat{str:sub(1,pos-1), r, str:sub(pos+1)}
 end
     
 function split_str (inputstr, sep)
+        inputstr = tostring(inputstr or "")
         if sep == nil then
                 sep = "%s"
         end
@@ -14,9 +17,9 @@ function split_str (inputstr, sep)
 end
     
 function firstToUpper(str)
-        return (str:gsub("^%l", string.upper))
+        return (tostring(str or ""):gsub("^%l", string.upper))
 end
 
 function firstToLower(str)
-        return (str:gsub("^%u", string.lower))
+        return (tostring(str or ""):gsub("^%u", string.lower))
 end

--- a/src/scripts/DD/UpdateFunctions/update_enemy.lua
+++ b/src/scripts/DD/UpdateFunctions/update_enemy.lua
@@ -27,6 +27,10 @@ function update_enemy()
         local position = gmcp and gmcp.Char and gmcp.Char.Vitals and
                 tonumber(gmcp.Char.Vitals.position)
 
+        if DD_GUI.prioritize_content_queue then
+                DD_GUI.prioritize_content_queue()
+        end
+
         if type(enemy) == "table" and
            position == 6 then
 

--- a/src/scripts/DD/UpdateFunctions/update_travel.lua
+++ b/src/scripts/DD/UpdateFunctions/update_travel.lua
@@ -10,6 +10,10 @@ function update_travel()
             return
     end
 
+    if DD_GUI.prioritize_content_queue then
+            DD_GUI.prioritize_content_queue()
+    end
+
     if (tonumber(vitals.position) ~= 6) then
 
             if DD_GUI.set_enemy_hitpoints_visible then

--- a/src/scripts/DD/UpdateFunctions/update_vitals.lua
+++ b/src/scripts/DD/UpdateFunctions/update_vitals.lua
@@ -27,6 +27,10 @@ function update_vitals()
         return
     end
 
+  if DD_GUI.prioritize_content_queue then
+      DD_GUI.prioritize_content_queue()
+  end
+
     if not hasFocus() then
         lost_focus = true
       end
@@ -85,7 +89,8 @@ function update_vitals()
     chsex_string = 'female'
   end
 
-  local pfp_filename = gmcp.Char.Base.race:lower():gsub("-", "_") .. '_'
+  local race_name = tostring(gmcp.Char.Base.race or "unknown")
+  local pfp_filename = race_name:lower():gsub("-", "_") .. '_'
   ..chsex_string .. '_1.png'
 
   local profile_avatar = DD_GUI.profile_avatar_filename and

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -9,7 +9,12 @@ mudlet.mapper_script = true
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.132"
+DD_GUI.package_version = "0.0.134"
+
+local profile_path = string.gsub(tostring(getMudletHomeDir() or ""), "\\", "/")
+local package_path = profile_path .. "/DD_GUI"
+local content_path = profile_path .. "/DD_GUI_Content"
+local lfs = require "lfs"
 
 -- Return nil when Mudlet cannot answer the package query. In that case the
 -- removal attempt is still made, because leaving the package installed is the
@@ -22,8 +27,10 @@ local function generic_mapper_is_installed()
         if type(getPackages) == "function" then
                 local ok, packages = pcall(getPackages)
                 if ok and type(packages) == "table" then
-                        for _, package_name in pairs(packages) do
+                        for package_key, package_name in pairs(packages) do
                                 if tostring(package_name):lower() ==
+                                   GENERIC_MAPPER_PACKAGE or
+                                   tostring(package_key):lower() ==
                                    GENERIC_MAPPER_PACKAGE then
                                         return true
                                 end
@@ -46,6 +53,74 @@ local function generic_mapper_is_installed()
         end
 
         return version ~= nil and tostring(version) ~= ""
+end
+
+-- Mudlet's legacy generic mapper may leave a profile-level autosave behind
+-- even after its package is removed. On the next profile start Mudlet can
+-- read that file before DD_GUI gets control and spend minutes in a blocking
+-- map load. Keep every copy reversible, and leave DD_GUI's own map untouched.
+local function quarantine_legacy_mapper_file(legacy_path)
+        if lfs.attributes(legacy_path, "mode") ~= "file" then
+                return false
+        end
+
+        local backup_path = legacy_path .. ".dd_gui_disabled"
+        local suffix = 1
+        while lfs.attributes(backup_path, "mode") do
+                suffix = suffix + 1
+                backup_path = legacy_path .. ".dd_gui_disabled." .. suffix
+        end
+
+        local ok, error_message = os.rename(legacy_path, backup_path)
+        if ok then
+                DD_GUI.legacy_mapper_autosave_quarantined = true
+                if type(cecho) == "function" then
+                        cecho("<yellow>Quarantined legacy mapper autosave; DD_GUI uses its own persistent map.<reset>\n")
+                end
+                return true
+        end
+
+        if type(cecho) == "function" then
+                cecho("<red>Could not quarantine legacy mapper autosave: " ..
+                      tostring(error_message or "unknown error") .. "<reset>\n")
+        end
+        return false
+end
+
+function DD_GUI.quarantine_legacy_mapper_autosave()
+        local moved = quarantine_legacy_mapper_file(
+                profile_path .. "/map/autosave.dat"
+        )
+
+        -- Mudlet also keeps dated native-map snapshots. The generic mapper
+        -- can make the newest one the file read during profile startup, so
+        -- quarantine that snapshot as well. Older snapshots remain available
+        -- for manual recovery and DD_GUI uses dragons_domain_mapper.dat.
+        if DD_GUI.legacy_mapper_snapshot_quarantined then
+                return moved
+        end
+
+        local map_directory = profile_path .. "/map"
+        local newest_path
+        local newest_time = -1
+        if lfs.attributes(map_directory, "mode") == "directory" then
+                for name in lfs.dir(map_directory) do
+                        if name:match("^%d%d%d%d%-%d%d%-%d%d#%d%d%-%d%d%-%d%dmap%.dat$") then
+                                local candidate = map_directory .. "/" .. name
+                                local modified = lfs.attributes(candidate, "modification") or 0
+                                if modified > newest_time then
+                                        newest_path = candidate
+                                        newest_time = modified
+                                end
+                        end
+                end
+        end
+
+        if newest_path then
+                moved = quarantine_legacy_mapper_file(newest_path) or moved
+                DD_GUI.legacy_mapper_snapshot_quarantined = true
+        end
+        return moved
 end
 
 -- DD_GUI owns the native mapper surface. Remove the legacy generic mapper as
@@ -102,13 +177,16 @@ function DD_GUI.schedule_generic_mapper_cleanup(watch_install)
                 attempts = attempts + 1
 
                 local installed = generic_mapper_is_installed()
+                if installed ~= false then
+                        DD_GUI.remove_conflicting_generic_mapper(true)
+                        installed = generic_mapper_is_installed()
+                end
+
+                DD_GUI.quarantine_legacy_mapper_autosave()
                 if installed == false and not watch_install then
                         return
                 end
 
-                if installed ~= false then
-                        DD_GUI.remove_conflicting_generic_mapper(true)
-                end
                 if attempts < 12 and type(tempTimer) == "function" then
                         DD_GUI.generic_mapper_cleanup_timer = tempTimer(
                                 0.25,
@@ -125,12 +203,8 @@ function DD_GUI.schedule_generic_mapper_cleanup(watch_install)
 end
 
 DD_GUI.remove_conflicting_generic_mapper(true)
+DD_GUI.quarantine_legacy_mapper_autosave()
 DD_GUI.schedule_generic_mapper_cleanup(false)
-
-local profile_path = string.gsub(getMudletHomeDir(), "\\", "/")
-local package_path = profile_path .. "/DD_GUI"
-local content_path = profile_path .. "/DD_GUI_Content"
-local lfs = require "lfs"
 
 local function ensure_directory(path)
         if lfs.attributes(path, "mode") ~= "directory" then

--- a/src/triggers/DD/LoginBootstrap.lua
+++ b/src/triggers/DD/LoginBootstrap.lua
@@ -1,7 +1,8 @@
 local function dd_gui_character_data_ready()
         return gmcp and gmcp.Char and gmcp.Char.Base and gmcp.Char.Vitals and
                 gmcp.Char.Stats and gmcp.Char.Worth and
-                gmcp.Char.Base.name and gmcp.Char.Vitals.hp
+                gmcp.Char.Base.name and gmcp.Char.Base.race and
+                gmcp.Char.Base.class and gmcp.Char.Vitals.hp
 end
 
 local attempts = 0


### PR DESCRIPTION
## Summary\n- throttle and persist custom-content downloads so large caches do not starve Mudlet\n- prioritize the current room, active mob, and character portrait assets\n- harden startup data handling and quarantine legacy generic-mapper map state\n\n## Verification\n- build and upload completed with DD_GUI 0.0.134\n- repaired local profile stayed responsive for a 60-second startup sample