### PR TITLE
Harden compass door-state synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,10 @@ data. The main panels are:
   plain exits are open, `(direction)` is closed, and `[direction]` is locked.
   The parser replaces stale directions instead of merging them forever, and
   the native Mudlet door table remains a per-direction fallback for older or
-  partial profiles. If a compass or mapper movement still receives a closed,
+  partial profiles. The GUI also refreshes the GMCP snapshot immediately when
+  a compass direction is pressed and once more shortly after a room event, so
+  a delayed `exit_details` update cannot leave a freshly entered room using
+  stale door state. If a compass or mapper movement still receives a closed,
   locked, missing-key, or wall response, the attempted direction is corrected
   immediately for the next attempt. If neither source has a state, it sends
   the normal movement command. Status gauges clamp GMCP current values to their reported maximums

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.135",
+  "version": "0.0.136",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/CompassExits.lua
+++ b/src/scripts/DD/CompassExits.lua
@@ -39,18 +39,59 @@ local function copy_statuses(statuses)
         return copy
 end
 
+local function truthy(value)
+        if value == true or value == 1 then
+                return true
+        end
+        local text = tostring(value or ""):lower()
+        return text == "true" or text == "yes" or text == "on" or text == "1"
+end
+
+local function decode_table(value)
+        if type(value) ~= "string" then
+                return value
+        end
+
+        local text = value:gsub("^%s+", ""):gsub("%s+$", "")
+        if text == "" then
+                return nil
+        end
+
+        -- Mudlet normally exposes nested GMCP objects as tables. Keep a
+        -- guarded fallback for profiles or protocol bridges that leave an
+        -- object as its JSON string instead.
+        if type(json) == "table" and type(json.decode) == "function" then
+                local ok, decoded = pcall(json.decode, text)
+                if ok and type(decoded) == "table" then
+                        return decoded
+                end
+        end
+        if type(decodeJson) == "function" then
+                local ok, decoded = pcall(decodeJson, text)
+                if ok and type(decoded) == "table" then
+                        return decoded
+                end
+        end
+        return value
+end
+
 local function normalise_status(value)
+        value = decode_table(value)
         if type(value) == "table" then
-                if value.wall == true or value.blocked == true then
+                if truthy(value.wall) or truthy(value.blocked) then
                         return 4
-                elseif value.locked == true or value.is_locked == true then
+                elseif truthy(value.locked) or truthy(value.is_locked) or
+                       truthy(value.isLocked) then
                         return 3
-                elseif value.closed == true or value.is_closed == true then
+                elseif truthy(value.closed) or truthy(value.is_closed) or
+                       truthy(value.isClosed) then
                         return 2
-                elseif value.open == true or value.is_open == true then
+                elseif truthy(value.open) or truthy(value.is_open) or
+                       truthy(value.isOpen) then
                         return 1
                 end
-                value = value.status or value.state or value.door_state
+                value = value.status or value.state or value.door_state or
+                        value.door_status or value.exit_state
         end
 
         local numeric = tonumber(value)
@@ -94,11 +135,44 @@ local function gmcp_exit_statuses(info)
         end
 
         local statuses = {}
-        local details = info.exit_details or info.exitDetails or info.exit_detail
-        local has_rich_payload = type(details) == "table"
+        local rich_sources = {}
+        local fallback_sources = {}
         local has_rich_status = false
 
+        local function add_source(collection, source)
+                source = decode_table(source)
+                if type(source) == "table" then
+                        table.insert(collection, source)
+                end
+        end
+
+        local function add_rich_source(source)
+                source = decode_table(source)
+                if type(source) ~= "table" then
+                        return
+                end
+
+                -- Accept both a direction-keyed object and a wrapper used by
+                -- a few GMCP bridges (`{ exits = { ... } }`).
+                local nested = source.exit_details or source.exitDetails or
+                        source.exit_detail or source.exits or source.data
+                add_source(rich_sources, nested or source)
+        end
+
+        add_rich_source(info.exit_details or info.exitDetails or info.exit_detail)
+        if gmcp and gmcp.Room then
+                add_rich_source(gmcp.Room.ExitDetails or gmcp.Room.exit_details or
+                        gmcp.Room.exitDetails or gmcp.Room.ExitDetail)
+        end
+        add_source(fallback_sources, info.exits)
+        if gmcp and gmcp.Room then
+                add_source(fallback_sources, gmcp.Room.Exits or gmcp.Room.exits)
+        end
+
+        local has_rich_payload = #rich_sources > 0
+
         local function read(source, allow_scalar)
+                source = decode_table(source)
                 if type(source) ~= "table" then
                         return
                 end
