### PR TITLE
Fix compass door-state command selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,20 +191,21 @@ data. The main panels are:
   clickable navigation compass. The compass includes `EQ` for equipment and
   `SCAN` for scanning. Movement buttons briefly highlight their borders while
   leaving the black cell background unchanged. For mapped rooms, movement
-  uses the current room's rich GMCP exit state before sending: `open` sends
+  uses one normalized per-direction exit-state resolver before sending: `open` sends
   the direction, `closed` sends `open direction` then the direction, and
   `locked` sends `unlock direction`, `open direction`, then the direction.
   Walls are treated as non-routable. The legacy MUD `[Exits: ...]` line is a
-  complete compatibility snapshot when rich GMCP exit data is unavailable:
+  compatibility source as well:
   plain exits are open, `(direction)` is closed, and `[direction]` is locked.
   The parser replaces stale directions instead of merging them forever, and
   the native Mudlet door table remains a per-direction fallback for older or
-  partial profiles. The GUI also refreshes the GMCP snapshot immediately when
-  a compass direction is pressed and once more shortly after a room event, so
-  a delayed `exit_details` update cannot leave a freshly entered room using
-  stale door state. If a compass or mapper movement still receives a closed,
-  locked, missing-key, or wall response, the attempted direction is corrected
-  immediately for the next attempt. If neither source has a state, it sends
+  partial profiles. Explicit closed/locked text markers are retained through
+  the click-time refresh, so a delayed or incomplete GMCP update cannot make a
+  door button fall back to the raw direction. A fresh room/GMCP snapshot
+  replaces that temporary text override, allowing a door opened or unlocked
+  in-game to be learned normally. If a compass or mapper movement still
+  receives a closed, locked, missing-key, or wall response, the attempted
+  direction is corrected immediately for the next attempt. If neither source has a state, it sends
   the normal movement command. Hovering over the `HITS`, `MANA`, `XP`, or `MOVES`
   gauge shows its live current/maximum values. Vampire `BLOOD` and Werewolf
   `RAGE` gauges expose the same tooltip; `THIRST` and `HUNGER` intentionally

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.137",
+  "version": "0.0.138",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/CompassExits.lua
+++ b/src/scripts/DD/CompassExits.lua
@@ -2,6 +2,7 @@ DD_GUI = DD_GUI or {}
 
 DD_GUI.exit_status_by_room = DD_GUI.exit_status_by_room or {}
 DD_GUI.exit_status_meta_by_room = DD_GUI.exit_status_meta_by_room or {}
+DD_GUI.exit_status_text_by_room = DD_GUI.exit_status_text_by_room or {}
 
 local compass_exit_aliases = {
         n = "n",
@@ -251,14 +252,6 @@ local function apply_statuses(room_id, statuses, source, complete)
                 return false
         end
 
-        local metadata = DD_GUI.exit_status_meta_by_room[room_id]
-        if source == "text" and metadata and metadata.source == "gmcp" and
-           metadata.complete then
-                -- The legacy [Exits: ...] line must never overwrite DD4's
-                -- richer, authoritative door state.
-                return false
-        end
-
         local previous = DD_GUI.exit_status_by_room[room_id]
         local normalised = {}
         if complete == true then
@@ -287,6 +280,28 @@ local function apply_statuses(room_id, statuses, source, complete)
                 )
         end
         return true
+end
+
+local function apply_text_overrides(room_id)
+        local snapshot = DD_GUI.exit_status_text_by_room[room_id]
+        if type(snapshot) ~= "table" or type(snapshot.explicit) ~= "table" then
+                return false
+        end
+
+        local has_override = false
+        for _ in pairs(snapshot.explicit) do
+                has_override = true
+                break
+        end
+        if not has_override then
+                return false
+        end
+
+        -- The text line is especially useful when a profile receives a
+        -- delayed or incomplete GMCP object. Keep explicit `(closed)` and
+        -- `[locked]` markers visible to the compass during the click that
+        -- follows the room description.
+        return apply_statuses(room_id, snapshot.explicit, "text", false)
 end
 
 -- GMCPMapper uses this same path when it reconciles a fresh Room.Info
@@ -347,7 +362,7 @@ function DD_GUI.mark_pending_exit_failed(state)
         return true
 end
 
-function DD_GUI.refresh_exit_status_from_gmcp()
+function DD_GUI.refresh_exit_status_from_gmcp(preserve_text_overrides)
         local info = gmcp and gmcp.Room and gmcp.Room.Info
         local room_id = type(info) == "table" and tonumber(info.vnum)
         if not room_id then
@@ -358,13 +373,24 @@ function DD_GUI.refresh_exit_status_from_gmcp()
 
         local statuses, complete = gmcp_exit_statuses(info)
         if complete then
-                return apply_statuses(room_id, statuses, "gmcp", true)
+                local applied = apply_statuses(room_id, statuses, "gmcp", true)
+                if preserve_text_overrides == true then
+                        apply_text_overrides(room_id)
+                else
+                        -- A fresh Room.Info event is newer than the last
+                        -- room-description line. Let it replace text-only
+                        -- state, while compass clicks explicitly preserve
+                        -- marked doors until the server confirms a change.
+                        DD_GUI.exit_status_text_by_room[room_id] = nil
+                end
+                return applied
         end
 
         -- Do not let a rich snapshot from an earlier connection suppress the
         -- text fallback when this session is using an older/partial payload.
         local metadata = DD_GUI.exit_status_meta_by_room[room_id]
