### PR TITLE
Add live tooltips to resource gauges

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,10 @@ data. The main panels are:
   stale door state. If a compass or mapper movement still receives a closed,
   locked, missing-key, or wall response, the attempted direction is corrected
   immediately for the next attempt. If neither source has a state, it sends
-  the normal movement command. Status gauges clamp GMCP current values to their reported maximums
+  the normal movement command. Hovering over the `HITS`, `MANA`, `XP`, or `MOVES`
+  gauge shows its live current/maximum values. Vampire `BLOOD` and Werewolf
+  `RAGE` gauges expose the same tooltip; `THIRST` and `HUNGER` intentionally
+  remain label-only. Status gauges clamp GMCP current values to their reported maximums
   and keep their fills inside their parent panels. Enemy hitpoints are rendered
   in a dedicated overlay below the enemy text, so the red gauge remains visible
   when the enemy console refreshes and disappears outside combat. The compass has the same shared braided

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.136",
+  "version": "0.0.137",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/CharsheetConsole.lua
+++ b/src/scripts/DD/CharsheetConsole.lua
@@ -29,6 +29,7 @@ local CONDITION_GAUGE_DEFINITIONS = {
       property = "Blood",
       label_property = "BloodLabel",
       label = "BLOOD",
+      tooltip_label = "BLOOD",
       value_field = "rage",
       maximum_field = "maxrage",
       color_key = "blood",
@@ -37,6 +38,7 @@ local CONDITION_GAUGE_DEFINITIONS = {
       property = "Rage",
       label_property = "RageLabel",
       label = "RAGE",
+      tooltip_label = "RAGE",
       value_field = "rage",
       maximum_field = "maxrage",
       color_key = "rage",
@@ -170,6 +172,14 @@ function DD_GUI.update_character_condition_gauges()
             vitals[definition.value_field],
             vitals[definition.maximum_field]),
           1000)
+        if DD_GUI.update_status_gauge_tooltip then
+          DD_GUI.update_status_gauge_tooltip(
+            gauge,
+            DD_GUI[definition.label_property],
+            definition.tooltip_label,
+            vitals[definition.value_field],
+            vitals[definition.maximum_field])
+        end
       end
     end
 end
@@ -1148,7 +1158,8 @@ local function build_character_condition_gauges()
         colors[definition.color_key],
         vitals[definition.value_field],
         vitals[definition.maximum_field],
-        {x = "0%", y = "0%", width = "100%", height = "100%"})
+        {x = "0%", y = "0%", width = "100%", height = "100%"},
+        definition.tooltip_label)
 
       DD_GUI[definition.property] = gauge
       DD_GUI[definition.label_property] = label

--- a/src/scripts/DD/DD_GUI.GaugesBox.lua
+++ b/src/scripts/DD/DD_GUI.GaugesBox.lua
@@ -48,6 +48,50 @@ local function update_gauge_fill_color(gauge, color, value, maximum)
     gauge.front:setStyleSheet(css)
 end
 
+local STATUS_GAUGE_TOOLTIP_DURATION = 6
+
+local function format_gauge_number(value)
+    local number = tonumber(value)
+    if number then
+      if number == math.floor(number) then
+        return string.format("%.0f", number)
+      end
+      return tostring(number)
+    end
+    return tostring(value or 0)
+end
+
+local function set_status_gauge_tooltip(gauge, label, tooltip_label,
+                                        value, maximum)
+    if not tooltip_label then
+      return
+    end
+
+    local tooltip = string.format("%s: %s / %s", tooltip_label,
+      format_gauge_number(value), format_gauge_number(maximum))
+
+    if gauge and gauge._dd_gui_tooltip == tooltip and
+       (not label or label._dd_gui_tooltip == tooltip) then
+      return
+    end
+
+    -- Geyser.Gauge puts its tooltip on the full-size text label. Keep the
+    -- separate centered label in sync as well so the hint remains available
+    -- across Mudlet versions with different click-through behaviour.
+    if gauge and type(gauge.setToolTip) == "function" then
+      pcall(gauge.setToolTip, gauge, tooltip,
+        STATUS_GAUGE_TOOLTIP_DURATION)
+      gauge._dd_gui_tooltip = tooltip
+    end
+    if label and type(label.setToolTip) == "function" then
+      pcall(label.setToolTip, label, tooltip,
+        STATUS_GAUGE_TOOLTIP_DURATION)
+      label._dd_gui_tooltip = tooltip
+    end
+end
+
+DD_GUI.update_status_gauge_tooltip = set_status_gauge_tooltip
+
 local function delete_existing_widget(widget)
     if not widget then
       return
