### PR TITLE
Prevent Mudlet startup CPU spikes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the codebase for the [Mudlet](https://www.mudlet.org/)-based GUI used by
 
 ## Installation (players)
 
-To install and use the GUI, connect to the MUD through Mudlet at **dragons-domain.org** on port **8888**. The GUI should automatically install when you connect, and the extra custom content should automatically download after you log in. The content synchronizer downloads one asset at a time with a short event-loop yield, so a first-run cache containing thousands of assets does not monopolize Mudlet; an interrupted sync resumes from the profile-owned cache. When GMCP identifies the current room, active enemy, or character portrait, matching images are promoted ahead of the background queue.
+To install and use the GUI, connect to the MUD through Mudlet at **dragons-domain.org** on port **8888**. The GUI should automatically install when you connect, and the extra custom content should automatically download after you log in. The content synchronizer checks the manifest in small yielding batches, then downloads one asset at a time with a short event-loop yield, so a first-run cache containing thousands of assets does not monopolize Mudlet; an interrupted sync resumes from the profile-owned cache. When GMCP identifies the current room, active enemy, or character portrait, matching images are promoted ahead of the background queue.
 
 You should expect a short delay while content downloads the first time you connect. Downloaded sounds, images, layouts, and other custom content are stored in the profile-owned `DD_GUI_Content` directory, separate from the installable package, so uninstalling and reinstalling the GUI does not remove them. Later connections and package updates reuse the existing content and only download new or changed assets. GUI settings, maps, comms history, and comms tab order are kept with the active Mudlet profile rather than inside the package.
 
@@ -88,8 +88,9 @@ data. The main panels are:
   even internal padding, and its title is kept to one compact room/vnum line
   with no extra rule beneath it, so northern rooms remain visible even when a
   room name is long. Newly visited areas receive a one-time density-based zoom
-  so a sparse map does not collapse into a tiny cluster; manual zoom remains
-  persistent. Use `ddmap fit` to refit the current area at any time.
+  so a sparse map does not collapse into a tiny cluster; that first-fit scan is
+  chunked so loading a large mapped area does not block Mudlet. Manual zoom
+  remains persistent. Use `ddmap fit` to refit the current area at any time.
   Mapped quest destinations receive a restrained gold highlight, and selected
   rooms can be routed to, avoided, or centred from the native mapper context
   menu. The mapper consumes DD4's structured `Room.Info` fields: stable
@@ -248,11 +249,16 @@ dropdown menus, and right-click context menus consistently.
 The GUI refreshes these views from the latest GMCP snapshot after login and
 reconnect. `bootstrap()` is idempotent for the installed package version, so
 running `lua bootstrap()` after reconnect refreshes the existing widgets
-without stacking another copy of the interface. When a package update really
-does require new widgets, the previous GUI roots are hidden safely before the
-new tree is built and then explicitly shown again after Mudlet reuses any named
-containers. The enemy hitpoint bar is a direct label overlay rather than a
-nested native gauge, which keeps it visible above the enemy console surface.
+without stacking another copy of the interface. Repeated bootstrap refreshes
+are deferred until Mudlet has finished the current event, and source reloads
+cancel stale settle timers. When a package update really does require new
+widgets, the previous GUI roots are hidden safely before the new tree is built
+and then explicitly shown again after Mudlet reuses any named containers. The
+inventory/equipment views redraw on item or worn-data updates rather than every
+vitals tick, and the character sheet avoids repainting its portrait and text
+when only a gauge changed. The enemy hitpoint bar is a direct label overlay
+rather than a nested native gauge, which keeps it visible above the enemy
+console surface.
 
 
 ## Aliases
@@ -331,8 +337,10 @@ and automatically quarantine later generic-mapper install attempts; run
 `ddmap cleanup` once the profile responds only if an older build left the
 package active. Close and restart Mudlet, and then load DD_GUI again. DD_GUI
 also guards its own persistent `dragons_domain_mapper.dat` load so repeated
-`bootstrap()` calls do not parse the native map repeatedly in one session. If
-Mudlet cannot respond long enough to run the command, make a backup of the profile's
+`bootstrap()` calls do not parse the native map repeatedly in one session. The
+custom-media manifest scan is also deliberately incremental, so a large cached
+content directory should not create a long synchronous CPU spike during login.
+If Mudlet cannot respond long enough to run the command, make a backup of the profile's
 `map\autosave.dat`, rename that file, restart Mudlet, and let DD_GUI rebuild
 from its own persistent map; the generic file is not used by DD_GUI.
 

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.134",
+  "version": "0.0.135",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/CharsheetConsole.lua
+++ b/src/scripts/DD/CharsheetConsole.lua
@@ -91,6 +91,16 @@ local function condition_gauge_specs()
 end
 
 local function set_condition_gauges_visible(gauges)
+    local layout_key = {}
+    for _, definition in ipairs(gauges or {}) do
+      layout_key[#layout_key + 1] = definition.property
+    end
+    layout_key = table.concat(layout_key, ",")
+    if DD_GUI.condition_gauge_layout_key == layout_key then
+      return
+    end
+    DD_GUI.condition_gauge_layout_key = layout_key
+
     local all_gauges = {}
     for _, key in ipairs(CONDITION_GAUGE_ORDER) do
       local definition = CONDITION_GAUGE_DEFINITIONS[key]
@@ -1112,6 +1122,7 @@ local function build_character_condition_gauges()
       return
     end
 
+    DD_GUI.condition_gauge_layout_key = nil
     DD_GUI.CharsheetConditions = Geyser.Container:new({
       name = "DD_GUI.CharsheetConditions",
       x = "4%", y = "89%",

--- a/src/scripts/DD/GMCPMapper.lua
+++ b/src/scripts/DD/GMCPMapper.lua
@@ -34,6 +34,9 @@ function load_dd_mapper()
         state.handlers = state.handlers or {}
         state.menu_events = state.menu_events or {}
         state.zoom_seen = state.zoom_seen or {}
+        state.auto_fit_jobs = {}
+        state.auto_fit_generation =
+                (tonumber(state.auto_fit_generation) or 0) + 1
         state.highlights = state.highlights or {}
         state.route = nil
 
@@ -1107,18 +1110,87 @@ function load_dd_mapper()
                         return
                 end
 
+                if state.auto_fit_jobs[key] then
+                        return
+                end
+
                 local seen = false
                 if type(getAreaUserData) == "function" then
                         local ok, value = dd_mapper_call(getAreaUserData, area_id, "dd_gui.autofit")
                         seen = ok and tostring(value) == "1"
                 end
-                if not seen then
-                        fit_area(area_id)
+                if seen then
                         state.zoom_seen[key] = true
-                        if type(setAreaUserData) == "function" then
-                                pcall(setAreaUserData, area_id, "dd_gui.autofit", "1")
-                        end
+                        return
                 end
+                local rooms_ok, rooms = dd_mapper_call(getAreaRooms, area_id)
+                if not rooms_ok or type(rooms) ~= "table" or #rooms == 0 then
+                        return
+                end
+
+                        -- The first room event after loading a large map used
+                        -- to scan every room in one callback. Keep the manual
+                        -- ddmap fit command synchronous, but yield automatic
+                        -- startup fitting so Mudlet can continue handling
+                        -- GMCP, painting, and input.
+                        local job = {
+                                rooms = rooms,
+                                index = 1,
+                                min_x = nil,
+                                max_x = nil,
+                                min_y = nil,
+                                max_y = nil,
+                                generation = state.auto_fit_generation,
+                        }
+                        state.auto_fit_jobs[key] = job
+
+                        local function finish()
+                                if state.auto_fit_jobs[key] ~= job or
+                                   state.auto_fit_generation ~= job.generation then
+                                        return
+                                end
+
+                                state.auto_fit_jobs[key] = nil
+                                local span = math.max(
+                                        (job.max_x or 0) - (job.min_x or 0),
+                                        (job.max_y or 0) - (job.min_y or 0)
+                                )
+                                local zoom = math.max(3.5, math.min(16, 4.5 + span * 0.65))
+                                pcall(setMapZoom, zoom, area_id)
+                                state.zoom_seen[key] = true
+                                if type(setAreaUserData) == "function" then
+                                        pcall(setAreaUserData, area_id, "dd_gui.autofit", "1")
+                                end
+                        end
+
+                        local function scan_chunk()
+                                if state.auto_fit_jobs[key] ~= job or
+                                   state.auto_fit_generation ~= job.generation then
+                                        return
+                                end
+
+                                local last = math.min(#rooms, job.index + 99)
+                                for index = job.index, last do
+                                        local coordinates = room_coordinates(rooms[index])
+                                        if coordinates then
+                                                job.min_x = job.min_x and math.min(job.min_x, coordinates[1]) or coordinates[1]
+                                                job.max_x = job.max_x and math.max(job.max_x, coordinates[1]) or coordinates[1]
+                                                job.min_y = job.min_y and math.min(job.min_y, coordinates[2]) or coordinates[2]
+                                                job.max_y = job.max_y and math.max(job.max_y, coordinates[2]) or coordinates[2]
+                                        end
+                                end
+                                job.index = last + 1
+
+                                if job.index <= #rooms and type(tempTimer) == "function" then
+                                        tempTimer(0.01, scan_chunk)
+                                elseif job.index <= #rooms then
+                                        scan_chunk()
+                                else
+                                        finish()
+                                end
+                        end
+
+                scan_chunk()
         end
 
         local function door_status(room_id, direction)

--- a/src/scripts/DD/GetCustomContent.lua
+++ b/src/scripts/DD/GetCustomContent.lua
@@ -13,11 +13,25 @@ DD_GUI.content_download_queue = downloadQueue
 isDownloadingFileList = DD_GUI.content_download_list_active == true
 local active_download_path = DD_GUI.content_download_path
 
+-- A previous package source can leave a manifest scan timer alive while
+-- Mudlet replaces the package. Cancel that callback before installing the
+-- new handler set; otherwise two scanners can walk the same 8,000+ rows.
+if DD_GUI.content_manifest_timer and type(killTimer) == "function" then
+  pcall(killTimer, DD_GUI.content_manifest_timer)
+end
+if DD_GUI.content_manifest_scan and not DD_GUI.content_download_path then
+  DD_GUI.content_download_active = false
+end
+DD_GUI.content_manifest_timer = nil
+DD_GUI.content_manifest_scan = nil
+
 -- Large first-run content sets can contain thousands of files. Keep one
 -- request active and yield between completion callbacks so the client can
 -- continue painting and processing input. Persist the state on DD_GUI so a
 -- package reload can replace handlers without losing the queue.
 local CONTENT_DOWNLOAD_DELAY = 0.05
+local CONTENT_MANIFEST_CHUNK_SIZE = 80
+local CONTENT_MANIFEST_DELAY = 0.01
 
 local function set_list_download_active(active)
   isDownloadingFileList = active == true
@@ -49,6 +63,25 @@ local function schedule_next_download(delay)
     function()
       DD_GUI.content_download_timer = nil
       start_next_download()
+    end
+  )
+end
+
+local function schedule_manifest_chunk(delay, callback)
+  if DD_GUI.content_manifest_timer then
+    return
+  end
+
+  if type(tempTimer) ~= "function" then
+    callback()
+    return
+  end
+
+  DD_GUI.content_manifest_timer = tempTimer(
+    delay or CONTENT_MANIFEST_DELAY,
+    function()
+      DD_GUI.content_manifest_timer = nil
+      callback()
     end
   )
 end
@@ -337,6 +370,47 @@ function get_custom_content()
 end
 
 -- Read, queue, and start
+local function process_file_list_chunk(scan)
+  if DD_GUI.content_manifest_scan ~= scan then
+    return
+  end
+
+  local first = scan.index
+  local last = math.min(#scan.lines, first + CONTENT_MANIFEST_CHUNK_SIZE - 1)
+  for index = first, last do
+    local v = scan.lines[index]
+    local result  = split_str(v, '|')
+    local sizeStr = (result[1] or ""):gsub("%s+$", "")
+    local relPath = (result[2] or ""):gsub("\r", ""):gsub("^%s+", ""):gsub("%s+$", "")
+
+    -- Ignore blank lines, directory entries, and malformed rows. The
+    -- persistent profile cache is checked before the package fallback so
+    -- existing content avoids an unnecessary download.
+    if relPath ~= "" and looks_like_file(relPath) then
+      local saveto = ms_path .. "/" .. relPath
+      local existing_path = DD_GUI.asset_path and
+        DD_GUI.asset_path(relPath) or saveto
+      local existing = lfs.attributes(existing_path, "size")
+
+      if existing == nil or tonumber(sizeStr) ~= tonumber(existing) then
+        table.insert(downloadQueue, { url = CONTENT_BASE .. relPath, saveto = saveto })
+      end
+    end
+  end
+
+  scan.index = last + 1
+  if scan.index <= #scan.lines then
+    schedule_manifest_chunk(CONTENT_MANIFEST_DELAY, function()
+      process_file_list_chunk(scan)
+    end)
+    return
+  end
+
+  DD_GUI.content_manifest_scan = nil
+  DD_GUI.prioritize_content_queue(true)
+  schedule_next_download(0)
+end
+
 function process_file_list()
   if not file_exists(FILELIST_LOCAL) then
     cecho("\n<white>Custom media unable to be checked.\n")
@@ -345,30 +419,16 @@ function process_file_list()
   end
 
   clear_content_download_queue()
-  local lines = lines_from(FILELIST_LOCAL)
+  local scan = {
+    lines = lines_from(FILELIST_LOCAL),
+    index = 1,
+  }
+  DD_GUI.content_manifest_scan = scan
 
-  for _, v in ipairs(lines) do
-    local result  = split_str(v, '|')
-    local sizeStr = (result[1] or ""):gsub("%s+$", "")
-    local relPath = (result[2] or ""):gsub("\r", ""):gsub("^%s+", ""):gsub("%s+$", "")
-
-    -- NEW: ignore blank lines and *directory* entries
-    if relPath ~= "" and looks_like_file(relPath) then
-      local saveto   = ms_path .. "/" .. relPath
-      local url      = CONTENT_BASE .. relPath
-      local existing_path = DD_GUI.asset_path and
-        DD_GUI.asset_path(relPath) or saveto
-      local existing = lfs.attributes(existing_path, "size")
-
-      if existing == nil or tonumber(sizeStr) ~= tonumber(existing) then
-        table.insert(downloadQueue, { url = url, saveto = saveto })
-      end
-    -- else: it's a directory or bad line — skip it
-    end
-  end
-
-  DD_GUI.prioritize_content_queue(true)
-  schedule_next_download(0)
+  -- Yield between small batches. The old implementation performed every
+  -- filesystem stat in the download-completion callback, which could freeze
+  -- Mudlet for a large profile even when the cache was already complete.
+  process_file_list_chunk(scan)
 end
 
 function start_next_download()

--- a/src/scripts/DD/UpdateFunctions/bootstrap.lua
+++ b/src/scripts/DD/UpdateFunctions/bootstrap.lua
@@ -2,6 +2,12 @@ DD_GUI = DD_GUI or {}
 
 -- A source reload must not let a timer from the previous package tree flush
 -- into widgets while this script set is still being replaced.
+DD_GUI.bootstrap_source_generation =
+        (tonumber(DD_GUI.bootstrap_source_generation) or 0) + 1
+if DD_GUI.bootstrap_refresh_timer and type(killTimer) == "function" then
+        pcall(killTimer, DD_GUI.bootstrap_refresh_timer)
+end
+DD_GUI.bootstrap_refresh_timer = nil
 DD_GUI.bootstrap_ready = false
 
 local function remove_conflicting_generic_mapper()
@@ -88,7 +94,7 @@ end
 -- event and coalesce a burst into one short deferred update pass. Named event
 -- handlers prevent a local source reload from stacking another copy.
 local data_refresh_specs = {
-        {key = "vitals", event = "gmcp.Char.Vitals", updates = {"update_vitals", "update_equipped"}},
+        {key = "vitals", event = "gmcp.Char.Vitals", updates = {"update_vitals"}},
         {key = "affects", event = "gmcp.Char.Affect", updates = {"update_affects"}},
         {key = "quest", event = "gmcp.Char.Quest", updates = {"update_quest_status"}},
         {key = "inventory", event = "gmcp.Char.Items", updates = {"update_inventory"}},
@@ -344,6 +350,7 @@ local function dd_gui_bootstrap_impl()
         remove_conflicting_generic_mapper()
 
         local package_version = dd_gui_installed_version()
+        local source_generation = DD_GUI.bootstrap_source_generation
 
         if DD_GUI.Theme and DD_GUI.Theme.apply_profile_style then
                 DD_GUI.Theme:apply_profile_style()
@@ -357,23 +364,37 @@ local function dd_gui_bootstrap_impl()
                 end
 
                 dd_gui_show_current_roots()
-                DD_GUI.refresh_data()
-                if DD_GUI.raise_info_box_contents then
-                        DD_GUI.raise_info_box_contents()
-                end
-                if DD_GUI.apply_mapper_theme then
-                        DD_GUI.apply_mapper_theme()
-                end
-                if DD_GUI.Layout then
-                        DD_GUI.Layout:apply(false)
-                end
-                if DD_GUI.FrameGrid and DD_GUI.FrameGrid.schedule_refresh then
-                        DD_GUI.FrameGrid:schedule_refresh(0.05)
-                end
+                -- Keep repeated bootstrap requests out of the event that
+                -- delivered GMCP/package-install data. A deferred settle
+                -- pass lets Mudlet finish its own widget/layout repaint first.
+                DD_GUI.bootstrap_refresh_timer = tempTimer(0, function()
+                        DD_GUI.bootstrap_refresh_timer = nil
+                        if DD_GUI.bootstrap_source_generation ~= source_generation then
+                                return
+                        end
+                        DD_GUI.refresh_data()
+                        if DD_GUI.raise_info_box_contents then
+                                DD_GUI.raise_info_box_contents()
+                        end
+                        if DD_GUI.apply_mapper_theme then
+                                DD_GUI.apply_mapper_theme()
+                        end
+                        if DD_GUI.Layout then
+                                DD_GUI.Layout:apply(false)
+                        end
+                        if DD_GUI.FrameGrid and DD_GUI.FrameGrid.schedule_refresh then
+                                DD_GUI.FrameGrid:schedule_refresh(0.05)
+                        end
+                end)
                 return
         end
 
-        if DD_GUI.bootstrap_ready then
+        -- bootstrap.lua is sourced again during a live package replacement,
+        -- before bootstrap_ready can be restored. Existing roots still need
+        -- to be hidden or the replacement creates a second repaint tree.
+        local has_existing_roots = (ui and ui.mainconsole_container) or
+                DD_GUI.Top or DD_GUI.Right or DD_GUI.Bottom
+        if DD_GUI.bootstrap_ready or has_existing_roots then
                 dd_gui_hide_previous_roots()
         end
 
@@ -446,6 +467,9 @@ local function dd_gui_bootstrap_impl()
         end
         DD_GUI.bootstrap_refresh_timer = tempTimer(0.1, function()
                 DD_GUI.bootstrap_refresh_timer = nil
+                if DD_GUI.bootstrap_source_generation ~= source_generation then
+                        return
+                end
                 DD_GUI.refresh_data()
                 if DD_GUI.raise_info_box_contents then
                         DD_GUI.raise_info_box_contents()

--- a/src/scripts/DD/UpdateFunctions/update_vitals.lua
+++ b/src/scripts/DD/UpdateFunctions/update_vitals.lua
@@ -10,6 +10,43 @@ local function current_affect_name()
     return tostring(affects[1][1].name or "")
 end
 
+local CHARACTER_SHEET_FIELDS = {
+    base = {"name", "race", "class", "subclass", "sex"},
+    stats = {
+        "str", "str_mod", "int", "int_mod", "wis", "wis_mod",
+        "dex", "dex_mod", "con", "con_mod", "fame", "crit", "swift",
+        "hitroll", "damroll", "ac", "r_acid", "r_lightning", "r_heat",
+        "r_cold", "save_vs",
+    },
+    worth = {
+        "level", "alignment", "xplvl", "xptnl", "platinum", "gold",
+        "silver", "copper", "steel", "titanium", "adamantite", "electrum",
+        "starmetal",
+    },
+    vitals = {"form"},
+}
+
+local function character_sheet_signature()
+    local char = gmcp and gmcp.Char or {}
+    local signature = {}
+
+    for _, scope_name in ipairs({"base", "stats", "worth", "vitals"}) do
+        local scope = char[scope_name == "base" and "Base" or
+            scope_name == "stats" and "Stats" or
+            scope_name == "worth" and "Worth" or "Vitals"] or {}
+        for _, field in ipairs(CHARACTER_SHEET_FIELDS[scope_name]) do
+            signature[#signature + 1] = scope_name .. ":" .. field .. "=" ..
+                tostring(scope[field] or "")
+        end
+    end
+
+    signature[#signature + 1] = "affect=" .. current_affect_name()
+    local profile_avatar = DD_GUI.profile_avatar_filename and
+        DD_GUI.profile_avatar_filename() or ""
+    signature[#signature + 1] = "avatar=" .. tostring(profile_avatar)
+    return table.concat(signature, "\31")
+end
+
 local function normalized_gauge_value(value, maximum)
     value = tonumber(value) or 0
     maximum = tonumber(maximum) or 0
@@ -70,6 +107,7 @@ function update_vitals()
   if DD_GUI.update_character_condition_gauges then
       DD_GUI.update_character_condition_gauges()
   end
+
   --DD_GUI.Xp:setValue(((gmcp.Char.Worth.xp * 1000) / gmcp.Char.Worth.maxxp), 1000)
   local xplvl = tonumber(gmcp.Char.Worth.xplvl) or 0
   local xptnl = tonumber(gmcp.Char.Worth.xptnl) or 0
@@ -78,6 +116,18 @@ function update_vitals()
   else
       DD_GUI.Xp:setValue(1000, 1000)
   end
+
+  -- Vitals arrive frequently. Avoid clearing and repainting the complete
+  -- character sheet, including its image, when only a gauge changed.
+  local sheet_signature = character_sheet_signature()
+  if DD_GUI.character_sheet_signature == sheet_signature then
+      if DD_GUI.update_drunk_icon then
+          DD_GUI.update_drunk_icon()
+      end
+      return
+  end
+  DD_GUI.character_sheet_signature = sheet_signature
+
   CharsheetConsole:clear()
   CharsheetConsole:resetAutoWrap()
 

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -9,7 +9,7 @@ mudlet.mapper_script = true
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.134"
+DD_GUI.package_version = "0.0.135"
 
 local profile_path = string.gsub(tostring(getMudletHomeDir() or ""), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## What changed\n- Scan large custom-media manifests incrementally so Mudlet yields between chunks.\n- Defer and guard bootstrap refreshes against stale timers and duplicate roots.\n- Avoid rebuilding inventory/equipment and the character sheet on every vitals tick when only gauges changed.\n- Chunk automatic mapper area fitting instead of walking an entire area in one callback.\n- Document the startup safeguards and bump the package to 0.0.135.\n\n## Why\nLocal profiles with thousands of cached assets could spend too long in synchronous Lua callbacks, producing high CPU, long freezes, or apparent crashes during reconnect/bootstrap.\n\n## Validation\nBuilt and uploaded with scripts/build-and-upload.ps1; generated package XML parsed successfully.