-        if metadata and metadata.source == "gmcp" then
+        if metadata and metadata.source == "gmcp" and
+           type(DD_GUI.exit_status_text_by_room[room_id]) ~= "table" then
                 DD_GUI.exit_status_meta_by_room[room_id] = nil
                 DD_GUI.exit_status_by_room[room_id] = nil
         end
@@ -377,13 +403,18 @@ function DD_GUI.update_exit_status(exit_text, complete_snapshot)
                 return false
         end
 
-        local metadata = DD_GUI.exit_status_meta_by_room[room_id]
-        if metadata and metadata.source == "gmcp" and metadata.complete then
-                return false
-        end
-
         local text = tostring(exit_text or "")
         text = text:gsub("\27%[[0-9;]*m", ""):lower()
+
+        -- Accept either the trigger capture (`north east (south)`) or the
+        -- complete matched line (`[Exits: north east (south)]`). This keeps
+        -- the parser working across Mudlet trigger-capture variations.
+        local marker_start = text:find("%[exits:%s*")
+        if marker_start then
+                text = text:sub(marker_start)
+                        :gsub("^%[exits:%s*", "")
+                        :gsub("%]%s*$", "")
+        end
 
         -- [Exits: ...] is a complete snapshot. Start empty so a door which
         -- was just opened/closed cannot retain its previous state forever.
@@ -422,7 +453,68 @@ function DD_GUI.update_exit_status(exit_text, complete_snapshot)
         if found == 0 and complete_snapshot ~= true then
                 return false
         end
+        DD_GUI.exit_status_text_by_room[room_id] = {
+                statuses = copy_statuses(statuses),
+                explicit = {},
+        }
+        for direction, status in pairs(statuses) do
+                if tonumber(status) == 2 or tonumber(status) == 3 then
+                        DD_GUI.exit_status_text_by_room[room_id].explicit[direction] = status
+                end
+        end
+
         return apply_statuses(room_id, statuses, "text", true)
+end
+
+function DD_GUI.get_current_exit_status(direction, preserve_text_overrides)
+        local short
+        for alias, value in pairs(compass_exit_aliases) do
+                if tostring(alias):lower() == tostring(direction or ""):lower() then
+                        short = value
+                        break
+                end
+        end
+        if not short then
+                return nil
+        end
+
+        if DD_GUI.refresh_exit_status_from_gmcp then
+                pcall(
+                        DD_GUI.refresh_exit_status_from_gmcp,
+                        preserve_text_overrides == true
+                )
+        end
+
+        local room_id = current_room_id()
+        if not room_id then
+                return nil
+        end
+
+        local parsed_status = DD_GUI.exit_status_by_room and
+                DD_GUI.exit_status_by_room[room_id]
+        if parsed_status and parsed_status[short] ~= nil then
+                return tonumber(parsed_status[short]) or 0
+        end
+
+        if type(getDoors) ~= "function" then
+                return nil
+        end
+        local ok, doors = pcall(getDoors, room_id)
+        if not ok or type(doors) ~= "table" then
+                return nil
+        end
+
+        local status = doors[short]
+        if status == nil then
+                local long_names = {
+                        n = "north", ne = "northeast", nw = "northwest",
+                        e = "east", se = "southeast", s = "south",
+                        sw = "southwest", w = "west", u = "up", d = "down",
+                        ["in"] = "in", out = "out",
+                }
+                status = doors[long_names[short]]
+        end
+        return tonumber(status)
 end
 
 local function kill_handler(handler_id)

--- a/src/scripts/DD/compass.resize.lua
+++ b/src/scripts/DD/compass.resize.lua
@@ -249,13 +249,12 @@ function build_compass()
       return nil
     end
 
-    -- A click can arrive between the room text and the final GMCP update.
-    -- Refresh immediately so the command uses the current room's latest
-    -- locked/closed state instead of a stale per-room cache.
-    if DD_GUI.refresh_exit_status_from_gmcp then
-      pcall(DD_GUI.refresh_exit_status_from_gmcp)
+    if DD_GUI.get_current_exit_status then
+      return DD_GUI.get_current_exit_status(name, true)
     end
 
+    -- Compatibility fallback for a profile that still has an older
+    -- CompassExits script loaded during a live rebuild.
     local room_id
     if gmcp and gmcp.Room and type(gmcp.Room.Info) == "table" then
       room_id = tonumber(gmcp.Room.Info.vnum)

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -9,7 +9,7 @@ mudlet.mapper_script = true
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.137"
+DD_GUI.package_version = "0.0.138"
 
 local profile_path = string.gsub(tostring(getMudletHomeDir() or ""), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"

--- a/src/triggers/DD/Mapping/UpdateExitStatus.lua
+++ b/src/triggers/DD/Mapping/UpdateExitStatus.lua
@@ -1,3 +1,6 @@
 if DD_GUI and DD_GUI.update_exit_status then
-        DD_GUI.update_exit_status(matches[2], true)
+        -- Pass the complete matched line when Mudlet provides it. The parser
+        -- also accepts the capture-only form for older profile runtimes.
+        local line = matches and (matches[1] or matches[2]) or ""
+        DD_GUI.update_exit_status(line, true)
 end


### PR DESCRIPTION
## Summary\n- normalize GMCP and [Exits: ...] door states through one compass resolver\n- preserve explicit closed/locked text markers across click-time refreshes\n- route compass buttons and keypad movement to open/unlock sequences\n- document the compatibility behavior and publish DD_GUI 0.0.138\n\n## Verification\n- .\\scripts\\build-and-upload.ps1\n- remote DD_GUI.xml reports 0.0.138\n- git diff --check