@@ -107,10 +181,18 @@ local function gmcp_exit_statuses(info)
                         -- id table. Only its nested rich form may contribute
                         -- a scalar state; otherwise a destination such as
                         -- "3025" would look like a blocked status.
+                        value = decode_table(value)
                         if not allow_scalar and type(value) ~= "table" then
                                 value = nil
                         end
                         local short = compass_exit_aliases[tostring(direction):lower()]
+                        if not short and type(value) == "table" then
+                                local embedded_direction = value.direction or value.dir or
+                                        value.name or value.exit or value.command
+                                short = compass_exit_aliases[
+                                        tostring(embedded_direction or ""):lower()
+                                ]
+                        end
                         local status = short and normalise_status(value)
                         if short and status ~= nil then
                                 statuses[short] = status
@@ -119,19 +201,49 @@ local function gmcp_exit_statuses(info)
                 end
         end
 
-        read(details, true)
+        for _, source in ipairs(rich_sources) do
+                read(source, true)
+        end
 
         -- Keep compatibility with a future/alternate Room.Info shape that
         -- embeds state directly in `exits` instead of `exit_details`.
-        if not has_rich_payload or not has_rich_status then
-                read(info.exits, false)
+        if not has_rich_status then
+                for _, source in ipairs(fallback_sources) do
+                        read(source, false)
+                end
         end
 
         -- DD4 sends exit_details as a complete object, including an empty
-        -- object for a room with no traversable exits. That is authoritative
-        -- even when there are no individual statuses to copy.
-        return statuses, has_rich_payload or has_rich_status
+        -- object for a room with no traversable exits. An empty rich object
+        -- is authoritative only when there is no legacy exit list alongside
+        -- it; otherwise preserve the text/native fallback for partial GMCP.
+        local has_legacy_exits = false
+        for _, source in ipairs(fallback_sources) do
+                for direction, value in pairs(source) do
+                        local short = compass_exit_aliases[tostring(direction):lower()]
+                        if not short and type(value) == "table" then
+                                local embedded_direction = value.direction or value.dir or
+                                        value.name or value.exit or value.command
+                                short = compass_exit_aliases[
+                                        tostring(embedded_direction or ""):lower()
+                                ]
+                        end
+                        if short then
+                                has_legacy_exits = true
+                                break
+                        end
+                end
+                if has_legacy_exits then
+                        break
+                end
+        end
+
+        local complete = has_rich_status or
+                (has_rich_payload and not has_legacy_exits)
+        return statuses, complete
 end
+
+DD_GUI.get_gmcp_exit_statuses = gmcp_exit_statuses
 
 local function apply_statuses(room_id, statuses, source, complete)
         room_id = tonumber(room_id)
@@ -319,6 +431,20 @@ local function kill_handler(handler_id)
         end
 end
 
+local function schedule_exit_status_refresh(delay)
+        if DD_GUI.exit_status_refresh_timer and type(killTimer) == "function" then
+                pcall(killTimer, DD_GUI.exit_status_refresh_timer)
+        end
+        DD_GUI.exit_status_refresh_timer = nil
+        if type(tempTimer) ~= "function" then
+                return
+        end
+        DD_GUI.exit_status_refresh_timer = tempTimer(delay or 0.05, function()
+                DD_GUI.exit_status_refresh_timer = nil
+                DD_GUI.refresh_exit_status_from_gmcp()
+        end)
+end
+
 -- Replace handlers left by an older live package tree. This matters during
 -- reinstallgui/bootstrap, where globals survive package removal.
 kill_handler(DD_GUI.exit_status_event_handler)
@@ -336,6 +462,7 @@ if type(registerAnonymousEventHandler) == "function" then
                 "gmcp.Room.Info",
                 function()
                         DD_GUI.refresh_exit_status_from_gmcp()
+                        schedule_exit_status_refresh(0.05)
                 end
         )
         DD_GUI.exit_status_event_handler = DD_GUI.exit_status_handlers.room
@@ -345,17 +472,10 @@ if type(registerAnonymousEventHandler) == "function" then
                 function()
                         clear_pending_exit_move()
                         DD_GUI.refresh_exit_status_from_gmcp()
-                        if type(tempTimer) == "function" then
-                                if DD_GUI.exit_status_refresh_timer and type(killTimer) == "function" then
-                                        pcall(killTimer, DD_GUI.exit_status_refresh_timer)
-                                end
-                                DD_GUI.exit_status_refresh_timer = tempTimer(0.1, function()
-                                        DD_GUI.exit_status_refresh_timer = nil
-                                        DD_GUI.refresh_exit_status_from_gmcp()
-                                end)
-                        end
+                        schedule_exit_status_refresh(0.1)
                 end
         )
 end
 
 DD_GUI.refresh_exit_status_from_gmcp()
