### PR TITLE
Fix compass door-state parsing for DD4 GMCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ data. The main panels are:
   Walls are treated as non-routable. The legacy MUD `[Exits: ...]` line is a
   compatibility source as well:
   plain exits are open, `(direction)` is closed, and `[direction]` is locked.
+  The resolver also unwraps DD4's nested `GMCP_OBJECT` representation, so the
+  server's `exit_details` state remains usable on Mudlet profiles where those
+  objects arrive inside anonymous table layers. Compass buttons and keyboard
+  movement refresh the current room state at the moment of the press, rather
+  than relying only on an earlier room event.
   The parser replaces stale directions instead of merging them forever, and
   the native Mudlet door table remains a per-direction fallback for older or
   partial profiles. Explicit closed/locked text markers are retained through

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "DD_GUI",
-  "version": "0.0.138",
+  "version": "0.0.139",
   "author": "nerble",
   "title": "Mudlet GUI for Dragons Domain MUD",
   "outputFile": true

--- a/src/scripts/DD/CompassExits.lua
+++ b/src/scripts/DD/CompassExits.lua
@@ -29,10 +29,14 @@ local compass_exit_aliases = {
         out = "out",
 }
 
+local function short_direction(direction)
+        return compass_exit_aliases[tostring(direction or ""):lower()]
+end
+
 local function copy_statuses(statuses)
         local copy = {}
         for direction, status in pairs(statuses or {}) do
-                local short = compass_exit_aliases[tostring(direction):lower()]
+                local short = short_direction(direction)
                 if short then
                         copy[short] = tonumber(status) or 0
                 end
@@ -61,6 +65,18 @@ local function decode_table(value)
         -- Mudlet normally exposes nested GMCP objects as tables. Keep a
         -- guarded fallback for profiles or protocol bridges that leave an
         -- object as its JSON string instead.
+        if type(yajl) == "table" and type(yajl.to_value) == "function" then
+                local ok, decoded = pcall(yajl.to_value, text)
+                if ok and type(decoded) == "table" then
+                        return decoded
+                end
+        end
+        if type(json_to_value) == "function" then
+                local ok, decoded = pcall(json_to_value, text)
+                if ok and type(decoded) == "table" then
+                        return decoded
+                end
+        end
         if type(json) == "table" and type(json.decode) == "function" then
                 local ok, decoded = pcall(json.decode, text)
                 if ok and type(decoded) == "table" then
@@ -111,6 +127,65 @@ local function normalise_status(value)
                 return 1
         end
         return nil
+end
+
+local function embedded_direction(value)
+        if type(value) ~= "table" then
+                return nil
+        end
+
+        return short_direction(
+                value.direction or value.dir or value.name or value.exit or
+                        value.command or value.move
+        )
+end
+
+-- DD4's COLOR_CODE_FIX representation makes GMCP object members arrive in
+-- Mudlet as one or more anonymous array layers, for example:
+--     exit_details = { { { n = { state = "closed" } } } }
+-- Walk those layers as well as the ordinary direction-keyed object form.
+local function walk_exit_detail_tree(source, callback, visited)
+        source = decode_table(source)
+        if type(source) ~= "table" or type(callback) ~= "function" then
+                return false
+        end
+
+        visited = visited or {}
+        if visited[source] then
+                return false
+        end
+        visited[source] = true
+
+        local found = false
+        for direction, value in pairs(source) do
+                local short = short_direction(direction)
+                if short then
+                        callback(short, value)
+                        found = true
+                end
+        end
+
+        local direction = embedded_direction(source)
+        if direction then
+                callback(direction, source)
+                found = true
+        end
+
+        if not found then
+                for _, value in pairs(source) do
+                        if type(value) == "table" or type(value) == "string" then
+                                if walk_exit_detail_tree(value, callback, visited) then
+                                        found = true
+                                end
+                        end
+                end
+        end
+
+        return found
+end
+
+function DD_GUI.walk_gmcp_exit_details(source, callback)
+        return walk_exit_detail_tree(source, callback, {})
 end
 
 local function current_room_id()
@@ -173,33 +248,21 @@ local function gmcp_exit_statuses(info)
         local has_rich_payload = #rich_sources > 0
 
         local function read(source, allow_scalar)
-                source = decode_table(source)
-                if type(source) ~= "table" then
-                        return
-                end
-                for direction, value in pairs(source) do
+                DD_GUI.walk_gmcp_exit_details(source, function(short, value)
                         -- Room.Info.exits is historically a direction -> room
                         -- id table. Only its nested rich form may contribute
                         -- a scalar state; otherwise a destination such as
                         -- "3025" would look like a blocked status.
                         value = decode_table(value)
                         if not allow_scalar and type(value) ~= "table" then
-                                value = nil
+                                return
                         end
-                        local short = compass_exit_aliases[tostring(direction):lower()]
-                        if not short and type(value) == "table" then
-                                local embedded_direction = value.direction or value.dir or
-                                        value.name or value.exit or value.command
-                                short = compass_exit_aliases[
-                                        tostring(embedded_direction or ""):lower()
-                                ]
-                        end
-                        local status = short and normalise_status(value)
-                        if short and status ~= nil then
+                        local status = normalise_status(value)
+                        if status ~= nil then
                                 statuses[short] = status
                                 has_rich_status = true
                         end
-                end
+                end)
         end
 
         for _, source in ipairs(rich_sources) do
@@ -220,20 +283,9 @@ local function gmcp_exit_statuses(info)
         -- it; otherwise preserve the text/native fallback for partial GMCP.
         local has_legacy_exits = false
         for _, source in ipairs(fallback_sources) do