@@ -81,7 +125,7 @@ local function add_gauge_segments(gauge, name)
 end
 
 local function new_status_gauge(name, parent, label_text, color, value, maximum,
-                                constraints)
+                                constraints, tooltip_label)
     constraints = constraints or {}
     local theme = DD_GUI.Theme
     local gauge = Geyser.Gauge:new({
@@ -126,6 +170,8 @@ local function new_status_gauge(name, parent, label_text, color, value, maximum,
     if DD_GUI.set_widget_clickthrough then
       DD_GUI.set_widget_clickthrough(label, true)
     end
+
+    set_status_gauge_tooltip(gauge, label, tooltip_label, value, maximum)
 
     return gauge, label
 end
@@ -204,21 +250,24 @@ function build_gauges()
 
     DD_GUI.Hitpoints, HitpointsLabel = new_status_gauge(
       "DD_GUI.Hitpoints", DD_GUI.FirstColumn, "HITS", colors.hp,
-      gmcp.Char.Vitals.hp, gmcp.Char.Vitals.maxhp)
+      gmcp.Char.Vitals.hp, gmcp.Char.Vitals.maxhp, nil, "HITS")
 
     DD_GUI.Mana, ManaLabel = new_status_gauge(
       "DD_GUI.Mana", DD_GUI.SecondColumn, "MANA", colors.mana,
-      gmcp.Char.Vitals.mana, gmcp.Char.Vitals.maxmana)
+      gmcp.Char.Vitals.mana, gmcp.Char.Vitals.maxmana, nil, "MANA")
 
     local xplvl = tonumber(gmcp.Char.Worth.xplvl) or 0
     local xptnl = tonumber(gmcp.Char.Worth.xptnl) or 0
+    local xp = tonumber(gmcp.Char.Worth.xp) or 0
+    local maxxp = tonumber(gmcp.Char.Worth.maxxp) or 0
     local xp_value = xptnl > 0 and math.max(0, xplvl - xptnl) or 1
     local xp_maximum = xptnl > 0 and xplvl or 1
     DD_GUI.Xp, XpLabel = new_status_gauge(
       "DD_GUI.Xp", DD_GUI.ThirdColumn, "XP", colors.xp,
-      xp_value, xp_maximum)
+      xp_value, xp_maximum, nil, "XP")
+    set_status_gauge_tooltip(DD_GUI.Xp, XpLabel, "XP", xp, maxxp)
 
     DD_GUI.Moves, MovesLabel = new_status_gauge(
       "DD_GUI.Moves", DD_GUI.FourthColumn, "MOVES", colors.moves,
-      gmcp.Char.Vitals.move, gmcp.Char.Vitals.maxmove)
+      gmcp.Char.Vitals.move, gmcp.Char.Vitals.maxmove, nil, "MOVES")
 end

--- a/src/scripts/DD/UpdateFunctions/update_vitals.lua
+++ b/src/scripts/DD/UpdateFunctions/update_vitals.lua
@@ -102,19 +102,41 @@ function update_vitals()
   end
   --GUI.Hitpoints:setValue((100/tonumber(gmcp.Char.Vitals.maxhp))*tonumber(gmcp.Char.Vitals.hp),100,tonumber(gmcp.Char.Vitals.hp))
   DD_GUI.Hitpoints:setValue(normalized_gauge_value(hp, maxhp),1000)
+  if DD_GUI.update_status_gauge_tooltip then
+      DD_GUI.update_status_gauge_tooltip(
+          DD_GUI.Hitpoints, HitpointsLabel, "HITS", hp, maxhp)
+  end
   DD_GUI.Mana:setValue(normalized_gauge_value(mana, maxmana),1000)
+  if DD_GUI.update_status_gauge_tooltip then
+      DD_GUI.update_status_gauge_tooltip(
+          DD_GUI.Mana, ManaLabel, "MANA", mana, maxmana)
+  end
   DD_GUI.Moves:setValue(normalized_gauge_value(move, maxmove),1000)
+  if DD_GUI.update_status_gauge_tooltip then
+      DD_GUI.update_status_gauge_tooltip(
+          DD_GUI.Moves, MovesLabel, "MOVES", move, maxmove)
+  end
   if DD_GUI.update_character_condition_gauges then
       DD_GUI.update_character_condition_gauges()
   end
 
   --DD_GUI.Xp:setValue(((gmcp.Char.Worth.xp * 1000) / gmcp.Char.Worth.maxxp), 1000)
+  local xp = tonumber(gmcp.Char.Worth.xp) or 0
+  local maxxp = tonumber(gmcp.Char.Worth.maxxp) or 0
   local xplvl = tonumber(gmcp.Char.Worth.xplvl) or 0
   local xptnl = tonumber(gmcp.Char.Worth.xptnl) or 0
   if xptnl > 0 then
       DD_GUI.Xp:setValue(normalized_gauge_value(xplvl - xptnl, xplvl),1000)
+      if DD_GUI.update_status_gauge_tooltip then
+          DD_GUI.update_status_gauge_tooltip(
+              DD_GUI.Xp, XpLabel, "XP", xp, maxxp)
+      end
   else
       DD_GUI.Xp:setValue(1000, 1000)
+      if DD_GUI.update_status_gauge_tooltip then
+          DD_GUI.update_status_gauge_tooltip(DD_GUI.Xp, XpLabel,
+              "XP", xp, maxxp)
+      end
   end
 
   -- Vitals arrive frequently. Avoid clearing and repainting the complete

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -9,7 +9,7 @@ mudlet.mapper_script = true
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.136"
+DD_GUI.package_version = "0.0.137"
 
 local profile_path = string.gsub(tostring(getMudletHomeDir() or ""), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"


### PR DESCRIPTION
Adds themed hover tooltips to the HITS, MANA, XP, and MOVES gauges, plus vampire BLOOD and werewolf RAGE. Tooltips refresh from live GMCP values; THIRST and HUNGER remain unchanged. README and package version updated to 0.0.137. Built and uploaded with scripts/build-and-upload.ps1.