+schedule_exit_status_refresh(0.05)

--- a/src/scripts/DD/GMCPMapper.lua
+++ b/src/scripts/DD/GMCPMapper.lua
@@ -154,15 +154,20 @@ function load_dd_mapper()
                         result.to = dd_mapper_number(
                                 value.to or value.vnum or value.room or value.id or value.destination
                         )
-                        local raw_status = value.status or value.state or value.door_state
+                        local raw_status = value.status or value.state or value.door_state or
+                                value.door_status or value.exit_state
                         if raw_status == nil then
-                                if value.wall == true or value.blocked == true then
+                                if value.wall == true or value.blocked == true or
+                                        value.wall == "true" or value.blocked == "true" then
                                         raw_status = "wall"
-                                elseif value.locked == true or value.is_locked == true then
+                                elseif value.locked == true or value.is_locked == true or
+                                        value.isLocked == true or value.locked == "true" then
                                         raw_status = "locked"
-                                elseif value.closed == true or value.is_closed == true then
+                                elseif value.closed == true or value.is_closed == true or
+                                        value.isClosed == true or value.closed == "true" then
                                         raw_status = "closed"
-                                elseif value.open == true or value.is_open == true then
+                                elseif value.open == true or value.is_open == true or
+                                        value.isOpen == true or value.open == "true" then
                                         raw_status = "open"
                                 end
                         end
@@ -303,6 +308,37 @@ function load_dd_mapper()
                         end
                 end
 
+                -- CompassExits owns the compatibility normalization for
+                -- alternate GMCP shapes. Reuse its state snapshot here so
+                -- mapper doors and compass commands cannot disagree when a
+                -- profile receives delayed or list-shaped exit details.
+                if DD_GUI.get_gmcp_exit_statuses then
+                        local status_ok, statuses, complete = pcall(
+                                DD_GUI.get_gmcp_exit_statuses, source
+                        )
+                        if status_ok and type(statuses) == "table" then
+                                for direction, status in pairs(statuses) do
+                                        local detail = exits[direction] or {
+                                                to = nil,
+                                                status = nil,
+                                                has_status = false,
+                                                blocked = false,
+                                                door = nil,
+                                                command = nil,
+                                                cost = nil,
+                                        }
+                                        detail.status = tonumber(status) or 0
+                                        detail.has_status = true
+                                        detail.blocked = detail.status == 4
+                                        exits[direction] = detail
+                                        has_exit_status = true
+                                end
+                                if complete == true then
+                                        has_exit_status = true
+                                end
+                        end
+                end
+
                 local arrival = source.arrival or source.transition or source.move_info
                 if type(arrival) ~= "table" then
                         arrival = nil
@@ -319,7 +355,11 @@ function load_dd_mapper()
                         flags = source.flags,
                         tags = normalise_tags(source.tags),
                         exits = exits,
-                        exit_status_complete = type(exit_details) == "table" or has_exit_status,
+                        -- A present but empty/malformed rich object must not
+                        -- suppress the legacy text/native door fallback when
+                        -- the ordinary exit list still contains destinations.
+                        exit_status_complete = has_exit_status or
+                                (type(exit_details) == "table" and next(exits) == nil),
                         special_exits = normalise_special_exits(
                                 source.special_exits or source.specialExits or source.special_exit_details
                         ),

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -249,6 +249,13 @@ function build_compass()
       return nil
     end
 
+    -- A click can arrive between the room text and the final GMCP update.
+    -- Refresh immediately so the command uses the current room's latest
+    -- locked/closed state instead of a stale per-room cache.
+    if DD_GUI.refresh_exit_status_from_gmcp then
+      pcall(DD_GUI.refresh_exit_status_from_gmcp)
+    end
+
     local room_id
     if gmcp and gmcp.Room and type(gmcp.Room.Info) == "table" then
       room_id = tonumber(gmcp.Room.Info.vnum)

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -9,7 +9,7 @@ mudlet.mapper_script = true
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.135"
+DD_GUI.package_version = "0.0.136"
 
 local profile_path = string.gsub(tostring(getMudletHomeDir() or ""), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
## Summary
- accept delayed, nested, JSON-string, and list-shaped GMCP exit-state payloads
- refresh the current room state immediately on compass movement and after room/connection events
- reuse the compass-normalized state in the native mapper so door commands stay consistent
- document the behavior and publish DD_GUI 0.0.136

Built and uploaded with scripts/build-and-upload.ps1.