-                for direction, value in pairs(source) do
-                        local short = compass_exit_aliases[tostring(direction):lower()]
-                        if not short and type(value) == "table" then
-                                local embedded_direction = value.direction or value.dir or
-                                        value.name or value.exit or value.command
-                                short = compass_exit_aliases[
-                                        tostring(embedded_direction or ""):lower()
-                                ]
-                        end
-                        if short then
-                                has_legacy_exits = true
-                                break
-                        end
-                end
+                DD_GUI.walk_gmcp_exit_details(source, function()
+                        has_legacy_exits = true
+                end)
                 if has_legacy_exits then
                         break
                 end
@@ -467,13 +519,7 @@ function DD_GUI.update_exit_status(exit_text, complete_snapshot)
 end
 
 function DD_GUI.get_current_exit_status(direction, preserve_text_overrides)
-        local short
-        for alias, value in pairs(compass_exit_aliases) do
-                if tostring(alias):lower() == tostring(direction or ""):lower() then
-                        short = value
-                        break
-                end
-        end
+        local short = short_direction(direction)
         if not short then
                 return nil
         end

--- a/src/scripts/DD/GMCPMapper.lua
+++ b/src/scripts/DD/GMCPMapper.lua
@@ -284,13 +284,18 @@ function load_dd_mapper()
 
                 local exits = {}
                 local has_exit_status = false
-                if type(source.exits) == "table" then
+                local function merge_legacy_exit(direction, value)
+                        local short = short_direction(direction)
+                        if direction_names[short] then
+                                exits[short] = normalise_exit(value)
+                                has_exit_status = has_exit_status or exits[short].has_status
+                        end
+                end
+                if DD_GUI.walk_gmcp_exit_details then
+                        DD_GUI.walk_gmcp_exit_details(source.exits, merge_legacy_exit)
+                elseif type(source.exits) == "table" then
                         for direction, value in pairs(source.exits) do
-                                local short = short_direction(direction)
-                                if direction_names[short] then
-                                        exits[short] = normalise_exit(value)
-                                        has_exit_status = has_exit_status or exits[short].has_status
-                                end
+                                merge_legacy_exit(direction, value)
                         end
                 end
 
@@ -298,13 +303,19 @@ function load_dd_mapper()
                 -- Merge it rather than replacing exits so older payloads keep
                 -- mapping exactly as before while rich state becomes authoritative.
                 local exit_details = source.exit_details or source.exitDetails or source.exit_detail
-                if type(exit_details) == "table" then
+                local has_rich_exit_payload = exit_details ~= nil
+                local function merge_rich_exit(direction, value)
+                        merge_exit_detail(exits, direction, value)
+                        local detail = exits[short_direction(direction)]
+                        if detail then
+                                has_exit_status = has_exit_status or detail.has_status
+                        end
+                end
+                if DD_GUI.walk_gmcp_exit_details then
+                        DD_GUI.walk_gmcp_exit_details(exit_details, merge_rich_exit)
+                elseif type(exit_details) == "table" then
                         for direction, value in pairs(exit_details) do
-                                merge_exit_detail(exits, direction, value)
-                                local detail = exits[short_direction(direction)]
-                                if detail then
-                                        has_exit_status = has_exit_status or detail.has_status
-                                end
+                                merge_rich_exit(direction, value)
                         end
                 end
 
@@ -359,7 +370,7 @@ function load_dd_mapper()
                         -- suppress the legacy text/native door fallback when
                         -- the ordinary exit list still contains destinations.
                         exit_status_complete = has_exit_status or
-                                (type(exit_details) == "table" and next(exits) == nil),
+                                (has_rich_exit_payload and next(exits) == nil),
                         special_exits = normalise_special_exits(
                                 source.special_exits or source.specialExits or source.special_exit_details
                         ),

--- a/src/scripts/DD/folder.lua
+++ b/src/scripts/DD/folder.lua
@@ -9,7 +9,7 @@ mudlet.mapper_script = true
 
 -- Mudlet builds without getPackageInfo() still need a reliable way to show
 -- the installed GUI version and decide whether bootstrap() may be reused.
-DD_GUI.package_version = "0.0.138"
+DD_GUI.package_version = "0.0.139"
 
 local profile_path = string.gsub(tostring(getMudletHomeDir() or ""), "\\", "/")
 local package_path = profile_path .. "/DD_GUI"

--- a/src/triggers/DD/Mapping/UpdateExitStatus.lua
+++ b/src/triggers/DD/Mapping/UpdateExitStatus.lua
@@ -1,6 +1,7 @@
 if DD_GUI and DD_GUI.update_exit_status then
-        -- Pass the complete matched line when Mudlet provides it. The parser
-        -- also accepts the capture-only form for older profile runtimes.
-        local line = matches and (matches[1] or matches[2]) or ""
+        -- Mudlet stores the first capture in matches[2]; matches[1] is the
+        -- whole matched line. Prefer the capture so colour/control text
+        -- outside the exit list cannot affect parsing.
+        local line = matches and (matches[2] or matches[1]) or ""
         DD_GUI.update_exit_status(line, true)
 end


### PR DESCRIPTION
Fixes compass and mapper movement falling back to raw directions when DD4 exit_details arrives in nested GMCP object layers. Adds yajl decoding, recursive exit-detail normalization, corrects Mudlet regex capture selection, updates the runtime package version to 0.0.139, and documents the compatibility behavior. Build and upload completed with scripts/build-and-upload.ps1.